### PR TITLE
make subroutinize() take a fontTools TTFont; add CLI script

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,31 @@
+[run]
+# measure 'branch' coverage in addition to 'statement' coverage
+# See: http://coverage.readthedocs.org/en/latest/branch.html#branch
+branch = True
+parallel = True
+
+# list of directories or packages to measure
+source = cffsubr
+
+# these are treated as equivalent when combining data
+[paths]
+source =
+    src/cffsubr
+    */site-packages/cffsubr
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # keywords to use in inline comments to skip coverage
+    pragma: no cover
+
+    # don't complain if tests don't hit defensive assertion code
+    raise AssertionError
+    raise NotImplementedError
+
+    # don't complain if non-runnable code isn't run
+    if 0:
+    if __name__ == .__main__.:
+
+# ignore source code that can’t be found
+ignore_errors = True

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -52,6 +52,10 @@ jobs:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
         # skip PyPy (no manylinux1), 32-bit linux, and other architectures
         CIBW_SKIP: "pp* cp*manylinux_i686 cp*manylinux_aarch64 cp*manylinux_ppc64le cp*manylinux_s390x"
+        CIBW_TEST_REQUIRES: "tox"
+        # run test suite with current tox python, no coverage
+        # TODO: run with coverage and publish to codecov.io
+        CIBW_TEST_COMMAND: "tox -e py"
 
     - uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -52,10 +52,10 @@ jobs:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
         # skip PyPy (no manylinux1), 32-bit linux, and other architectures
         CIBW_SKIP: "pp* cp*manylinux_i686 cp*manylinux_aarch64 cp*manylinux_ppc64le cp*manylinux_s390x"
-        CIBW_TEST_REQUIRES: "tox"
-        # run test suite with current tox python, no coverage
+        CIBW_TEST_REQUIRES: "pytest"
+        # run test suite with pytest, no coverage
         # TODO: run with coverage and publish to codecov.io
-        CIBW_TEST_COMMAND: "tox -e py"
+        CIBW_TEST_COMMAND: "pytest"
 
     - uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -50,8 +50,8 @@ jobs:
         CIBW_BUILD: "cp36-*"
         # build using the manylinux1 image to ensure manylinux1 wheels are produced
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-        # skip PyPy (no manylinux1), 32-bit linux, and other architectures
-        CIBW_SKIP: "pp* cp*manylinux_i686 cp*manylinux_aarch64 cp*manylinux_ppc64le cp*manylinux_s390x"
+        # skip PyPy (no manylinux1), 32-bit linux and win, and other architectures
+        CIBW_SKIP: "pp* cp*manylinux_i686 cp*manylinux_aarch64 cp*manylinux_ppc64le cp*manylinux_s390x cp*win32"
         CIBW_TEST_REQUIRES: "pytest"
         # run test suite with pytest, no coverage
         # TODO: run with coverage and publish to codecov.io

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -55,7 +55,7 @@ jobs:
         CIBW_TEST_REQUIRES: "pytest"
         # run test suite with pytest, no coverage
         # TODO: run with coverage and publish to codecov.io
-        CIBW_TEST_COMMAND: "pytest"
+        CIBW_TEST_COMMAND: "cd {project} && pytest"
 
     - uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -55,7 +55,7 @@ jobs:
         CIBW_TEST_REQUIRES: "pytest"
         # run test suite with pytest, no coverage
         # TODO: run with coverage and publish to codecov.io
-        CIBW_TEST_COMMAND: "cd {project} && pytest"
+        CIBW_TEST_COMMAND: "pytest {project}/tests"
 
     - uses: actions/upload-artifact@v1
       with:

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,10 @@ setup(
     ext_modules=[tx],
     zip_safe=False,
     cmdclass=cmdclass,
-    install_requires=["importlib_resources; python_version < '3.7'"],
+    install_requires=[
+        "importlib_resources; python_version < '3.7'",
+        "fontTools >= 4.10.2",
+    ],
     setup_requires=[
         "setuptools_scm",
         # finds all git tracked files including submodules when making sdist MANIFEST

--- a/src/cffsubr/__init__.py
+++ b/src/cffsubr/__init__.py
@@ -55,7 +55,7 @@ def _run_embedded_tx(*args, **kwargs):
         args, returncode, stdout, stderr.
     """
     with path(__name__, "tx") as tx_cli:
-        return subprocess.run([tx_cli] + list(args), **kwargs)
+        return subprocess.run([str(tx_cli)] + list(args), **kwargs)
 
 
 def _tx_subroutinize(data: bytes, output_format: str = CFFTableTag.CFF) -> bytes:
@@ -87,7 +87,7 @@ def _tx_subroutinize(data: bytes, output_format: str = CFFTableTag.CFF) -> bytes
             f"-{output_format.rstrip().lower()}",
             "+S",
             "+b",
-            tmp.name,
+            str(tmp.name),
             # capture_output=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/src/cffsubr/__init__.py
+++ b/src/cffsubr/__init__.py
@@ -82,12 +82,15 @@ def _tx_subroutinize(data: bytes, output_format: str = CFFTableTag.CFF) -> bytes
         tmp.write(data)
     try:
         # write to stdout and capture output
+        # TODO: use 'capture_output' parameter once we go >= 3.7 only
         result = _run_embedded_tx(
             f"-{output_format.rstrip().lower()}",
             "+S",
             "+b",
             tmp.name,
-            capture_output=True,
+            # capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             check=True,
         )
     except subprocess.CalledProcessError as e:

--- a/src/cffsubr/__init__.py
+++ b/src/cffsubr/__init__.py
@@ -1,7 +1,10 @@
+import copy
 import enum
+import io
 import subprocess
 import os
 import tempfile
+from typing import BinaryIO, Optional, Union
 
 try:
     from importlib.resources import path
@@ -9,19 +12,33 @@ except ImportError:
     # use backport for python < 3.7
     from importlib_resources import path
 
+from fontTools import ttLib
 
-__all__ = ["subroutinize", "OutputFormat", "Error"]
 
-
-class OutputFormat(enum.Enum):
-    CFF = "cff"
-    CFF2 = "cff2"
+__all__ = ["subroutinize", "Error"]
 
 
 try:
     from ._version import version as __version__
 except ImportError:
     __version__ = "0.0.0+unknown"
+
+
+class CFFTableTag(str, enum.Enum):
+    CFF = "CFF "
+    CFF2 = "CFF2"
+
+    def __str__(self):
+        return self.value
+
+    @classmethod
+    def from_version(cls, value: int) -> "CFFTableTag":
+        if value == 1:
+            return cls.CFF
+        elif value == 2:
+            return cls.CFF2
+        else:
+            raise ValueError(f"{value} is not a valid CFF table version")
 
 
 class Error(Exception):
@@ -31,27 +48,42 @@ class Error(Exception):
 def _run_embedded_tx(*args, **kwargs):
     """Run the embedded tx executable with the list of positional arguments.
 
-    Return a subprocess.CompletedProcess object with the following attributes:
-    args, returncode, stdout, stderr.
     All keyword arguments are forwarded to subprocess.run function.
+
+    Return:
+        subprocess.CompletedProcess object with the following attributes:
+        args, returncode, stdout, stderr.
     """
     with path(__name__, "tx") as tx_cli:
         return subprocess.run([tx_cli] + list(args), **kwargs)
 
 
-def subroutinize(fontdata: bytes, output_format=OutputFormat.CFF2) -> bytes:
-    """Run subroutinizer on the input font data and return processed output."""
-    if not isinstance(fontdata, bytes):
-        raise TypeError(f"expected bytes, found {type(fontdata).__name__}")
-    output_format = OutputFormat(output_format)
+def _tx_subroutinize(data: bytes, output_format: str = CFFTableTag.CFF) -> bytes:
+    """Run tx subroutinizer on OTF or CFF table raw data.
+
+    Args:
+        data (bytes): CFF 1.0 table data, or an entire OTF sfnt data containing
+            either 'CFF ' or 'CFF2' table.
+        output_format (str): the format of the output table, 'CFF ' or 'CFF2'.
+
+    Returns:
+        (bytes) Compressed CFF or CFF2 table data. NOTE: Even when a whole OTF
+        is passed in as input, just a single CFF or CFF2 table data is returned.
+
+    Raises:
+        cffsubr.Error if subroutinization process fails.
+    """
+    if not isinstance(data, bytes):
+        raise TypeError(f"expected bytes, found {type(data).__name__}")
+    output_format = CFFTableTag(output_format.rjust(4))
     # We can't read from stdin because of this issue:
     # https://github.com/adobe-type-tools/afdko/issues/937
     with tempfile.NamedTemporaryFile(prefix="tx-", delete=False) as tmp:
-        tmp.write(fontdata)
+        tmp.write(data)
     try:
         # write to stdout and capture output
         result = _run_embedded_tx(
-            f"-{output_format.value}",
+            f"-{output_format.rstrip().lower()}",
             "+S",
             "+b",
             tmp.name,
@@ -63,3 +95,85 @@ def subroutinize(fontdata: bytes, output_format=OutputFormat.CFF2) -> bytes:
     finally:
         os.remove(tmp.name)
     return result.stdout
+
+
+def _sniff_cff_table_format(otf: ttLib.TTFont) -> Optional[CFFTableTag]:
+    return next(
+        (
+            CFFTableTag(tag)
+            for tag in otf.keys()
+            if tag in CFFTableTag.__members__.values()
+        ),
+        None,
+    )
+
+
+def subroutinize(
+    otf: ttLib.TTFont,
+    cff_version: Optional[int] = None,
+    keep_glyph_names: bool = True,
+    inplace: bool = True,
+) -> ttLib.TTFont:
+    """Run subroutinizer on a FontTools TTFont's 'CFF ' or 'CFF2' table.
+
+    Args:
+        otf (TTFont): the input CFF-flavored OTF as a FontTools TTFont. It should
+            contain either 'CFF ' or 'CFF2' table.
+        cff_version (Optional[str]): the output table format version, 1 for 'CFF ',
+            2 for 'CFF2'. By default, it's the same as the input table format.
+        keep_glyph_names (bool): CFF 1.0 stores the postscript glyph names and uses
+            the more compact post table format 3.0. CFF2 does not contain glyph names.
+            When converting from CFF to CFF2, the post table will be set to format 2.0
+            to preserve the glyph names. If you prefer instead to drop all glyph names
+            and keep the post format 3.0, set keep_glyph_names=False.
+        inplace (bool): whether to create a copy or modify the input font. By default
+            the input font is modified.
+
+    Returns:
+        The modified font containing the subroutinized CFF or CFF2 table.
+        This will be a different TTFont object if inplace=False.
+
+    Raises:
+        cffsubr.Error if the font doesn't contain 'CFF ' or 'CFF2' table,
+        or if subroutinization process fails.
+    """
+    input_format = _sniff_cff_table_format(otf)
+    if not input_format:
+        raise Error("Invalid OTF: no 'CFF ' or 'CFF2' tables found")
+
+    if cff_version is None:
+        output_format = input_format
+    else:
+        output_format = CFFTableTag.from_version(cff_version)
+
+    if not inplace:
+        otf = copy.deepcopy(otf)
+
+    glyphOrder = otf.getGlyphOrder()
+
+    buf = io.BytesIO()
+    otf.save(buf)
+    otf_data = buf.getvalue()
+
+    compressed_cff_data = _tx_subroutinize(otf_data, output_format)
+
+    cff_table = ttLib.newTable(output_format)
+    cff_table.decompile(compressed_cff_data, otf)
+
+    del otf[input_format]
+    otf[output_format] = cff_table
+
+    if (
+        input_format == CFFTableTag.CFF
+        and output_format == CFFTableTag.CFF2
+        and keep_glyph_names
+    ):
+        # set 'post' to format 2 to keep the glyph names dropped from CFF2
+        post_table = otf.get("post")
+        if post_table and post_table.formatType != 2.0:
+            post_table.formatType = 2.0
+            post_table.extraNames = []
+            post_table.mapping = {}
+            post_table.glyphOrder = glyphOrder
+
+    return otf

--- a/src/cffsubr/__main__.py
+++ b/src/cffsubr/__main__.py
@@ -1,0 +1,55 @@
+import sys
+import argparse
+from fontTools import ttLib
+import cffsubr
+
+
+def main(args=None):
+    """Compress OpenType Font's CFF or CFF2 table by computing subroutines."""
+
+    parser = argparse.ArgumentParser("cffsubr", description=main.__doc__)
+    parser.add_argument(
+        "input_file", help="input font file. Must contain either CFF or CFF2 table"
+    )
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument(
+        "-o",
+        "--output-file",
+        default=None,
+        help="optional path to output file. By default, dump binary data to stdout",
+    )
+    output_group.add_argument(
+        "-i",
+        "--inplace",
+        action="store_true",
+        help="whether to overwrite the input file",
+    )
+    parser.add_argument(
+        "-f",
+        "--cff-version",
+        default=None,
+        type=int,
+        choices=(1, 2),
+        help="output CFF table format version",
+    )
+    parser.add_argument(
+        "-N",
+        "--no-glyph-names",
+        dest="keep_glyph_names",
+        action="store_false",
+        help="whether to drop postscript glyph names when converting from CFF to CFF2.",
+    )
+    options = parser.parse_args(args)
+
+    if options.inplace:
+        options.output_file = options.input_file
+    elif not options.output_file:
+        options.output_file = sys.stdout.buffer
+
+    with ttLib.TTFont(options.input_file, lazy=True) as font:
+        cffsubr.subroutinize(font, options.cff_version, options.keep_glyph_names)
+        font.save(options.output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cffsubr_test.py
+++ b/tests/cffsubr_test.py
@@ -1,0 +1,101 @@
+import io
+import pathlib
+from fontTools import ttLib
+import cffsubr
+import pytest
+
+
+DATA_DIR = pathlib.Path(__file__).parent / "data"
+
+
+def load_test_font(name):
+    font = ttLib.TTFont()
+    font.importXML(DATA_DIR / name)
+    buf = io.BytesIO()
+    font.save(buf)
+    buf.seek(0)
+    return ttLib.TTFont(buf)
+
+
+class TestSubroutinize:
+    @pytest.mark.parametrize(
+        "testfile, table_tag",
+        [
+            ("SourceSansPro-Regular.subset.ttx", "CFF "),
+            ("SourceSansVariable-Roman.subset.ttx", "CFF2"),
+        ],
+    )
+    def test_output_same_cff_version(self, testfile, table_tag):
+        font = load_test_font(testfile)
+
+        assert cffsubr._sniff_cff_table_format(font) == table_tag
+
+        cffsubr.subroutinize(font)
+
+        assert cffsubr._sniff_cff_table_format(font) == table_tag
+
+    @pytest.mark.parametrize(
+        "testfile, cff_version",
+        [
+            ("SourceSansPro-Regular.subset.ttx", 2),
+            ("SourceSansVariable-Roman.subset.ttx", 1),
+        ],
+    )
+    def test_output_different_cff_version(self, testfile, cff_version):
+        font = load_test_font(testfile)
+        table_tag = cffsubr._sniff_cff_table_format(font)
+
+        cffsubr.subroutinize(font, cff_version=cff_version)
+
+        assert cffsubr._sniff_cff_table_format(font) != table_tag
+
+    @pytest.mark.parametrize(
+        "testfile",
+        ["SourceSansPro-Regular.subset.ttx", "SourceSansVariable-Roman.subset.ttx"],
+    )
+    def test_inplace(self, testfile):
+        font = load_test_font(testfile)
+
+        font2 = cffsubr.subroutinize(font, inplace=False)
+        assert font is not font2
+
+        font3 = cffsubr.subroutinize(font, inplace=True)
+        assert font3 is font
+
+    def test_keep_glyph_names(self):
+        font = load_test_font("SourceSansPro-Regular.subset.ttx")
+        glyph_order = font.getGlyphOrder()
+
+        assert font["post"].formatType == 3.0
+        assert font["post"].glyphOrder is None
+
+        cffsubr.subroutinize(font, cff_version=2)
+
+        assert font["post"].formatType == 2.0
+        assert font["post"].glyphOrder == glyph_order
+
+        buf = io.BytesIO()
+        font.save(buf)
+        buf.seek(0)
+        font2 = ttLib.TTFont(buf)
+
+        assert font2.getGlyphOrder() == glyph_order
+
+    def test_drop_glyph_names(self):
+        font = load_test_font("SourceSansPro-Regular.subset.ttx")
+        glyph_order = font.getGlyphOrder()
+
+        assert font["post"].formatType == 3.0
+        assert font["post"].glyphOrder is None
+
+        cffsubr.subroutinize(font, cff_version=2, keep_glyph_names=False)
+
+        assert font["post"].formatType == 3.0
+        assert font["post"].glyphOrder is None
+
+        buf = io.BytesIO()
+        font.save(buf)
+        buf.seek(0)
+        font2 = ttLib.TTFont(buf)
+
+        assert font2.getGlyphOrder() != glyph_order

--- a/tests/data/LICENSE.md
+++ b/tests/data/LICENSE.md
@@ -1,0 +1,93 @@
+Copyright 2010-2018 Adobe (http://www.adobe.com/), with Reserved Font Name 'Source'. All Rights Reserved. Source is a trademark of Adobe in the United States and/or other countries.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+
+This license is copied below, and is also available with a FAQ at: http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/tests/data/SourceSansPro-Regular.subset.ttx
+++ b/tests/data/SourceSansPro-Regular.subset.ttx
@@ -1,0 +1,17303 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.10">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="space"/>
+    <GlyphID id="2" name="A"/>
+    <GlyphID id="3" name="B"/>
+    <GlyphID id="4" name="C"/>
+    <GlyphID id="5" name="D"/>
+    <GlyphID id="6" name="E"/>
+    <GlyphID id="7" name="F"/>
+    <GlyphID id="8" name="G"/>
+    <GlyphID id="9" name="H"/>
+    <GlyphID id="10" name="I"/>
+    <GlyphID id="11" name="J"/>
+    <GlyphID id="12" name="K"/>
+    <GlyphID id="13" name="L"/>
+    <GlyphID id="14" name="M"/>
+    <GlyphID id="15" name="N"/>
+    <GlyphID id="16" name="O"/>
+    <GlyphID id="17" name="P"/>
+    <GlyphID id="18" name="Q"/>
+    <GlyphID id="19" name="R"/>
+    <GlyphID id="20" name="S"/>
+    <GlyphID id="21" name="T"/>
+    <GlyphID id="22" name="U"/>
+    <GlyphID id="23" name="V"/>
+    <GlyphID id="24" name="W"/>
+    <GlyphID id="25" name="X"/>
+    <GlyphID id="26" name="Y"/>
+    <GlyphID id="27" name="Z"/>
+    <GlyphID id="28" name="a"/>
+    <GlyphID id="29" name="b"/>
+    <GlyphID id="30" name="c"/>
+    <GlyphID id="31" name="d"/>
+    <GlyphID id="32" name="e"/>
+    <GlyphID id="33" name="f"/>
+    <GlyphID id="34" name="g"/>
+    <GlyphID id="35" name="h"/>
+    <GlyphID id="36" name="i"/>
+    <GlyphID id="37" name="j"/>
+    <GlyphID id="38" name="k"/>
+    <GlyphID id="39" name="l"/>
+    <GlyphID id="40" name="m"/>
+    <GlyphID id="41" name="n"/>
+    <GlyphID id="42" name="o"/>
+    <GlyphID id="43" name="p"/>
+    <GlyphID id="44" name="q"/>
+    <GlyphID id="45" name="r"/>
+    <GlyphID id="46" name="s"/>
+    <GlyphID id="47" name="t"/>
+    <GlyphID id="48" name="u"/>
+    <GlyphID id="49" name="v"/>
+    <GlyphID id="50" name="w"/>
+    <GlyphID id="51" name="x"/>
+    <GlyphID id="52" name="y"/>
+    <GlyphID id="53" name="z"/>
+    <GlyphID id="54" name="Agrave"/>
+    <GlyphID id="55" name="Aacute"/>
+    <GlyphID id="56" name="Acircumflex"/>
+    <GlyphID id="57" name="Atilde"/>
+    <GlyphID id="58" name="Adieresis"/>
+    <GlyphID id="59" name="Aring"/>
+    <GlyphID id="60" name="AE"/>
+    <GlyphID id="61" name="Ccedilla"/>
+    <GlyphID id="62" name="Egrave"/>
+    <GlyphID id="63" name="Eacute"/>
+    <GlyphID id="64" name="Ecircumflex"/>
+    <GlyphID id="65" name="Edieresis"/>
+    <GlyphID id="66" name="Igrave"/>
+    <GlyphID id="67" name="Iacute"/>
+    <GlyphID id="68" name="Icircumflex"/>
+    <GlyphID id="69" name="Idieresis"/>
+    <GlyphID id="70" name="Ntilde"/>
+    <GlyphID id="71" name="Ograve"/>
+    <GlyphID id="72" name="Oacute"/>
+    <GlyphID id="73" name="Ocircumflex"/>
+    <GlyphID id="74" name="Otilde"/>
+    <GlyphID id="75" name="Odieresis"/>
+    <GlyphID id="76" name="Oslash"/>
+    <GlyphID id="77" name="Ugrave"/>
+    <GlyphID id="78" name="Uacute"/>
+    <GlyphID id="79" name="Ucircumflex"/>
+    <GlyphID id="80" name="Udieresis"/>
+    <GlyphID id="81" name="Yacute"/>
+    <GlyphID id="82" name="Eth"/>
+    <GlyphID id="83" name="Thorn"/>
+    <GlyphID id="84" name="uni004C00B7004C"/>
+    <GlyphID id="85" name="agrave"/>
+    <GlyphID id="86" name="aacute"/>
+    <GlyphID id="87" name="acircumflex"/>
+    <GlyphID id="88" name="atilde"/>
+    <GlyphID id="89" name="adieresis"/>
+    <GlyphID id="90" name="aring"/>
+    <GlyphID id="91" name="ae"/>
+    <GlyphID id="92" name="ccedilla"/>
+    <GlyphID id="93" name="egrave"/>
+    <GlyphID id="94" name="eacute"/>
+    <GlyphID id="95" name="ecircumflex"/>
+    <GlyphID id="96" name="edieresis"/>
+    <GlyphID id="97" name="igrave"/>
+    <GlyphID id="98" name="iacute"/>
+    <GlyphID id="99" name="icircumflex"/>
+    <GlyphID id="100" name="idieresis"/>
+    <GlyphID id="101" name="ntilde"/>
+    <GlyphID id="102" name="ograve"/>
+    <GlyphID id="103" name="oacute"/>
+    <GlyphID id="104" name="ocircumflex"/>
+    <GlyphID id="105" name="otilde"/>
+    <GlyphID id="106" name="odieresis"/>
+    <GlyphID id="107" name="oslash"/>
+    <GlyphID id="108" name="germandbls"/>
+    <GlyphID id="109" name="ugrave"/>
+    <GlyphID id="110" name="uacute"/>
+    <GlyphID id="111" name="ucircumflex"/>
+    <GlyphID id="112" name="udieresis"/>
+    <GlyphID id="113" name="yacute"/>
+    <GlyphID id="114" name="ydieresis"/>
+    <GlyphID id="115" name="eth"/>
+    <GlyphID id="116" name="thorn"/>
+    <GlyphID id="117" name="uni006C00B7006C"/>
+    <GlyphID id="118" name="f_f"/>
+    <GlyphID id="119" name="f_t"/>
+    <GlyphID id="120" name="f_f_t"/>
+    <GlyphID id="121" name="mu"/>
+    <GlyphID id="122" name="ampersand"/>
+    <GlyphID id="123" name="zero"/>
+    <GlyphID id="124" name="one"/>
+    <GlyphID id="125" name="two"/>
+    <GlyphID id="126" name="three"/>
+    <GlyphID id="127" name="four"/>
+    <GlyphID id="128" name="five"/>
+    <GlyphID id="129" name="six"/>
+    <GlyphID id="130" name="seven"/>
+    <GlyphID id="131" name="eight"/>
+    <GlyphID id="132" name="nine"/>
+    <GlyphID id="133" name="period"/>
+    <GlyphID id="134" name="comma"/>
+    <GlyphID id="135" name="colon"/>
+    <GlyphID id="136" name="semicolon"/>
+    <GlyphID id="137" name="exclam"/>
+    <GlyphID id="138" name="exclamdown"/>
+    <GlyphID id="139" name="question"/>
+    <GlyphID id="140" name="questiondown"/>
+    <GlyphID id="141" name="quotesingle"/>
+    <GlyphID id="142" name="quotedbl"/>
+    <GlyphID id="143" name="guillemotleft"/>
+    <GlyphID id="144" name="guillemotright"/>
+    <GlyphID id="145" name="hyphen"/>
+    <GlyphID id="146" name="periodcentered"/>
+    <GlyphID id="147" name="underscore"/>
+    <GlyphID id="148" name="parenleft"/>
+    <GlyphID id="149" name="parenright"/>
+    <GlyphID id="150" name="bracketleft"/>
+    <GlyphID id="151" name="bracketright"/>
+    <GlyphID id="152" name="braceleft"/>
+    <GlyphID id="153" name="braceright"/>
+    <GlyphID id="154" name="slash"/>
+    <GlyphID id="155" name="bar"/>
+    <GlyphID id="156" name="backslash"/>
+    <GlyphID id="157" name="brokenbar"/>
+    <GlyphID id="158" name="asterisk"/>
+    <GlyphID id="159" name="section"/>
+    <GlyphID id="160" name="paragraph"/>
+    <GlyphID id="161" name="copyright"/>
+    <GlyphID id="162" name="registered"/>
+    <GlyphID id="163" name="at"/>
+    <GlyphID id="164" name="numbersign"/>
+    <GlyphID id="165" name="zero.sups"/>
+    <GlyphID id="166" name="one.sups"/>
+    <GlyphID id="167" name="two.sups"/>
+    <GlyphID id="168" name="three.sups"/>
+    <GlyphID id="169" name="four.sups"/>
+    <GlyphID id="170" name="five.sups"/>
+    <GlyphID id="171" name="six.sups"/>
+    <GlyphID id="172" name="seven.sups"/>
+    <GlyphID id="173" name="eight.sups"/>
+    <GlyphID id="174" name="nine.sups"/>
+    <GlyphID id="175" name="plus.sups"/>
+    <GlyphID id="176" name="equal.sups"/>
+    <GlyphID id="177" name="parenleft.sups"/>
+    <GlyphID id="178" name="parenright.sups"/>
+    <GlyphID id="179" name="period.sups"/>
+    <GlyphID id="180" name="comma.sups"/>
+    <GlyphID id="181" name="zero.dnom"/>
+    <GlyphID id="182" name="one.dnom"/>
+    <GlyphID id="183" name="two.dnom"/>
+    <GlyphID id="184" name="three.dnom"/>
+    <GlyphID id="185" name="four.dnom"/>
+    <GlyphID id="186" name="five.dnom"/>
+    <GlyphID id="187" name="six.dnom"/>
+    <GlyphID id="188" name="seven.dnom"/>
+    <GlyphID id="189" name="eight.dnom"/>
+    <GlyphID id="190" name="nine.dnom"/>
+    <GlyphID id="191" name="parenleft.dnom"/>
+    <GlyphID id="192" name="parenright.dnom"/>
+    <GlyphID id="193" name="period.dnom"/>
+    <GlyphID id="194" name="comma.dnom"/>
+    <GlyphID id="195" name="zero.numr"/>
+    <GlyphID id="196" name="one.numr"/>
+    <GlyphID id="197" name="two.numr"/>
+    <GlyphID id="198" name="three.numr"/>
+    <GlyphID id="199" name="four.numr"/>
+    <GlyphID id="200" name="five.numr"/>
+    <GlyphID id="201" name="six.numr"/>
+    <GlyphID id="202" name="seven.numr"/>
+    <GlyphID id="203" name="eight.numr"/>
+    <GlyphID id="204" name="nine.numr"/>
+    <GlyphID id="205" name="parenleft.numr"/>
+    <GlyphID id="206" name="parenright.numr"/>
+    <GlyphID id="207" name="period.numr"/>
+    <GlyphID id="208" name="comma.numr"/>
+    <GlyphID id="209" name="ordfeminine"/>
+    <GlyphID id="210" name="ordmasculine"/>
+    <GlyphID id="211" name="A.sups"/>
+    <GlyphID id="212" name="B.sups"/>
+    <GlyphID id="213" name="C.sups"/>
+    <GlyphID id="214" name="D.sups"/>
+    <GlyphID id="215" name="E.sups"/>
+    <GlyphID id="216" name="F.sups"/>
+    <GlyphID id="217" name="G.sups"/>
+    <GlyphID id="218" name="H.sups"/>
+    <GlyphID id="219" name="I.sups"/>
+    <GlyphID id="220" name="J.sups"/>
+    <GlyphID id="221" name="K.sups"/>
+    <GlyphID id="222" name="L.sups"/>
+    <GlyphID id="223" name="M.sups"/>
+    <GlyphID id="224" name="N.sups"/>
+    <GlyphID id="225" name="O.sups"/>
+    <GlyphID id="226" name="P.sups"/>
+    <GlyphID id="227" name="Q.sups"/>
+    <GlyphID id="228" name="R.sups"/>
+    <GlyphID id="229" name="S.sups"/>
+    <GlyphID id="230" name="T.sups"/>
+    <GlyphID id="231" name="U.sups"/>
+    <GlyphID id="232" name="V.sups"/>
+    <GlyphID id="233" name="W.sups"/>
+    <GlyphID id="234" name="X.sups"/>
+    <GlyphID id="235" name="Y.sups"/>
+    <GlyphID id="236" name="Z.sups"/>
+    <GlyphID id="237" name="a.sups"/>
+    <GlyphID id="238" name="b.sups"/>
+    <GlyphID id="239" name="c.sups"/>
+    <GlyphID id="240" name="d.sups"/>
+    <GlyphID id="241" name="e.sups"/>
+    <GlyphID id="242" name="f.sups"/>
+    <GlyphID id="243" name="g.sups"/>
+    <GlyphID id="244" name="h.sups"/>
+    <GlyphID id="245" name="i.sups"/>
+    <GlyphID id="246" name="j.sups"/>
+    <GlyphID id="247" name="k.sups"/>
+    <GlyphID id="248" name="l.sups"/>
+    <GlyphID id="249" name="m.sups"/>
+    <GlyphID id="250" name="n.sups"/>
+    <GlyphID id="251" name="o.sups"/>
+    <GlyphID id="252" name="p.sups"/>
+    <GlyphID id="253" name="q.sups"/>
+    <GlyphID id="254" name="r.sups"/>
+    <GlyphID id="255" name="s.sups"/>
+    <GlyphID id="256" name="t.sups"/>
+    <GlyphID id="257" name="u.sups"/>
+    <GlyphID id="258" name="v.sups"/>
+    <GlyphID id="259" name="w.sups"/>
+    <GlyphID id="260" name="x.sups"/>
+    <GlyphID id="261" name="y.sups"/>
+    <GlyphID id="262" name="z.sups"/>
+    <GlyphID id="263" name="egrave.sups"/>
+    <GlyphID id="264" name="eacute.sups"/>
+    <GlyphID id="265" name="colon.sups"/>
+    <GlyphID id="266" name="hyphen.sups"/>
+    <GlyphID id="267" name="currency"/>
+    <GlyphID id="268" name="dollar"/>
+    <GlyphID id="269" name="sterling"/>
+    <GlyphID id="270" name="yen"/>
+    <GlyphID id="271" name="cent"/>
+    <GlyphID id="272" name="slash.frac"/>
+    <GlyphID id="273" name="percent"/>
+    <GlyphID id="274" name="onequarter"/>
+    <GlyphID id="275" name="onehalf"/>
+    <GlyphID id="276" name="threequarters"/>
+    <GlyphID id="277" name="plus"/>
+    <GlyphID id="278" name="multiply"/>
+    <GlyphID id="279" name="divide"/>
+    <GlyphID id="280" name="equal"/>
+    <GlyphID id="281" name="less"/>
+    <GlyphID id="282" name="greater"/>
+    <GlyphID id="283" name="plusminus"/>
+    <GlyphID id="284" name="asciicircum"/>
+    <GlyphID id="285" name="asciitilde"/>
+    <GlyphID id="286" name="logicalnot"/>
+    <GlyphID id="287" name="degree"/>
+    <GlyphID id="288" name="grave"/>
+    <GlyphID id="289" name="acute"/>
+    <GlyphID id="290" name="dieresis"/>
+    <GlyphID id="291" name="macron"/>
+    <GlyphID id="292" name="cedilla"/>
+    <GlyphID id="293" name="space.frac"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="3.006"/>
+    <checkSumAdjustment value="0x1a132bfe"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Aug  9 14:21:37 2019"/>
+    <modified value="Thu May 28 12:10:01 2020"/>
+    <xMin value="-167"/>
+    <yMin value="-250"/>
+    <xMax value="946"/>
+    <yMax value="916"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="3"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1024"/>
+    <descent value="-400"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="2200"/>
+    <minLeftSideBearing value="-454"/>
+    <minRightSideBearing value="-454"/>
+    <xMaxExtent value="2159"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="294"/>
+  </hhea>
+
+  <maxp>
+    <tableVersion value="0x5000"/>
+    <numGlyphs value="294"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="3"/>
+    <xAvgCharWidth value="522"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="291"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="11"/>
+      <bWeight value="5"/>
+      <bProportion value="3"/>
+      <bContrast value="3"/>
+      <bStrokeVariation value="4"/>
+      <bArmStyle value="3"/>
+      <bLetterForm value="2"/>
+      <bMidline value="2"/>
+      <bXHeight value="4"/>
+    </panose>
+    <ulUnicodeRange1 value="01100000 00000000 00000010 11110111"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000011"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="ADBO"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="32"/>
+    <usLastCharIndex value="65535"/>
+    <sTypoAscender value="1024"/>
+    <sTypoDescender value="-400"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1024"/>
+    <usWinDescent value="400"/>
+    <ulCodePageRange1 value="00100000 00000000 00000001 10011111"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="486"/>
+    <sCapHeight value="660"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="3"/>
+  </OS_2>
+
+  <name>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      © 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/), with Reserved Font Name ‘Source’.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Source Sans Pro
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      3.006;ADBO;SourceSansPro-Regular;ADOBE
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Source Sans Pro
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      SourceSansPro-Regular
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Source is a trademark of Adobe Systems Incorporated in the United States and/or other countries.
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Adobe Systems Incorporated
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Paul D. Hunt
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://www.adobe.com/type
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: http://scripts.sil.org/OFL. This Font Software is distributed on an ‘AS IS’ BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://scripts.sil.org/OFL
+    </namerecord>
+  </name>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x21" name="exclam"/><!-- EXCLAMATION MARK -->
+      <map code="0x22" name="quotedbl"/><!-- QUOTATION MARK -->
+      <map code="0x23" name="numbersign"/><!-- NUMBER SIGN -->
+      <map code="0x24" name="dollar"/><!-- DOLLAR SIGN -->
+      <map code="0x25" name="percent"/><!-- PERCENT SIGN -->
+      <map code="0x26" name="ampersand"/><!-- AMPERSAND -->
+      <map code="0x27" name="quotesingle"/><!-- APOSTROPHE -->
+      <map code="0x28" name="parenleft"/><!-- LEFT PARENTHESIS -->
+      <map code="0x29" name="parenright"/><!-- RIGHT PARENTHESIS -->
+      <map code="0x2a" name="asterisk"/><!-- ASTERISK -->
+      <map code="0x2b" name="plus"/><!-- PLUS SIGN -->
+      <map code="0x2c" name="comma"/><!-- COMMA -->
+      <map code="0x2d" name="hyphen"/><!-- HYPHEN-MINUS -->
+      <map code="0x2e" name="period"/><!-- FULL STOP -->
+      <map code="0x2f" name="slash"/><!-- SOLIDUS -->
+      <map code="0x30" name="zero"/><!-- DIGIT ZERO -->
+      <map code="0x31" name="one"/><!-- DIGIT ONE -->
+      <map code="0x32" name="two"/><!-- DIGIT TWO -->
+      <map code="0x33" name="three"/><!-- DIGIT THREE -->
+      <map code="0x34" name="four"/><!-- DIGIT FOUR -->
+      <map code="0x35" name="five"/><!-- DIGIT FIVE -->
+      <map code="0x36" name="six"/><!-- DIGIT SIX -->
+      <map code="0x37" name="seven"/><!-- DIGIT SEVEN -->
+      <map code="0x38" name="eight"/><!-- DIGIT EIGHT -->
+      <map code="0x39" name="nine"/><!-- DIGIT NINE -->
+      <map code="0x3a" name="colon"/><!-- COLON -->
+      <map code="0x3b" name="semicolon"/><!-- SEMICOLON -->
+      <map code="0x3c" name="less"/><!-- LESS-THAN SIGN -->
+      <map code="0x3d" name="equal"/><!-- EQUALS SIGN -->
+      <map code="0x3e" name="greater"/><!-- GREATER-THAN SIGN -->
+      <map code="0x3f" name="question"/><!-- QUESTION MARK -->
+      <map code="0x40" name="at"/><!-- COMMERCIAL AT -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x44" name="D"/><!-- LATIN CAPITAL LETTER D -->
+      <map code="0x45" name="E"/><!-- LATIN CAPITAL LETTER E -->
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x47" name="G"/><!-- LATIN CAPITAL LETTER G -->
+      <map code="0x48" name="H"/><!-- LATIN CAPITAL LETTER H -->
+      <map code="0x49" name="I"/><!-- LATIN CAPITAL LETTER I -->
+      <map code="0x4a" name="J"/><!-- LATIN CAPITAL LETTER J -->
+      <map code="0x4b" name="K"/><!-- LATIN CAPITAL LETTER K -->
+      <map code="0x4c" name="L"/><!-- LATIN CAPITAL LETTER L -->
+      <map code="0x4d" name="M"/><!-- LATIN CAPITAL LETTER M -->
+      <map code="0x4e" name="N"/><!-- LATIN CAPITAL LETTER N -->
+      <map code="0x4f" name="O"/><!-- LATIN CAPITAL LETTER O -->
+      <map code="0x50" name="P"/><!-- LATIN CAPITAL LETTER P -->
+      <map code="0x51" name="Q"/><!-- LATIN CAPITAL LETTER Q -->
+      <map code="0x52" name="R"/><!-- LATIN CAPITAL LETTER R -->
+      <map code="0x53" name="S"/><!-- LATIN CAPITAL LETTER S -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x55" name="U"/><!-- LATIN CAPITAL LETTER U -->
+      <map code="0x56" name="V"/><!-- LATIN CAPITAL LETTER V -->
+      <map code="0x57" name="W"/><!-- LATIN CAPITAL LETTER W -->
+      <map code="0x58" name="X"/><!-- LATIN CAPITAL LETTER X -->
+      <map code="0x59" name="Y"/><!-- LATIN CAPITAL LETTER Y -->
+      <map code="0x5a" name="Z"/><!-- LATIN CAPITAL LETTER Z -->
+      <map code="0x5b" name="bracketleft"/><!-- LEFT SQUARE BRACKET -->
+      <map code="0x5c" name="backslash"/><!-- REVERSE SOLIDUS -->
+      <map code="0x5d" name="bracketright"/><!-- RIGHT SQUARE BRACKET -->
+      <map code="0x5e" name="asciicircum"/><!-- CIRCUMFLEX ACCENT -->
+      <map code="0x5f" name="underscore"/><!-- LOW LINE -->
+      <map code="0x60" name="grave"/><!-- GRAVE ACCENT -->
+      <map code="0x61" name="a"/><!-- LATIN SMALL LETTER A -->
+      <map code="0x62" name="b"/><!-- LATIN SMALL LETTER B -->
+      <map code="0x63" name="c"/><!-- LATIN SMALL LETTER C -->
+      <map code="0x64" name="d"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="e"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="f"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="g"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="h"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="i"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="j"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="k"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6d" name="m"/><!-- LATIN SMALL LETTER M -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x70" name="p"/><!-- LATIN SMALL LETTER P -->
+      <map code="0x71" name="q"/><!-- LATIN SMALL LETTER Q -->
+      <map code="0x72" name="r"/><!-- LATIN SMALL LETTER R -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+      <map code="0x75" name="u"/><!-- LATIN SMALL LETTER U -->
+      <map code="0x76" name="v"/><!-- LATIN SMALL LETTER V -->
+      <map code="0x77" name="w"/><!-- LATIN SMALL LETTER W -->
+      <map code="0x78" name="x"/><!-- LATIN SMALL LETTER X -->
+      <map code="0x79" name="y"/><!-- LATIN SMALL LETTER Y -->
+      <map code="0x7a" name="z"/><!-- LATIN SMALL LETTER Z -->
+      <map code="0x7b" name="braceleft"/><!-- LEFT CURLY BRACKET -->
+      <map code="0x7c" name="bar"/><!-- VERTICAL LINE -->
+      <map code="0x7d" name="braceright"/><!-- RIGHT CURLY BRACKET -->
+      <map code="0x7e" name="asciitilde"/><!-- TILDE -->
+      <map code="0xa0" name="space"/><!-- NO-BREAK SPACE -->
+      <map code="0xa1" name="exclamdown"/><!-- INVERTED EXCLAMATION MARK -->
+      <map code="0xa2" name="cent"/><!-- CENT SIGN -->
+      <map code="0xa3" name="sterling"/><!-- POUND SIGN -->
+      <map code="0xa4" name="currency"/><!-- CURRENCY SIGN -->
+      <map code="0xa5" name="yen"/><!-- YEN SIGN -->
+      <map code="0xa6" name="brokenbar"/><!-- BROKEN BAR -->
+      <map code="0xa7" name="section"/><!-- SECTION SIGN -->
+      <map code="0xa8" name="dieresis"/><!-- DIAERESIS -->
+      <map code="0xa9" name="copyright"/><!-- COPYRIGHT SIGN -->
+      <map code="0xaa" name="ordfeminine"/><!-- FEMININE ORDINAL INDICATOR -->
+      <map code="0xab" name="guillemotleft"/><!-- LEFT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+      <map code="0xac" name="logicalnot"/><!-- NOT SIGN -->
+      <map code="0xad" name="hyphen"/><!-- SOFT HYPHEN -->
+      <map code="0xae" name="registered"/><!-- REGISTERED SIGN -->
+      <map code="0xaf" name="macron"/><!-- MACRON -->
+      <map code="0xb0" name="degree"/><!-- DEGREE SIGN -->
+      <map code="0xb1" name="plusminus"/><!-- PLUS-MINUS SIGN -->
+      <map code="0xb2" name="two.sups"/><!-- SUPERSCRIPT TWO -->
+      <map code="0xb3" name="three.sups"/><!-- SUPERSCRIPT THREE -->
+      <map code="0xb4" name="acute"/><!-- ACUTE ACCENT -->
+      <map code="0xb5" name="mu"/><!-- MICRO SIGN -->
+      <map code="0xb6" name="paragraph"/><!-- PILCROW SIGN -->
+      <map code="0xb7" name="periodcentered"/><!-- MIDDLE DOT -->
+      <map code="0xb8" name="cedilla"/><!-- CEDILLA -->
+      <map code="0xb9" name="one.sups"/><!-- SUPERSCRIPT ONE -->
+      <map code="0xba" name="ordmasculine"/><!-- MASCULINE ORDINAL INDICATOR -->
+      <map code="0xbb" name="guillemotright"/><!-- RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+      <map code="0xbc" name="onequarter"/><!-- VULGAR FRACTION ONE QUARTER -->
+      <map code="0xbd" name="onehalf"/><!-- VULGAR FRACTION ONE HALF -->
+      <map code="0xbe" name="threequarters"/><!-- VULGAR FRACTION THREE QUARTERS -->
+      <map code="0xbf" name="questiondown"/><!-- INVERTED QUESTION MARK -->
+      <map code="0xc0" name="Agrave"/><!-- LATIN CAPITAL LETTER A WITH GRAVE -->
+      <map code="0xc1" name="Aacute"/><!-- LATIN CAPITAL LETTER A WITH ACUTE -->
+      <map code="0xc2" name="Acircumflex"/><!-- LATIN CAPITAL LETTER A WITH CIRCUMFLEX -->
+      <map code="0xc3" name="Atilde"/><!-- LATIN CAPITAL LETTER A WITH TILDE -->
+      <map code="0xc4" name="Adieresis"/><!-- LATIN CAPITAL LETTER A WITH DIAERESIS -->
+      <map code="0xc5" name="Aring"/><!-- LATIN CAPITAL LETTER A WITH RING ABOVE -->
+      <map code="0xc6" name="AE"/><!-- LATIN CAPITAL LETTER AE -->
+      <map code="0xc7" name="Ccedilla"/><!-- LATIN CAPITAL LETTER C WITH CEDILLA -->
+      <map code="0xc8" name="Egrave"/><!-- LATIN CAPITAL LETTER E WITH GRAVE -->
+      <map code="0xc9" name="Eacute"/><!-- LATIN CAPITAL LETTER E WITH ACUTE -->
+      <map code="0xca" name="Ecircumflex"/><!-- LATIN CAPITAL LETTER E WITH CIRCUMFLEX -->
+      <map code="0xcb" name="Edieresis"/><!-- LATIN CAPITAL LETTER E WITH DIAERESIS -->
+      <map code="0xcc" name="Igrave"/><!-- LATIN CAPITAL LETTER I WITH GRAVE -->
+      <map code="0xcd" name="Iacute"/><!-- LATIN CAPITAL LETTER I WITH ACUTE -->
+      <map code="0xce" name="Icircumflex"/><!-- LATIN CAPITAL LETTER I WITH CIRCUMFLEX -->
+      <map code="0xcf" name="Idieresis"/><!-- LATIN CAPITAL LETTER I WITH DIAERESIS -->
+      <map code="0xd0" name="Eth"/><!-- LATIN CAPITAL LETTER ETH -->
+      <map code="0xd1" name="Ntilde"/><!-- LATIN CAPITAL LETTER N WITH TILDE -->
+      <map code="0xd2" name="Ograve"/><!-- LATIN CAPITAL LETTER O WITH GRAVE -->
+      <map code="0xd3" name="Oacute"/><!-- LATIN CAPITAL LETTER O WITH ACUTE -->
+      <map code="0xd4" name="Ocircumflex"/><!-- LATIN CAPITAL LETTER O WITH CIRCUMFLEX -->
+      <map code="0xd5" name="Otilde"/><!-- LATIN CAPITAL LETTER O WITH TILDE -->
+      <map code="0xd6" name="Odieresis"/><!-- LATIN CAPITAL LETTER O WITH DIAERESIS -->
+      <map code="0xd7" name="multiply"/><!-- MULTIPLICATION SIGN -->
+      <map code="0xd8" name="Oslash"/><!-- LATIN CAPITAL LETTER O WITH STROKE -->
+      <map code="0xd9" name="Ugrave"/><!-- LATIN CAPITAL LETTER U WITH GRAVE -->
+      <map code="0xda" name="Uacute"/><!-- LATIN CAPITAL LETTER U WITH ACUTE -->
+      <map code="0xdb" name="Ucircumflex"/><!-- LATIN CAPITAL LETTER U WITH CIRCUMFLEX -->
+      <map code="0xdc" name="Udieresis"/><!-- LATIN CAPITAL LETTER U WITH DIAERESIS -->
+      <map code="0xdd" name="Yacute"/><!-- LATIN CAPITAL LETTER Y WITH ACUTE -->
+      <map code="0xde" name="Thorn"/><!-- LATIN CAPITAL LETTER THORN -->
+      <map code="0xdf" name="germandbls"/><!-- LATIN SMALL LETTER SHARP S -->
+      <map code="0xe0" name="agrave"/><!-- LATIN SMALL LETTER A WITH GRAVE -->
+      <map code="0xe1" name="aacute"/><!-- LATIN SMALL LETTER A WITH ACUTE -->
+      <map code="0xe2" name="acircumflex"/><!-- LATIN SMALL LETTER A WITH CIRCUMFLEX -->
+      <map code="0xe3" name="atilde"/><!-- LATIN SMALL LETTER A WITH TILDE -->
+      <map code="0xe4" name="adieresis"/><!-- LATIN SMALL LETTER A WITH DIAERESIS -->
+      <map code="0xe5" name="aring"/><!-- LATIN SMALL LETTER A WITH RING ABOVE -->
+      <map code="0xe6" name="ae"/><!-- LATIN SMALL LETTER AE -->
+      <map code="0xe7" name="ccedilla"/><!-- LATIN SMALL LETTER C WITH CEDILLA -->
+      <map code="0xe8" name="egrave"/><!-- LATIN SMALL LETTER E WITH GRAVE -->
+      <map code="0xe9" name="eacute"/><!-- LATIN SMALL LETTER E WITH ACUTE -->
+      <map code="0xea" name="ecircumflex"/><!-- LATIN SMALL LETTER E WITH CIRCUMFLEX -->
+      <map code="0xeb" name="edieresis"/><!-- LATIN SMALL LETTER E WITH DIAERESIS -->
+      <map code="0xec" name="igrave"/><!-- LATIN SMALL LETTER I WITH GRAVE -->
+      <map code="0xed" name="iacute"/><!-- LATIN SMALL LETTER I WITH ACUTE -->
+      <map code="0xee" name="icircumflex"/><!-- LATIN SMALL LETTER I WITH CIRCUMFLEX -->
+      <map code="0xef" name="idieresis"/><!-- LATIN SMALL LETTER I WITH DIAERESIS -->
+      <map code="0xf0" name="eth"/><!-- LATIN SMALL LETTER ETH -->
+      <map code="0xf1" name="ntilde"/><!-- LATIN SMALL LETTER N WITH TILDE -->
+      <map code="0xf2" name="ograve"/><!-- LATIN SMALL LETTER O WITH GRAVE -->
+      <map code="0xf3" name="oacute"/><!-- LATIN SMALL LETTER O WITH ACUTE -->
+      <map code="0xf4" name="ocircumflex"/><!-- LATIN SMALL LETTER O WITH CIRCUMFLEX -->
+      <map code="0xf5" name="otilde"/><!-- LATIN SMALL LETTER O WITH TILDE -->
+      <map code="0xf6" name="odieresis"/><!-- LATIN SMALL LETTER O WITH DIAERESIS -->
+      <map code="0xf7" name="divide"/><!-- DIVISION SIGN -->
+      <map code="0xf8" name="oslash"/><!-- LATIN SMALL LETTER O WITH STROKE -->
+      <map code="0xf9" name="ugrave"/><!-- LATIN SMALL LETTER U WITH GRAVE -->
+      <map code="0xfa" name="uacute"/><!-- LATIN SMALL LETTER U WITH ACUTE -->
+      <map code="0xfb" name="ucircumflex"/><!-- LATIN SMALL LETTER U WITH CIRCUMFLEX -->
+      <map code="0xfc" name="udieresis"/><!-- LATIN SMALL LETTER U WITH DIAERESIS -->
+      <map code="0xfd" name="yacute"/><!-- LATIN SMALL LETTER Y WITH ACUTE -->
+      <map code="0xfe" name="thorn"/><!-- LATIN SMALL LETTER THORN -->
+      <map code="0xff" name="ydieresis"/><!-- LATIN SMALL LETTER Y WITH DIAERESIS -->
+    </cmap_format_4>
+    <cmap_format_12 platformID="0" platEncID="4" format="12" reserved="0" length="952" language="0" nGroups="78">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x21" name="exclam"/><!-- EXCLAMATION MARK -->
+      <map code="0x22" name="quotedbl"/><!-- QUOTATION MARK -->
+      <map code="0x23" name="numbersign"/><!-- NUMBER SIGN -->
+      <map code="0x24" name="dollar"/><!-- DOLLAR SIGN -->
+      <map code="0x25" name="percent"/><!-- PERCENT SIGN -->
+      <map code="0x26" name="ampersand"/><!-- AMPERSAND -->
+      <map code="0x27" name="quotesingle"/><!-- APOSTROPHE -->
+      <map code="0x28" name="parenleft"/><!-- LEFT PARENTHESIS -->
+      <map code="0x29" name="parenright"/><!-- RIGHT PARENTHESIS -->
+      <map code="0x2a" name="asterisk"/><!-- ASTERISK -->
+      <map code="0x2b" name="plus"/><!-- PLUS SIGN -->
+      <map code="0x2c" name="comma"/><!-- COMMA -->
+      <map code="0x2d" name="hyphen"/><!-- HYPHEN-MINUS -->
+      <map code="0x2e" name="period"/><!-- FULL STOP -->
+      <map code="0x2f" name="slash"/><!-- SOLIDUS -->
+      <map code="0x30" name="zero"/><!-- DIGIT ZERO -->
+      <map code="0x31" name="one"/><!-- DIGIT ONE -->
+      <map code="0x32" name="two"/><!-- DIGIT TWO -->
+      <map code="0x33" name="three"/><!-- DIGIT THREE -->
+      <map code="0x34" name="four"/><!-- DIGIT FOUR -->
+      <map code="0x35" name="five"/><!-- DIGIT FIVE -->
+      <map code="0x36" name="six"/><!-- DIGIT SIX -->
+      <map code="0x37" name="seven"/><!-- DIGIT SEVEN -->
+      <map code="0x38" name="eight"/><!-- DIGIT EIGHT -->
+      <map code="0x39" name="nine"/><!-- DIGIT NINE -->
+      <map code="0x3a" name="colon"/><!-- COLON -->
+      <map code="0x3b" name="semicolon"/><!-- SEMICOLON -->
+      <map code="0x3c" name="less"/><!-- LESS-THAN SIGN -->
+      <map code="0x3d" name="equal"/><!-- EQUALS SIGN -->
+      <map code="0x3e" name="greater"/><!-- GREATER-THAN SIGN -->
+      <map code="0x3f" name="question"/><!-- QUESTION MARK -->
+      <map code="0x40" name="at"/><!-- COMMERCIAL AT -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x44" name="D"/><!-- LATIN CAPITAL LETTER D -->
+      <map code="0x45" name="E"/><!-- LATIN CAPITAL LETTER E -->
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x47" name="G"/><!-- LATIN CAPITAL LETTER G -->
+      <map code="0x48" name="H"/><!-- LATIN CAPITAL LETTER H -->
+      <map code="0x49" name="I"/><!-- LATIN CAPITAL LETTER I -->
+      <map code="0x4a" name="J"/><!-- LATIN CAPITAL LETTER J -->
+      <map code="0x4b" name="K"/><!-- LATIN CAPITAL LETTER K -->
+      <map code="0x4c" name="L"/><!-- LATIN CAPITAL LETTER L -->
+      <map code="0x4d" name="M"/><!-- LATIN CAPITAL LETTER M -->
+      <map code="0x4e" name="N"/><!-- LATIN CAPITAL LETTER N -->
+      <map code="0x4f" name="O"/><!-- LATIN CAPITAL LETTER O -->
+      <map code="0x50" name="P"/><!-- LATIN CAPITAL LETTER P -->
+      <map code="0x51" name="Q"/><!-- LATIN CAPITAL LETTER Q -->
+      <map code="0x52" name="R"/><!-- LATIN CAPITAL LETTER R -->
+      <map code="0x53" name="S"/><!-- LATIN CAPITAL LETTER S -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x55" name="U"/><!-- LATIN CAPITAL LETTER U -->
+      <map code="0x56" name="V"/><!-- LATIN CAPITAL LETTER V -->
+      <map code="0x57" name="W"/><!-- LATIN CAPITAL LETTER W -->
+      <map code="0x58" name="X"/><!-- LATIN CAPITAL LETTER X -->
+      <map code="0x59" name="Y"/><!-- LATIN CAPITAL LETTER Y -->
+      <map code="0x5a" name="Z"/><!-- LATIN CAPITAL LETTER Z -->
+      <map code="0x5b" name="bracketleft"/><!-- LEFT SQUARE BRACKET -->
+      <map code="0x5c" name="backslash"/><!-- REVERSE SOLIDUS -->
+      <map code="0x5d" name="bracketright"/><!-- RIGHT SQUARE BRACKET -->
+      <map code="0x5e" name="asciicircum"/><!-- CIRCUMFLEX ACCENT -->
+      <map code="0x5f" name="underscore"/><!-- LOW LINE -->
+      <map code="0x60" name="grave"/><!-- GRAVE ACCENT -->
+      <map code="0x61" name="a"/><!-- LATIN SMALL LETTER A -->
+      <map code="0x62" name="b"/><!-- LATIN SMALL LETTER B -->
+      <map code="0x63" name="c"/><!-- LATIN SMALL LETTER C -->
+      <map code="0x64" name="d"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="e"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="f"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="g"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="h"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="i"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="j"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="k"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6d" name="m"/><!-- LATIN SMALL LETTER M -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x70" name="p"/><!-- LATIN SMALL LETTER P -->
+      <map code="0x71" name="q"/><!-- LATIN SMALL LETTER Q -->
+      <map code="0x72" name="r"/><!-- LATIN SMALL LETTER R -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+      <map code="0x75" name="u"/><!-- LATIN SMALL LETTER U -->
+      <map code="0x76" name="v"/><!-- LATIN SMALL LETTER V -->
+      <map code="0x77" name="w"/><!-- LATIN SMALL LETTER W -->
+      <map code="0x78" name="x"/><!-- LATIN SMALL LETTER X -->
+      <map code="0x79" name="y"/><!-- LATIN SMALL LETTER Y -->
+      <map code="0x7a" name="z"/><!-- LATIN SMALL LETTER Z -->
+      <map code="0x7b" name="braceleft"/><!-- LEFT CURLY BRACKET -->
+      <map code="0x7c" name="bar"/><!-- VERTICAL LINE -->
+      <map code="0x7d" name="braceright"/><!-- RIGHT CURLY BRACKET -->
+      <map code="0x7e" name="asciitilde"/><!-- TILDE -->
+      <map code="0xa0" name="space"/><!-- NO-BREAK SPACE -->
+      <map code="0xa1" name="exclamdown"/><!-- INVERTED EXCLAMATION MARK -->
+      <map code="0xa2" name="cent"/><!-- CENT SIGN -->
+      <map code="0xa3" name="sterling"/><!-- POUND SIGN -->
+      <map code="0xa4" name="currency"/><!-- CURRENCY SIGN -->
+      <map code="0xa5" name="yen"/><!-- YEN SIGN -->
+      <map code="0xa6" name="brokenbar"/><!-- BROKEN BAR -->
+      <map code="0xa7" name="section"/><!-- SECTION SIGN -->
+      <map code="0xa8" name="dieresis"/><!-- DIAERESIS -->
+      <map code="0xa9" name="copyright"/><!-- COPYRIGHT SIGN -->
+      <map code="0xaa" name="ordfeminine"/><!-- FEMININE ORDINAL INDICATOR -->
+      <map code="0xab" name="guillemotleft"/><!-- LEFT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+      <map code="0xac" name="logicalnot"/><!-- NOT SIGN -->
+      <map code="0xad" name="hyphen"/><!-- SOFT HYPHEN -->
+      <map code="0xae" name="registered"/><!-- REGISTERED SIGN -->
+      <map code="0xaf" name="macron"/><!-- MACRON -->
+      <map code="0xb0" name="degree"/><!-- DEGREE SIGN -->
+      <map code="0xb1" name="plusminus"/><!-- PLUS-MINUS SIGN -->
+      <map code="0xb2" name="two.sups"/><!-- SUPERSCRIPT TWO -->
+      <map code="0xb3" name="three.sups"/><!-- SUPERSCRIPT THREE -->
+      <map code="0xb4" name="acute"/><!-- ACUTE ACCENT -->
+      <map code="0xb5" name="mu"/><!-- MICRO SIGN -->
+      <map code="0xb6" name="paragraph"/><!-- PILCROW SIGN -->
+      <map code="0xb7" name="periodcentered"/><!-- MIDDLE DOT -->
+      <map code="0xb8" name="cedilla"/><!-- CEDILLA -->
+      <map code="0xb9" name="one.sups"/><!-- SUPERSCRIPT ONE -->
+      <map code="0xba" name="ordmasculine"/><!-- MASCULINE ORDINAL INDICATOR -->
+      <map code="0xbb" name="guillemotright"/><!-- RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+      <map code="0xbc" name="onequarter"/><!-- VULGAR FRACTION ONE QUARTER -->
+      <map code="0xbd" name="onehalf"/><!-- VULGAR FRACTION ONE HALF -->
+      <map code="0xbe" name="threequarters"/><!-- VULGAR FRACTION THREE QUARTERS -->
+      <map code="0xbf" name="questiondown"/><!-- INVERTED QUESTION MARK -->
+      <map code="0xc0" name="Agrave"/><!-- LATIN CAPITAL LETTER A WITH GRAVE -->
+      <map code="0xc1" name="Aacute"/><!-- LATIN CAPITAL LETTER A WITH ACUTE -->
+      <map code="0xc2" name="Acircumflex"/><!-- LATIN CAPITAL LETTER A WITH CIRCUMFLEX -->
+      <map code="0xc3" name="Atilde"/><!-- LATIN CAPITAL LETTER A WITH TILDE -->
+      <map code="0xc4" name="Adieresis"/><!-- LATIN CAPITAL LETTER A WITH DIAERESIS -->
+      <map code="0xc5" name="Aring"/><!-- LATIN CAPITAL LETTER A WITH RING ABOVE -->
+      <map code="0xc6" name="AE"/><!-- LATIN CAPITAL LETTER AE -->
+      <map code="0xc7" name="Ccedilla"/><!-- LATIN CAPITAL LETTER C WITH CEDILLA -->
+      <map code="0xc8" name="Egrave"/><!-- LATIN CAPITAL LETTER E WITH GRAVE -->
+      <map code="0xc9" name="Eacute"/><!-- LATIN CAPITAL LETTER E WITH ACUTE -->
+      <map code="0xca" name="Ecircumflex"/><!-- LATIN CAPITAL LETTER E WITH CIRCUMFLEX -->
+      <map code="0xcb" name="Edieresis"/><!-- LATIN CAPITAL LETTER E WITH DIAERESIS -->
+      <map code="0xcc" name="Igrave"/><!-- LATIN CAPITAL LETTER I WITH GRAVE -->
+      <map code="0xcd" name="Iacute"/><!-- LATIN CAPITAL LETTER I WITH ACUTE -->
+      <map code="0xce" name="Icircumflex"/><!-- LATIN CAPITAL LETTER I WITH CIRCUMFLEX -->
+      <map code="0xcf" name="Idieresis"/><!-- LATIN CAPITAL LETTER I WITH DIAERESIS -->
+      <map code="0xd0" name="Eth"/><!-- LATIN CAPITAL LETTER ETH -->
+      <map code="0xd1" name="Ntilde"/><!-- LATIN CAPITAL LETTER N WITH TILDE -->
+      <map code="0xd2" name="Ograve"/><!-- LATIN CAPITAL LETTER O WITH GRAVE -->
+      <map code="0xd3" name="Oacute"/><!-- LATIN CAPITAL LETTER O WITH ACUTE -->
+      <map code="0xd4" name="Ocircumflex"/><!-- LATIN CAPITAL LETTER O WITH CIRCUMFLEX -->
+      <map code="0xd5" name="Otilde"/><!-- LATIN CAPITAL LETTER O WITH TILDE -->
+      <map code="0xd6" name="Odieresis"/><!-- LATIN CAPITAL LETTER O WITH DIAERESIS -->
+      <map code="0xd7" name="multiply"/><!-- MULTIPLICATION SIGN -->
+      <map code="0xd8" name="Oslash"/><!-- LATIN CAPITAL LETTER O WITH STROKE -->
+      <map code="0xd9" name="Ugrave"/><!-- LATIN CAPITAL LETTER U WITH GRAVE -->
+      <map code="0xda" name="Uacute"/><!-- LATIN CAPITAL LETTER U WITH ACUTE -->
+      <map code="0xdb" name="Ucircumflex"/><!-- LATIN CAPITAL LETTER U WITH CIRCUMFLEX -->
+      <map code="0xdc" name="Udieresis"/><!-- LATIN CAPITAL LETTER U WITH DIAERESIS -->
+      <map code="0xdd" name="Yacute"/><!-- LATIN CAPITAL LETTER Y WITH ACUTE -->
+      <map code="0xde" name="Thorn"/><!-- LATIN CAPITAL LETTER THORN -->
+      <map code="0xdf" name="germandbls"/><!-- LATIN SMALL LETTER SHARP S -->
+      <map code="0xe0" name="agrave"/><!-- LATIN SMALL LETTER A WITH GRAVE -->
+      <map code="0xe1" name="aacute"/><!-- LATIN SMALL LETTER A WITH ACUTE -->
+      <map code="0xe2" name="acircumflex"/><!-- LATIN SMALL LETTER A WITH CIRCUMFLEX -->
+      <map code="0xe3" name="atilde"/><!-- LATIN SMALL LETTER A WITH TILDE -->
+      <map code="0xe4" name="adieresis"/><!-- LATIN SMALL LETTER A WITH DIAERESIS -->
+      <map code="0xe5" name="aring"/><!-- LATIN SMALL LETTER A WITH RING ABOVE -->
+      <map code="0xe6" name="ae"/><!-- LATIN SMALL LETTER AE -->
+      <map code="0xe7" name="ccedilla"/><!-- LATIN SMALL LETTER C WITH CEDILLA -->
+      <map code="0xe8" name="egrave"/><!-- LATIN SMALL LETTER E WITH GRAVE -->
+      <map code="0xe9" name="eacute"/><!-- LATIN SMALL LETTER E WITH ACUTE -->
+      <map code="0xea" name="ecircumflex"/><!-- LATIN SMALL LETTER E WITH CIRCUMFLEX -->
+      <map code="0xeb" name="edieresis"/><!-- LATIN SMALL LETTER E WITH DIAERESIS -->
+      <map code="0xec" name="igrave"/><!-- LATIN SMALL LETTER I WITH GRAVE -->
+      <map code="0xed" name="iacute"/><!-- LATIN SMALL LETTER I WITH ACUTE -->
+      <map code="0xee" name="icircumflex"/><!-- LATIN SMALL LETTER I WITH CIRCUMFLEX -->
+      <map code="0xef" name="idieresis"/><!-- LATIN SMALL LETTER I WITH DIAERESIS -->
+      <map code="0xf0" name="eth"/><!-- LATIN SMALL LETTER ETH -->
+      <map code="0xf1" name="ntilde"/><!-- LATIN SMALL LETTER N WITH TILDE -->
+      <map code="0xf2" name="ograve"/><!-- LATIN SMALL LETTER O WITH GRAVE -->
+      <map code="0xf3" name="oacute"/><!-- LATIN SMALL LETTER O WITH ACUTE -->
+      <map code="0xf4" name="ocircumflex"/><!-- LATIN SMALL LETTER O WITH CIRCUMFLEX -->
+      <map code="0xf5" name="otilde"/><!-- LATIN SMALL LETTER O WITH TILDE -->
+      <map code="0xf6" name="odieresis"/><!-- LATIN SMALL LETTER O WITH DIAERESIS -->
+      <map code="0xf7" name="divide"/><!-- DIVISION SIGN -->
+      <map code="0xf8" name="oslash"/><!-- LATIN SMALL LETTER O WITH STROKE -->
+      <map code="0xf9" name="ugrave"/><!-- LATIN SMALL LETTER U WITH GRAVE -->
+      <map code="0xfa" name="uacute"/><!-- LATIN SMALL LETTER U WITH ACUTE -->
+      <map code="0xfb" name="ucircumflex"/><!-- LATIN SMALL LETTER U WITH CIRCUMFLEX -->
+      <map code="0xfc" name="udieresis"/><!-- LATIN SMALL LETTER U WITH DIAERESIS -->
+      <map code="0xfd" name="yacute"/><!-- LATIN SMALL LETTER Y WITH ACUTE -->
+      <map code="0xfe" name="thorn"/><!-- LATIN SMALL LETTER THORN -->
+      <map code="0xff" name="ydieresis"/><!-- LATIN SMALL LETTER Y WITH DIAERESIS -->
+    </cmap_format_12>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x21" name="exclam"/><!-- EXCLAMATION MARK -->
+      <map code="0x22" name="quotedbl"/><!-- QUOTATION MARK -->
+      <map code="0x23" name="numbersign"/><!-- NUMBER SIGN -->
+      <map code="0x24" name="dollar"/><!-- DOLLAR SIGN -->
+      <map code="0x25" name="percent"/><!-- PERCENT SIGN -->
+      <map code="0x26" name="ampersand"/><!-- AMPERSAND -->
+      <map code="0x27" name="quotesingle"/><!-- APOSTROPHE -->
+      <map code="0x28" name="parenleft"/><!-- LEFT PARENTHESIS -->
+      <map code="0x29" name="parenright"/><!-- RIGHT PARENTHESIS -->
+      <map code="0x2a" name="asterisk"/><!-- ASTERISK -->
+      <map code="0x2b" name="plus"/><!-- PLUS SIGN -->
+      <map code="0x2c" name="comma"/><!-- COMMA -->
+      <map code="0x2d" name="hyphen"/><!-- HYPHEN-MINUS -->
+      <map code="0x2e" name="period"/><!-- FULL STOP -->
+      <map code="0x2f" name="slash"/><!-- SOLIDUS -->
+      <map code="0x30" name="zero"/><!-- DIGIT ZERO -->
+      <map code="0x31" name="one"/><!-- DIGIT ONE -->
+      <map code="0x32" name="two"/><!-- DIGIT TWO -->
+      <map code="0x33" name="three"/><!-- DIGIT THREE -->
+      <map code="0x34" name="four"/><!-- DIGIT FOUR -->
+      <map code="0x35" name="five"/><!-- DIGIT FIVE -->
+      <map code="0x36" name="six"/><!-- DIGIT SIX -->
+      <map code="0x37" name="seven"/><!-- DIGIT SEVEN -->
+      <map code="0x38" name="eight"/><!-- DIGIT EIGHT -->
+      <map code="0x39" name="nine"/><!-- DIGIT NINE -->
+      <map code="0x3a" name="colon"/><!-- COLON -->
+      <map code="0x3b" name="semicolon"/><!-- SEMICOLON -->
+      <map code="0x3c" name="less"/><!-- LESS-THAN SIGN -->
+      <map code="0x3d" name="equal"/><!-- EQUALS SIGN -->
+      <map code="0x3e" name="greater"/><!-- GREATER-THAN SIGN -->
+      <map code="0x3f" name="question"/><!-- QUESTION MARK -->
+      <map code="0x40" name="at"/><!-- COMMERCIAL AT -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x44" name="D"/><!-- LATIN CAPITAL LETTER D -->
+      <map code="0x45" name="E"/><!-- LATIN CAPITAL LETTER E -->
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x47" name="G"/><!-- LATIN CAPITAL LETTER G -->
+      <map code="0x48" name="H"/><!-- LATIN CAPITAL LETTER H -->
+      <map code="0x49" name="I"/><!-- LATIN CAPITAL LETTER I -->
+      <map code="0x4a" name="J"/><!-- LATIN CAPITAL LETTER J -->
+      <map code="0x4b" name="K"/><!-- LATIN CAPITAL LETTER K -->
+      <map code="0x4c" name="L"/><!-- LATIN CAPITAL LETTER L -->
+      <map code="0x4d" name="M"/><!-- LATIN CAPITAL LETTER M -->
+      <map code="0x4e" name="N"/><!-- LATIN CAPITAL LETTER N -->
+      <map code="0x4f" name="O"/><!-- LATIN CAPITAL LETTER O -->
+      <map code="0x50" name="P"/><!-- LATIN CAPITAL LETTER P -->
+      <map code="0x51" name="Q"/><!-- LATIN CAPITAL LETTER Q -->
+      <map code="0x52" name="R"/><!-- LATIN CAPITAL LETTER R -->
+      <map code="0x53" name="S"/><!-- LATIN CAPITAL LETTER S -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x55" name="U"/><!-- LATIN CAPITAL LETTER U -->
+      <map code="0x56" name="V"/><!-- LATIN CAPITAL LETTER V -->
+      <map code="0x57" name="W"/><!-- LATIN CAPITAL LETTER W -->
+      <map code="0x58" name="X"/><!-- LATIN CAPITAL LETTER X -->
+      <map code="0x59" name="Y"/><!-- LATIN CAPITAL LETTER Y -->
+      <map code="0x5a" name="Z"/><!-- LATIN CAPITAL LETTER Z -->
+      <map code="0x5b" name="bracketleft"/><!-- LEFT SQUARE BRACKET -->
+      <map code="0x5c" name="backslash"/><!-- REVERSE SOLIDUS -->
+      <map code="0x5d" name="bracketright"/><!-- RIGHT SQUARE BRACKET -->
+      <map code="0x5e" name="asciicircum"/><!-- CIRCUMFLEX ACCENT -->
+      <map code="0x5f" name="underscore"/><!-- LOW LINE -->
+      <map code="0x60" name="grave"/><!-- GRAVE ACCENT -->
+      <map code="0x61" name="a"/><!-- LATIN SMALL LETTER A -->
+      <map code="0x62" name="b"/><!-- LATIN SMALL LETTER B -->
+      <map code="0x63" name="c"/><!-- LATIN SMALL LETTER C -->
+      <map code="0x64" name="d"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="e"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="f"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="g"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="h"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="i"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="j"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="k"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6d" name="m"/><!-- LATIN SMALL LETTER M -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x70" name="p"/><!-- LATIN SMALL LETTER P -->
+      <map code="0x71" name="q"/><!-- LATIN SMALL LETTER Q -->
+      <map code="0x72" name="r"/><!-- LATIN SMALL LETTER R -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+      <map code="0x75" name="u"/><!-- LATIN SMALL LETTER U -->
+      <map code="0x76" name="v"/><!-- LATIN SMALL LETTER V -->
+      <map code="0x77" name="w"/><!-- LATIN SMALL LETTER W -->
+      <map code="0x78" name="x"/><!-- LATIN SMALL LETTER X -->
+      <map code="0x79" name="y"/><!-- LATIN SMALL LETTER Y -->
+      <map code="0x7a" name="z"/><!-- LATIN SMALL LETTER Z -->
+      <map code="0x7b" name="braceleft"/><!-- LEFT CURLY BRACKET -->
+      <map code="0x7c" name="bar"/><!-- VERTICAL LINE -->
+      <map code="0x7d" name="braceright"/><!-- RIGHT CURLY BRACKET -->
+      <map code="0x7e" name="asciitilde"/><!-- TILDE -->
+      <map code="0xa0" name="space"/><!-- NO-BREAK SPACE -->
+      <map code="0xa1" name="exclamdown"/><!-- INVERTED EXCLAMATION MARK -->
+      <map code="0xa2" name="cent"/><!-- CENT SIGN -->
+      <map code="0xa3" name="sterling"/><!-- POUND SIGN -->
+      <map code="0xa4" name="currency"/><!-- CURRENCY SIGN -->
+      <map code="0xa5" name="yen"/><!-- YEN SIGN -->
+      <map code="0xa6" name="brokenbar"/><!-- BROKEN BAR -->
+      <map code="0xa7" name="section"/><!-- SECTION SIGN -->
+      <map code="0xa8" name="dieresis"/><!-- DIAERESIS -->
+      <map code="0xa9" name="copyright"/><!-- COPYRIGHT SIGN -->
+      <map code="0xaa" name="ordfeminine"/><!-- FEMININE ORDINAL INDICATOR -->
+      <map code="0xab" name="guillemotleft"/><!-- LEFT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+      <map code="0xac" name="logicalnot"/><!-- NOT SIGN -->
+      <map code="0xad" name="hyphen"/><!-- SOFT HYPHEN -->
+      <map code="0xae" name="registered"/><!-- REGISTERED SIGN -->
+      <map code="0xaf" name="macron"/><!-- MACRON -->
+      <map code="0xb0" name="degree"/><!-- DEGREE SIGN -->
+      <map code="0xb1" name="plusminus"/><!-- PLUS-MINUS SIGN -->
+      <map code="0xb2" name="two.sups"/><!-- SUPERSCRIPT TWO -->
+      <map code="0xb3" name="three.sups"/><!-- SUPERSCRIPT THREE -->
+      <map code="0xb4" name="acute"/><!-- ACUTE ACCENT -->
+      <map code="0xb5" name="mu"/><!-- MICRO SIGN -->
+      <map code="0xb6" name="paragraph"/><!-- PILCROW SIGN -->
+      <map code="0xb7" name="periodcentered"/><!-- MIDDLE DOT -->
+      <map code="0xb8" name="cedilla"/><!-- CEDILLA -->
+      <map code="0xb9" name="one.sups"/><!-- SUPERSCRIPT ONE -->
+      <map code="0xba" name="ordmasculine"/><!-- MASCULINE ORDINAL INDICATOR -->
+      <map code="0xbb" name="guillemotright"/><!-- RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+      <map code="0xbc" name="onequarter"/><!-- VULGAR FRACTION ONE QUARTER -->
+      <map code="0xbd" name="onehalf"/><!-- VULGAR FRACTION ONE HALF -->
+      <map code="0xbe" name="threequarters"/><!-- VULGAR FRACTION THREE QUARTERS -->
+      <map code="0xbf" name="questiondown"/><!-- INVERTED QUESTION MARK -->
+      <map code="0xc0" name="Agrave"/><!-- LATIN CAPITAL LETTER A WITH GRAVE -->
+      <map code="0xc1" name="Aacute"/><!-- LATIN CAPITAL LETTER A WITH ACUTE -->
+      <map code="0xc2" name="Acircumflex"/><!-- LATIN CAPITAL LETTER A WITH CIRCUMFLEX -->
+      <map code="0xc3" name="Atilde"/><!-- LATIN CAPITAL LETTER A WITH TILDE -->
+      <map code="0xc4" name="Adieresis"/><!-- LATIN CAPITAL LETTER A WITH DIAERESIS -->
+      <map code="0xc5" name="Aring"/><!-- LATIN CAPITAL LETTER A WITH RING ABOVE -->
+      <map code="0xc6" name="AE"/><!-- LATIN CAPITAL LETTER AE -->
+      <map code="0xc7" name="Ccedilla"/><!-- LATIN CAPITAL LETTER C WITH CEDILLA -->
+      <map code="0xc8" name="Egrave"/><!-- LATIN CAPITAL LETTER E WITH GRAVE -->
+      <map code="0xc9" name="Eacute"/><!-- LATIN CAPITAL LETTER E WITH ACUTE -->
+      <map code="0xca" name="Ecircumflex"/><!-- LATIN CAPITAL LETTER E WITH CIRCUMFLEX -->
+      <map code="0xcb" name="Edieresis"/><!-- LATIN CAPITAL LETTER E WITH DIAERESIS -->
+      <map code="0xcc" name="Igrave"/><!-- LATIN CAPITAL LETTER I WITH GRAVE -->
+      <map code="0xcd" name="Iacute"/><!-- LATIN CAPITAL LETTER I WITH ACUTE -->
+      <map code="0xce" name="Icircumflex"/><!-- LATIN CAPITAL LETTER I WITH CIRCUMFLEX -->
+      <map code="0xcf" name="Idieresis"/><!-- LATIN CAPITAL LETTER I WITH DIAERESIS -->
+      <map code="0xd0" name="Eth"/><!-- LATIN CAPITAL LETTER ETH -->
+      <map code="0xd1" name="Ntilde"/><!-- LATIN CAPITAL LETTER N WITH TILDE -->
+      <map code="0xd2" name="Ograve"/><!-- LATIN CAPITAL LETTER O WITH GRAVE -->
+      <map code="0xd3" name="Oacute"/><!-- LATIN CAPITAL LETTER O WITH ACUTE -->
+      <map code="0xd4" name="Ocircumflex"/><!-- LATIN CAPITAL LETTER O WITH CIRCUMFLEX -->
+      <map code="0xd5" name="Otilde"/><!-- LATIN CAPITAL LETTER O WITH TILDE -->
+      <map code="0xd6" name="Odieresis"/><!-- LATIN CAPITAL LETTER O WITH DIAERESIS -->
+      <map code="0xd7" name="multiply"/><!-- MULTIPLICATION SIGN -->
+      <map code="0xd8" name="Oslash"/><!-- LATIN CAPITAL LETTER O WITH STROKE -->
+      <map code="0xd9" name="Ugrave"/><!-- LATIN CAPITAL LETTER U WITH GRAVE -->
+      <map code="0xda" name="Uacute"/><!-- LATIN CAPITAL LETTER U WITH ACUTE -->
+      <map code="0xdb" name="Ucircumflex"/><!-- LATIN CAPITAL LETTER U WITH CIRCUMFLEX -->
+      <map code="0xdc" name="Udieresis"/><!-- LATIN CAPITAL LETTER U WITH DIAERESIS -->
+      <map code="0xdd" name="Yacute"/><!-- LATIN CAPITAL LETTER Y WITH ACUTE -->
+      <map code="0xde" name="Thorn"/><!-- LATIN CAPITAL LETTER THORN -->
+      <map code="0xdf" name="germandbls"/><!-- LATIN SMALL LETTER SHARP S -->
+      <map code="0xe0" name="agrave"/><!-- LATIN SMALL LETTER A WITH GRAVE -->
+      <map code="0xe1" name="aacute"/><!-- LATIN SMALL LETTER A WITH ACUTE -->
+      <map code="0xe2" name="acircumflex"/><!-- LATIN SMALL LETTER A WITH CIRCUMFLEX -->
+      <map code="0xe3" name="atilde"/><!-- LATIN SMALL LETTER A WITH TILDE -->
+      <map code="0xe4" name="adieresis"/><!-- LATIN SMALL LETTER A WITH DIAERESIS -->
+      <map code="0xe5" name="aring"/><!-- LATIN SMALL LETTER A WITH RING ABOVE -->
+      <map code="0xe6" name="ae"/><!-- LATIN SMALL LETTER AE -->
+      <map code="0xe7" name="ccedilla"/><!-- LATIN SMALL LETTER C WITH CEDILLA -->
+      <map code="0xe8" name="egrave"/><!-- LATIN SMALL LETTER E WITH GRAVE -->
+      <map code="0xe9" name="eacute"/><!-- LATIN SMALL LETTER E WITH ACUTE -->
+      <map code="0xea" name="ecircumflex"/><!-- LATIN SMALL LETTER E WITH CIRCUMFLEX -->
+      <map code="0xeb" name="edieresis"/><!-- LATIN SMALL LETTER E WITH DIAERESIS -->
+      <map code="0xec" name="igrave"/><!-- LATIN SMALL LETTER I WITH GRAVE -->
+      <map code="0xed" name="iacute"/><!-- LATIN SMALL LETTER I WITH ACUTE -->
+      <map code="0xee" name="icircumflex"/><!-- LATIN SMALL LETTER I WITH CIRCUMFLEX -->
+      <map code="0xef" name="idieresis"/><!-- LATIN SMALL LETTER I WITH DIAERESIS -->
+      <map code="0xf0" name="eth"/><!-- LATIN SMALL LETTER ETH -->
+      <map code="0xf1" name="ntilde"/><!-- LATIN SMALL LETTER N WITH TILDE -->
+      <map code="0xf2" name="ograve"/><!-- LATIN SMALL LETTER O WITH GRAVE -->
+      <map code="0xf3" name="oacute"/><!-- LATIN SMALL LETTER O WITH ACUTE -->
+      <map code="0xf4" name="ocircumflex"/><!-- LATIN SMALL LETTER O WITH CIRCUMFLEX -->
+      <map code="0xf5" name="otilde"/><!-- LATIN SMALL LETTER O WITH TILDE -->
+      <map code="0xf6" name="odieresis"/><!-- LATIN SMALL LETTER O WITH DIAERESIS -->
+      <map code="0xf7" name="divide"/><!-- DIVISION SIGN -->
+      <map code="0xf8" name="oslash"/><!-- LATIN SMALL LETTER O WITH STROKE -->
+      <map code="0xf9" name="ugrave"/><!-- LATIN SMALL LETTER U WITH GRAVE -->
+      <map code="0xfa" name="uacute"/><!-- LATIN SMALL LETTER U WITH ACUTE -->
+      <map code="0xfb" name="ucircumflex"/><!-- LATIN SMALL LETTER U WITH CIRCUMFLEX -->
+      <map code="0xfc" name="udieresis"/><!-- LATIN SMALL LETTER U WITH DIAERESIS -->
+      <map code="0xfd" name="yacute"/><!-- LATIN SMALL LETTER Y WITH ACUTE -->
+      <map code="0xfe" name="thorn"/><!-- LATIN SMALL LETTER THORN -->
+      <map code="0xff" name="ydieresis"/><!-- LATIN SMALL LETTER Y WITH DIAERESIS -->
+    </cmap_format_4>
+    <cmap_format_12 platformID="3" platEncID="10" format="12" reserved="0" length="952" language="0" nGroups="78">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x21" name="exclam"/><!-- EXCLAMATION MARK -->
+      <map code="0x22" name="quotedbl"/><!-- QUOTATION MARK -->
+      <map code="0x23" name="numbersign"/><!-- NUMBER SIGN -->
+      <map code="0x24" name="dollar"/><!-- DOLLAR SIGN -->
+      <map code="0x25" name="percent"/><!-- PERCENT SIGN -->
+      <map code="0x26" name="ampersand"/><!-- AMPERSAND -->
+      <map code="0x27" name="quotesingle"/><!-- APOSTROPHE -->
+      <map code="0x28" name="parenleft"/><!-- LEFT PARENTHESIS -->
+      <map code="0x29" name="parenright"/><!-- RIGHT PARENTHESIS -->
+      <map code="0x2a" name="asterisk"/><!-- ASTERISK -->
+      <map code="0x2b" name="plus"/><!-- PLUS SIGN -->
+      <map code="0x2c" name="comma"/><!-- COMMA -->
+      <map code="0x2d" name="hyphen"/><!-- HYPHEN-MINUS -->
+      <map code="0x2e" name="period"/><!-- FULL STOP -->
+      <map code="0x2f" name="slash"/><!-- SOLIDUS -->
+      <map code="0x30" name="zero"/><!-- DIGIT ZERO -->
+      <map code="0x31" name="one"/><!-- DIGIT ONE -->
+      <map code="0x32" name="two"/><!-- DIGIT TWO -->
+      <map code="0x33" name="three"/><!-- DIGIT THREE -->
+      <map code="0x34" name="four"/><!-- DIGIT FOUR -->
+      <map code="0x35" name="five"/><!-- DIGIT FIVE -->
+      <map code="0x36" name="six"/><!-- DIGIT SIX -->
+      <map code="0x37" name="seven"/><!-- DIGIT SEVEN -->
+      <map code="0x38" name="eight"/><!-- DIGIT EIGHT -->
+      <map code="0x39" name="nine"/><!-- DIGIT NINE -->
+      <map code="0x3a" name="colon"/><!-- COLON -->
+      <map code="0x3b" name="semicolon"/><!-- SEMICOLON -->
+      <map code="0x3c" name="less"/><!-- LESS-THAN SIGN -->
+      <map code="0x3d" name="equal"/><!-- EQUALS SIGN -->
+      <map code="0x3e" name="greater"/><!-- GREATER-THAN SIGN -->
+      <map code="0x3f" name="question"/><!-- QUESTION MARK -->
+      <map code="0x40" name="at"/><!-- COMMERCIAL AT -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x44" name="D"/><!-- LATIN CAPITAL LETTER D -->
+      <map code="0x45" name="E"/><!-- LATIN CAPITAL LETTER E -->
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x47" name="G"/><!-- LATIN CAPITAL LETTER G -->
+      <map code="0x48" name="H"/><!-- LATIN CAPITAL LETTER H -->
+      <map code="0x49" name="I"/><!-- LATIN CAPITAL LETTER I -->
+      <map code="0x4a" name="J"/><!-- LATIN CAPITAL LETTER J -->
+      <map code="0x4b" name="K"/><!-- LATIN CAPITAL LETTER K -->
+      <map code="0x4c" name="L"/><!-- LATIN CAPITAL LETTER L -->
+      <map code="0x4d" name="M"/><!-- LATIN CAPITAL LETTER M -->
+      <map code="0x4e" name="N"/><!-- LATIN CAPITAL LETTER N -->
+      <map code="0x4f" name="O"/><!-- LATIN CAPITAL LETTER O -->
+      <map code="0x50" name="P"/><!-- LATIN CAPITAL LETTER P -->
+      <map code="0x51" name="Q"/><!-- LATIN CAPITAL LETTER Q -->
+      <map code="0x52" name="R"/><!-- LATIN CAPITAL LETTER R -->
+      <map code="0x53" name="S"/><!-- LATIN CAPITAL LETTER S -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x55" name="U"/><!-- LATIN CAPITAL LETTER U -->
+      <map code="0x56" name="V"/><!-- LATIN CAPITAL LETTER V -->
+      <map code="0x57" name="W"/><!-- LATIN CAPITAL LETTER W -->
+      <map code="0x58" name="X"/><!-- LATIN CAPITAL LETTER X -->
+      <map code="0x59" name="Y"/><!-- LATIN CAPITAL LETTER Y -->
+      <map code="0x5a" name="Z"/><!-- LATIN CAPITAL LETTER Z -->
+      <map code="0x5b" name="bracketleft"/><!-- LEFT SQUARE BRACKET -->
+      <map code="0x5c" name="backslash"/><!-- REVERSE SOLIDUS -->
+      <map code="0x5d" name="bracketright"/><!-- RIGHT SQUARE BRACKET -->
+      <map code="0x5e" name="asciicircum"/><!-- CIRCUMFLEX ACCENT -->
+      <map code="0x5f" name="underscore"/><!-- LOW LINE -->
+      <map code="0x60" name="grave"/><!-- GRAVE ACCENT -->
+      <map code="0x61" name="a"/><!-- LATIN SMALL LETTER A -->
+      <map code="0x62" name="b"/><!-- LATIN SMALL LETTER B -->
+      <map code="0x63" name="c"/><!-- LATIN SMALL LETTER C -->
+      <map code="0x64" name="d"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="e"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="f"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="g"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="h"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="i"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="j"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="k"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6d" name="m"/><!-- LATIN SMALL LETTER M -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x70" name="p"/><!-- LATIN SMALL LETTER P -->
+      <map code="0x71" name="q"/><!-- LATIN SMALL LETTER Q -->
+      <map code="0x72" name="r"/><!-- LATIN SMALL LETTER R -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+      <map code="0x75" name="u"/><!-- LATIN SMALL LETTER U -->
+      <map code="0x76" name="v"/><!-- LATIN SMALL LETTER V -->
+      <map code="0x77" name="w"/><!-- LATIN SMALL LETTER W -->
+      <map code="0x78" name="x"/><!-- LATIN SMALL LETTER X -->
+      <map code="0x79" name="y"/><!-- LATIN SMALL LETTER Y -->
+      <map code="0x7a" name="z"/><!-- LATIN SMALL LETTER Z -->
+      <map code="0x7b" name="braceleft"/><!-- LEFT CURLY BRACKET -->
+      <map code="0x7c" name="bar"/><!-- VERTICAL LINE -->
+      <map code="0x7d" name="braceright"/><!-- RIGHT CURLY BRACKET -->
+      <map code="0x7e" name="asciitilde"/><!-- TILDE -->
+      <map code="0xa0" name="space"/><!-- NO-BREAK SPACE -->
+      <map code="0xa1" name="exclamdown"/><!-- INVERTED EXCLAMATION MARK -->
+      <map code="0xa2" name="cent"/><!-- CENT SIGN -->
+      <map code="0xa3" name="sterling"/><!-- POUND SIGN -->
+      <map code="0xa4" name="currency"/><!-- CURRENCY SIGN -->
+      <map code="0xa5" name="yen"/><!-- YEN SIGN -->
+      <map code="0xa6" name="brokenbar"/><!-- BROKEN BAR -->
+      <map code="0xa7" name="section"/><!-- SECTION SIGN -->
+      <map code="0xa8" name="dieresis"/><!-- DIAERESIS -->
+      <map code="0xa9" name="copyright"/><!-- COPYRIGHT SIGN -->
+      <map code="0xaa" name="ordfeminine"/><!-- FEMININE ORDINAL INDICATOR -->
+      <map code="0xab" name="guillemotleft"/><!-- LEFT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+      <map code="0xac" name="logicalnot"/><!-- NOT SIGN -->
+      <map code="0xad" name="hyphen"/><!-- SOFT HYPHEN -->
+      <map code="0xae" name="registered"/><!-- REGISTERED SIGN -->
+      <map code="0xaf" name="macron"/><!-- MACRON -->
+      <map code="0xb0" name="degree"/><!-- DEGREE SIGN -->
+      <map code="0xb1" name="plusminus"/><!-- PLUS-MINUS SIGN -->
+      <map code="0xb2" name="two.sups"/><!-- SUPERSCRIPT TWO -->
+      <map code="0xb3" name="three.sups"/><!-- SUPERSCRIPT THREE -->
+      <map code="0xb4" name="acute"/><!-- ACUTE ACCENT -->
+      <map code="0xb5" name="mu"/><!-- MICRO SIGN -->
+      <map code="0xb6" name="paragraph"/><!-- PILCROW SIGN -->
+      <map code="0xb7" name="periodcentered"/><!-- MIDDLE DOT -->
+      <map code="0xb8" name="cedilla"/><!-- CEDILLA -->
+      <map code="0xb9" name="one.sups"/><!-- SUPERSCRIPT ONE -->
+      <map code="0xba" name="ordmasculine"/><!-- MASCULINE ORDINAL INDICATOR -->
+      <map code="0xbb" name="guillemotright"/><!-- RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+      <map code="0xbc" name="onequarter"/><!-- VULGAR FRACTION ONE QUARTER -->
+      <map code="0xbd" name="onehalf"/><!-- VULGAR FRACTION ONE HALF -->
+      <map code="0xbe" name="threequarters"/><!-- VULGAR FRACTION THREE QUARTERS -->
+      <map code="0xbf" name="questiondown"/><!-- INVERTED QUESTION MARK -->
+      <map code="0xc0" name="Agrave"/><!-- LATIN CAPITAL LETTER A WITH GRAVE -->
+      <map code="0xc1" name="Aacute"/><!-- LATIN CAPITAL LETTER A WITH ACUTE -->
+      <map code="0xc2" name="Acircumflex"/><!-- LATIN CAPITAL LETTER A WITH CIRCUMFLEX -->
+      <map code="0xc3" name="Atilde"/><!-- LATIN CAPITAL LETTER A WITH TILDE -->
+      <map code="0xc4" name="Adieresis"/><!-- LATIN CAPITAL LETTER A WITH DIAERESIS -->
+      <map code="0xc5" name="Aring"/><!-- LATIN CAPITAL LETTER A WITH RING ABOVE -->
+      <map code="0xc6" name="AE"/><!-- LATIN CAPITAL LETTER AE -->
+      <map code="0xc7" name="Ccedilla"/><!-- LATIN CAPITAL LETTER C WITH CEDILLA -->
+      <map code="0xc8" name="Egrave"/><!-- LATIN CAPITAL LETTER E WITH GRAVE -->
+      <map code="0xc9" name="Eacute"/><!-- LATIN CAPITAL LETTER E WITH ACUTE -->
+      <map code="0xca" name="Ecircumflex"/><!-- LATIN CAPITAL LETTER E WITH CIRCUMFLEX -->
+      <map code="0xcb" name="Edieresis"/><!-- LATIN CAPITAL LETTER E WITH DIAERESIS -->
+      <map code="0xcc" name="Igrave"/><!-- LATIN CAPITAL LETTER I WITH GRAVE -->
+      <map code="0xcd" name="Iacute"/><!-- LATIN CAPITAL LETTER I WITH ACUTE -->
+      <map code="0xce" name="Icircumflex"/><!-- LATIN CAPITAL LETTER I WITH CIRCUMFLEX -->
+      <map code="0xcf" name="Idieresis"/><!-- LATIN CAPITAL LETTER I WITH DIAERESIS -->
+      <map code="0xd0" name="Eth"/><!-- LATIN CAPITAL LETTER ETH -->
+      <map code="0xd1" name="Ntilde"/><!-- LATIN CAPITAL LETTER N WITH TILDE -->
+      <map code="0xd2" name="Ograve"/><!-- LATIN CAPITAL LETTER O WITH GRAVE -->
+      <map code="0xd3" name="Oacute"/><!-- LATIN CAPITAL LETTER O WITH ACUTE -->
+      <map code="0xd4" name="Ocircumflex"/><!-- LATIN CAPITAL LETTER O WITH CIRCUMFLEX -->
+      <map code="0xd5" name="Otilde"/><!-- LATIN CAPITAL LETTER O WITH TILDE -->
+      <map code="0xd6" name="Odieresis"/><!-- LATIN CAPITAL LETTER O WITH DIAERESIS -->
+      <map code="0xd7" name="multiply"/><!-- MULTIPLICATION SIGN -->
+      <map code="0xd8" name="Oslash"/><!-- LATIN CAPITAL LETTER O WITH STROKE -->
+      <map code="0xd9" name="Ugrave"/><!-- LATIN CAPITAL LETTER U WITH GRAVE -->
+      <map code="0xda" name="Uacute"/><!-- LATIN CAPITAL LETTER U WITH ACUTE -->
+      <map code="0xdb" name="Ucircumflex"/><!-- LATIN CAPITAL LETTER U WITH CIRCUMFLEX -->
+      <map code="0xdc" name="Udieresis"/><!-- LATIN CAPITAL LETTER U WITH DIAERESIS -->
+      <map code="0xdd" name="Yacute"/><!-- LATIN CAPITAL LETTER Y WITH ACUTE -->
+      <map code="0xde" name="Thorn"/><!-- LATIN CAPITAL LETTER THORN -->
+      <map code="0xdf" name="germandbls"/><!-- LATIN SMALL LETTER SHARP S -->
+      <map code="0xe0" name="agrave"/><!-- LATIN SMALL LETTER A WITH GRAVE -->
+      <map code="0xe1" name="aacute"/><!-- LATIN SMALL LETTER A WITH ACUTE -->
+      <map code="0xe2" name="acircumflex"/><!-- LATIN SMALL LETTER A WITH CIRCUMFLEX -->
+      <map code="0xe3" name="atilde"/><!-- LATIN SMALL LETTER A WITH TILDE -->
+      <map code="0xe4" name="adieresis"/><!-- LATIN SMALL LETTER A WITH DIAERESIS -->
+      <map code="0xe5" name="aring"/><!-- LATIN SMALL LETTER A WITH RING ABOVE -->
+      <map code="0xe6" name="ae"/><!-- LATIN SMALL LETTER AE -->
+      <map code="0xe7" name="ccedilla"/><!-- LATIN SMALL LETTER C WITH CEDILLA -->
+      <map code="0xe8" name="egrave"/><!-- LATIN SMALL LETTER E WITH GRAVE -->
+      <map code="0xe9" name="eacute"/><!-- LATIN SMALL LETTER E WITH ACUTE -->
+      <map code="0xea" name="ecircumflex"/><!-- LATIN SMALL LETTER E WITH CIRCUMFLEX -->
+      <map code="0xeb" name="edieresis"/><!-- LATIN SMALL LETTER E WITH DIAERESIS -->
+      <map code="0xec" name="igrave"/><!-- LATIN SMALL LETTER I WITH GRAVE -->
+      <map code="0xed" name="iacute"/><!-- LATIN SMALL LETTER I WITH ACUTE -->
+      <map code="0xee" name="icircumflex"/><!-- LATIN SMALL LETTER I WITH CIRCUMFLEX -->
+      <map code="0xef" name="idieresis"/><!-- LATIN SMALL LETTER I WITH DIAERESIS -->
+      <map code="0xf0" name="eth"/><!-- LATIN SMALL LETTER ETH -->
+      <map code="0xf1" name="ntilde"/><!-- LATIN SMALL LETTER N WITH TILDE -->
+      <map code="0xf2" name="ograve"/><!-- LATIN SMALL LETTER O WITH GRAVE -->
+      <map code="0xf3" name="oacute"/><!-- LATIN SMALL LETTER O WITH ACUTE -->
+      <map code="0xf4" name="ocircumflex"/><!-- LATIN SMALL LETTER O WITH CIRCUMFLEX -->
+      <map code="0xf5" name="otilde"/><!-- LATIN SMALL LETTER O WITH TILDE -->
+      <map code="0xf6" name="odieresis"/><!-- LATIN SMALL LETTER O WITH DIAERESIS -->
+      <map code="0xf7" name="divide"/><!-- DIVISION SIGN -->
+      <map code="0xf8" name="oslash"/><!-- LATIN SMALL LETTER O WITH STROKE -->
+      <map code="0xf9" name="ugrave"/><!-- LATIN SMALL LETTER U WITH GRAVE -->
+      <map code="0xfa" name="uacute"/><!-- LATIN SMALL LETTER U WITH ACUTE -->
+      <map code="0xfb" name="ucircumflex"/><!-- LATIN SMALL LETTER U WITH CIRCUMFLEX -->
+      <map code="0xfc" name="udieresis"/><!-- LATIN SMALL LETTER U WITH DIAERESIS -->
+      <map code="0xfd" name="yacute"/><!-- LATIN SMALL LETTER Y WITH ACUTE -->
+      <map code="0xfe" name="thorn"/><!-- LATIN SMALL LETTER THORN -->
+      <map code="0xff" name="ydieresis"/><!-- LATIN SMALL LETTER Y WITH DIAERESIS -->
+    </cmap_format_12>
+  </cmap>
+
+  <post>
+    <formatType value="3.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-50"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+  </post>
+
+  <CFF>
+    <major value="1"/>
+    <minor value="0"/>
+    <CFFFont name="SourceSansPro-Regular">
+      <version value="2.20"/>
+      <Notice value="Source is a trademark of Adobe Systems Incorporated in the United States and/or other countries."/>
+      <Copyright value="Copyright 2010â2019 Adobe Systems Incorporated (http://www.adobe.com/), with Reserved Font Name 'Source'."/>
+      <FamilyName value="Source Sans Pro"/>
+      <isFixedPitch value="0"/>
+      <ItalicAngle value="0"/>
+      <UnderlinePosition value="-75"/>
+      <UnderlineThickness value="50"/>
+      <PaintType value="0"/>
+      <CharstringType value="2"/>
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FontBBox value="-167 -250 946 916"/>
+      <StrokeWidth value="0"/>
+      <!-- charset is dumped separately as the 'GlyphOrder' element -->
+      <Encoding name="StandardEncoding"/>
+      <Private>
+        <BlueScale value="0.039625"/>
+        <BlueShift value="7"/>
+        <BlueFuzz value="1"/>
+        <ForceBold value="0"/>
+        <LanguageGroup value="0"/>
+        <ExpansionFactor value="0.06"/>
+        <initialRandomSeed value="0"/>
+        <defaultWidthX value="0"/>
+        <nominalWidthX value="560"/>
+      </Private>
+      <CharStrings>
+        <CharString name=".notdef">
+          94 89 0 rmoveto
+          476 0 rlineto
+          0 660 rlineto
+          -476 0 rlineto
+          109 -601 rmoveto
+          73 131 rlineto
+          54 102 rlineto
+          4 0 rlineto
+          52 -102 rlineto
+          73 -131 rlineto
+          -129 329 rmoveto
+          -50 94 rlineto
+          -66 118 rlineto
+          234 0 rlineto
+          -65 -118 rlineto
+          -49 -94 rlineto
+          -175 -277 rmoveto
+          0 461 rlineto
+          127 -232 rlineto
+          217 -229 rmoveto
+          -125 229 rlineto
+          125 232 rlineto
+          endchar
+        </CharString>
+        <CharString name="A">
+          -16 204 366 rmoveto
+          23 73 21 72 20 76 rrcurveto
+          4 0 rlineto
+          21 -76 21 -72 24 -73 rrcurveto
+          31 -99 rlineto
+          -196 0 rlineto
+          -170 -267 rmoveto
+          85 0 rlineto
+          63 199 rlineto
+          239 0 rlineto
+          62 -199 rlineto
+          89 0 rlineto
+          -221 656 rlineto
+          -96 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="A.sups">
+          -197 138 632 rmoveto
+          14 48 15 47 13 49 rrcurveto
+          2 0 rlineto
+          14 -48 14 -47 15 -49 rrcurveto
+          19 -61 rlineto
+          -125 0 rlineto
+          -120 -177 rmoveto
+          64 0 rlineto
+          40 127 rlineto
+          156 0 rlineto
+          39 -127 rlineto
+          67 0 rlineto
+          -146 432 rlineto
+          -73 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="AE">
+          263 290 376 rmoveto
+          36 70 36 73 35 71 rrcurveto
+          4 0 rlineto
+          0 -332 rlineto
+          -172 0 rlineto
+          -221 -258 rmoveto
+          89 0 rlineto
+          98 191 rlineto
+          206 0 rlineto
+          0 -191 rlineto
+          373 0 rlineto
+          0 71 rlineto
+          -288 0 rlineto
+          0 238 rlineto
+          232 0 rlineto
+          0 71 rlineto
+          -232 0 rlineto
+          0 205 rlineto
+          278 0 rlineto
+          0 71 rlineto
+          -412 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="Aacute">
+          -16 204 366 rmoveto
+          23 73 21 72 20 76 rrcurveto
+          4 0 rlineto
+          21 -76 21 -72 24 -73 rrcurveto
+          31 -99 rlineto
+          -196 0 rlineto
+          -170 -267 rmoveto
+          85 0 rlineto
+          63 199 rlineto
+          239 0 rlineto
+          62 -199 rlineto
+          89 0 rlineto
+          -221 656 rlineto
+          -96 0 rlineto
+          -9 41 rmoveto
+          186 115 rlineto
+          -39 56 rlineto
+          -179 -130 rlineto
+          endchar
+        </CharString>
+        <CharString name="Acircumflex">
+          -16 204 366 rmoveto
+          23 73 21 72 20 76 rrcurveto
+          4 0 rlineto
+          21 -76 21 -72 24 -73 rrcurveto
+          31 -99 rlineto
+          -196 0 rlineto
+          -170 -267 rmoveto
+          85 0 rlineto
+          63 199 rlineto
+          239 0 rlineto
+          62 -199 rlineto
+          89 0 rlineto
+          -221 656 rlineto
+          -96 0 rlineto
+          -65 43 rmoveto
+          110 92 rlineto
+          4 0 rlineto
+          110 -92 rlineto
+          36 26 rlineto
+          -104 113 rlineto
+          -88 0 rlineto
+          -104 -113 rlineto
+          endchar
+        </CharString>
+        <CharString name="Adieresis">
+          -16 204 366 rmoveto
+          23 73 21 72 20 76 rrcurveto
+          4 0 rlineto
+          21 -76 21 -72 24 -73 rrcurveto
+          31 -99 rlineto
+          -196 0 rlineto
+          -170 -267 rmoveto
+          85 0 rlineto
+          63 199 rlineto
+          239 0 rlineto
+          62 -199 rlineto
+          89 0 rlineto
+          -221 656 rlineto
+          -96 0 rlineto
+          -56 59 rmoveto
+          29 0 20 21 0 28 rrcurveto
+          0 29 -20 21 -29 0 rrcurveto
+          -28 0 -21 -21 0 -29 rrcurveto
+          0 -28 21 -21 28 0 rrcurveto
+          206 0 rmoveto
+          28 0 21 21 0 28 rrcurveto
+          0 29 -21 21 -28 0 rrcurveto
+          -29 0 -20 -21 0 -29 rrcurveto
+          0 -28 20 -21 29 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="Agrave">
+          -16 204 366 rmoveto
+          23 73 21 72 20 76 rrcurveto
+          4 0 rlineto
+          21 -76 21 -72 24 -73 rrcurveto
+          31 -99 rlineto
+          -196 0 rlineto
+          -170 -267 rmoveto
+          85 0 rlineto
+          63 199 rlineto
+          239 0 rlineto
+          62 -199 rlineto
+          89 0 rlineto
+          -221 656 rlineto
+          -96 0 rlineto
+          103 41 rmoveto
+          32 41 rlineto
+          -179 130 rlineto
+          -39 -56 rlineto
+          endchar
+        </CharString>
+        <CharString name="Aring">
+          -16 204 366 rmoveto
+          23 73 21 72 20 76 rrcurveto
+          4 0 rlineto
+          21 -76 21 -72 24 -73 rrcurveto
+          31 -99 rlineto
+          -196 0 rlineto
+          -170 -267 rmoveto
+          85 0 rlineto
+          63 199 rlineto
+          239 0 rlineto
+          62 -199 rlineto
+          89 0 rlineto
+          -221 656 rlineto
+          -96 0 rlineto
+          47 79 rmoveto
+          -33 0 -24 19 0 35 rrcurveto
+          0 36 24 19 33 0 rrcurveto
+          33 0 24 -19 0 -36 rrcurveto
+          0 -35 -24 -19 -33 0 rrcurveto
+          0 -36 rmoveto
+          67 0 44 34 0 56 rrcurveto
+          0 56 -44 35 -67 0 rrcurveto
+          -67 0 -44 -35 0 -56 rrcurveto
+          0 -56 44 -34 67 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="Atilde">
+          -16 204 366 rmoveto
+          23 73 21 72 20 76 rrcurveto
+          4 0 rlineto
+          21 -76 21 -72 24 -73 rrcurveto
+          31 -99 rlineto
+          -196 0 rlineto
+          -170 -267 rmoveto
+          85 0 rlineto
+          63 199 rlineto
+          239 0 rlineto
+          62 -199 rlineto
+          89 0 rlineto
+          -221 656 rlineto
+          -96 0 rlineto
+          122 53 rmoveto
+          60 0 39 46 3 77 rrcurveto
+          -56 4 rlineto
+          -5 -43 -18 -23 -25 0 rrcurveto
+          -47 0 -26 71 -75 0 rrcurveto
+          -60 0 -39 -46 -3 -77 rrcurveto
+          56 -4 rlineto
+          4 42 19 23 25 0 rrcurveto
+          47 0 26 -70 75 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="B">
+          28 90 0 rmoveto
+          210 0 rlineto
+          146 0 102 63 0 129 rrcurveto
+          0 90 -55 52 -78 15 rrcurveto
+          0 4 rlineto
+          61 20 35 58 0 65 rrcurveto
+          0 115 -93 45 -133 0 rrcurveto
+          -195 0 rlineto
+          84 -279 rmoveto
+          0 212 rlineto
+          100 0 rlineto
+          102 0 52 -28 0 -76 rrcurveto
+          0 -67 -46 -41 -111 0 rrcurveto
+          -97 -310 rmoveto
+          0 246 rlineto
+          114 0 rlineto
+          114 0 63 -37 0 -81 rrcurveto
+          0 -88 -65 -40 -112 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="B.sups">
+          -168 57 394 rmoveto
+          144 0 rlineto
+          97 0 69 42 0 85 rrcurveto
+          0 59 -36 34 -63 11 rrcurveto
+          0 2 rlineto
+          51 14 24 38 0 42 rrcurveto
+          0 76 -63 29 -89 0 rrcurveto
+          -134 0 rlineto
+          63 -182 rmoveto
+          0 133 rlineto
+          65 0 rlineto
+          64 0 32 -19 0 -44 rrcurveto
+          0 -45 -28 -25 -71 0 rrcurveto
+          -62 -201 rmoveto
+          0 155 rlineto
+          73 0 rlineto
+          73 0 39 -23 0 -50 rrcurveto
+          0 -57 -40 -25 -72 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="C">
+          11 338 -12 rmoveto
+          84 0 64 34 53 61 rrcurveto
+          -46 50 rlineto
+          -42 -46 -47 -25 -63 0 rrcurveto
+          -124 0 -78 103 0 165 rrcurveto
+          0 163 82 101 123 0 rrcurveto
+          56 0 43 -23 35 -36 rrcurveto
+          46 52 rlineto
+          -39 43 -62 38 -80 0 rrcurveto
+          -167 0 -124 -129 0 -211 rrcurveto
+          0 -214 122 -126 164 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="C.sups">
+          -181 225 386 rmoveto
+          57 0 44 23 34 40 rrcurveto
+          -35 38 rlineto
+          -26 -29 -31 -17 -40 0 rrcurveto
+          -80 0 -50 65 0 105 rrcurveto
+          0 103 53 66 80 0 rrcurveto
+          34 0 27 -15 24 -24 rrcurveto
+          35 39 rlineto
+          -26 30 -42 24 -53 0 rrcurveto
+          -112 0 -86 -86 0 -139 rrcurveto
+          0 -141 83 -82 110 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="Ccedilla">
+          11 255 -226 rmoveto
+          106 5 59 28 0 58 rrcurveto
+          0 41 -27 19 -46 11 rrcurveto
+          23 54 rlineto
+          69 7 54 33 46 53 rrcurveto
+          -46 50 rlineto
+          -42 -46 -47 -25 -63 0 rrcurveto
+          -124 0 -78 103 0 165 rrcurveto
+          0 163 82 101 123 0 rrcurveto
+          56 0 43 -23 35 -36 rrcurveto
+          46 52 rlineto
+          -39 43 -62 38 -80 0 rrcurveto
+          -167 0 -124 -129 0 -211 rrcurveto
+          0 -204 111 -124 152 -11 rrcurveto
+          -36 -77 rlineto
+          57 -8 20 -14 0 -26 rrcurveto
+          0 -29 -25 -15 -84 -6 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="D">
+          56 90 0 rmoveto
+          168 0 rlineto
+          198 0 108 122 0 209 rrcurveto
+          0 208 -108 117 -202 0 rrcurveto
+          -164 0 rlineto
+          84 -587 rmoveto
+          0 518 rlineto
+          74 0 rlineto
+          153 0 76 -91 0 -165 rrcurveto
+          0 -166 -76 -96 -153 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="D.sups">
+          -149 57 394 rmoveto
+          115 0 rlineto
+          132 0 74 79 0 140 rrcurveto
+          0 138 -74 75 -135 0 rrcurveto
+          -112 0 rlineto
+          63 -381 rmoveto
+          0 330 rlineto
+          46 0 rlineto
+          97 0 50 -54 0 -109 rrcurveto
+          0 -108 -49 -59 -96 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="E">
+          -33 90 0 rmoveto
+          388 0 rlineto
+          0 71 rlineto
+          -304 0 rlineto
+          0 238 rlineto
+          248 0 rlineto
+          0 71 rlineto
+          -248 0 rlineto
+          0 205 rlineto
+          294 0 rlineto
+          0 71 rlineto
+          -378 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="E.sups">
+          -208 57 394 rmoveto
+          263 0 rlineto
+          0 53 rlineto
+          -200 0 rlineto
+          0 148 rlineto
+          164 0 rlineto
+          0 52 rlineto
+          -164 0 rlineto
+          0 127 rlineto
+          194 0 rlineto
+          0 52 rlineto
+          -257 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="Eacute">
+          -33 90 0 rmoveto
+          388 0 rlineto
+          0 71 rlineto
+          -304 0 rlineto
+          0 238 rlineto
+          248 0 rlineto
+          0 71 rlineto
+          -248 0 rlineto
+          0 205 rlineto
+          294 0 rlineto
+          0 71 rlineto
+          -378 0 rlineto
+          144 41 rmoveto
+          186 115 rlineto
+          -39 56 rlineto
+          -179 -130 rlineto
+          endchar
+        </CharString>
+        <CharString name="Ecircumflex">
+          -33 90 0 rmoveto
+          388 0 rlineto
+          0 71 rlineto
+          -304 0 rlineto
+          0 238 rlineto
+          248 0 rlineto
+          0 71 rlineto
+          -248 0 rlineto
+          0 205 rlineto
+          294 0 rlineto
+          0 71 rlineto
+          -378 0 rlineto
+          88 43 rmoveto
+          110 92 rlineto
+          4 0 rlineto
+          110 -92 rlineto
+          36 26 rlineto
+          -104 113 rlineto
+          -88 0 rlineto
+          -104 -113 rlineto
+          endchar
+        </CharString>
+        <CharString name="Edieresis">
+          -33 90 0 rmoveto
+          388 0 rlineto
+          0 71 rlineto
+          -304 0 rlineto
+          0 238 rlineto
+          248 0 rlineto
+          0 71 rlineto
+          -248 0 rlineto
+          0 205 rlineto
+          294 0 rlineto
+          0 71 rlineto
+          -378 0 rlineto
+          97 59 rmoveto
+          29 0 20 21 0 28 rrcurveto
+          0 29 -20 21 -29 0 rrcurveto
+          -28 0 -21 -21 0 -29 rrcurveto
+          0 -28 21 -21 28 0 rrcurveto
+          206 0 rmoveto
+          28 0 21 21 0 28 rrcurveto
+          0 29 -21 21 -28 0 rrcurveto
+          -29 0 -20 -21 0 -29 rrcurveto
+          0 -28 20 -21 29 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="Egrave">
+          -33 90 0 rmoveto
+          388 0 rlineto
+          0 71 rlineto
+          -304 0 rlineto
+          0 238 rlineto
+          248 0 rlineto
+          0 71 rlineto
+          -248 0 rlineto
+          0 205 rlineto
+          294 0 rlineto
+          0 71 rlineto
+          -378 0 rlineto
+          256 41 rmoveto
+          32 41 rlineto
+          -179 130 rlineto
+          -39 -56 rlineto
+          endchar
+        </CharString>
+        <CharString name="Eth">
+          77 112 0 rmoveto
+          168 0 rlineto
+          198 0 108 122 0 209 rrcurveto
+          0 208 -108 117 -202 0 rrcurveto
+          -164 0 rlineto
+          0 -280 rlineto
+          -79 -3 rlineto
+          0 -60 rlineto
+          79 0 rlineto
+          84 -244 rmoveto
+          0 244 rlineto
+          148 0 rlineto
+          0 63 rlineto
+          -148 0 rlineto
+          0 211 rlineto
+          74 0 rlineto
+          153 0 76 -91 0 -165 rrcurveto
+          0 -166 -76 -96 -153 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="F">
+          -65 90 0 rmoveto
+          84 0 rlineto
+          0 293 rlineto
+          250 0 rlineto
+          0 71 rlineto
+          -250 0 rlineto
+          0 221 rlineto
+          294 0 rlineto
+          0 71 rlineto
+          -378 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="F.sups">
+          -230 57 394 rmoveto
+          63 0 rlineto
+          0 189 rlineto
+          165 0 rlineto
+          0 53 rlineto
+          -165 0 rlineto
+          0 138 rlineto
+          194 0 rlineto
+          0 52 rlineto
+          -257 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="G">
+          57 348 -12 rmoveto
+          88 0 72 32 43 44 rrcurveto
+          0 276 rlineto
+          -216 0 rlineto
+          0 -69 rlineto
+          139 0 rlineto
+          0 -171 rlineto
+          -26 -24 -45 -14 -47 0 rrcurveto
+          -140 0 -77 103 0 165 rrcurveto
+          0 163 84 101 132 0 rrcurveto
+          66 0 42 -25 33 -34 rrcurveto
+          46 52 rlineto
+          -38 41 -60 40 -91 0 rrcurveto
+          -174 0 -127 -129 0 -211 rrcurveto
+          0 -214 123 -126 173 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="G.sups">
+          -148 232 386 rmoveto
+          59 0 49 22 29 28 rrcurveto
+          0 186 rlineto
+          -145 0 rlineto
+          0 -52 rlineto
+          89 0 rlineto
+          0 -106 rlineto
+          -16 -14 -29 -9 -29 0 rrcurveto
+          -91 0 -50 65 0 106 rrcurveto
+          0 103 54 65 85 0 rrcurveto
+          43 0 27 -16 22 -22 rrcurveto
+          34 39 rlineto
+          -27 27 -40 26 -59 0 rrcurveto
+          -118 0 -86 -85 0 -140 rrcurveto
+          0 -141 83 -82 116 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="H">
+          92 90 0 rmoveto
+          84 0 rlineto
+          0 308 rlineto
+          304 0 rlineto
+          0 -308 rlineto
+          84 0 rlineto
+          0 656 rlineto
+          -84 0 rlineto
+          0 -274 rlineto
+          -304 0 rlineto
+          0 274 rlineto
+          -84 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="H.sups">
+          -125 57 394 rmoveto
+          63 0 rlineto
+          0 200 rlineto
+          195 0 rlineto
+          0 -200 rlineto
+          63 0 rlineto
+          0 432 rlineto
+          -63 0 rlineto
+          0 -177 rlineto
+          -195 0 rlineto
+          0 177 rlineto
+          -63 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="I">
+          -297 90 0 rmoveto
+          84 0 rlineto
+          0 656 rlineto
+          -84 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="I.sups">
+          -383 57 394 rmoveto
+          63 0 rlineto
+          0 432 rlineto
+          -63 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="Iacute">
+          -297 90 0 rmoveto
+          84 0 rlineto
+          0 656 rlineto
+          -84 0 rlineto
+          -14 41 rmoveto
+          186 115 rlineto
+          -39 56 rlineto
+          -179 -130 rlineto
+          endchar
+        </CharString>
+        <CharString name="Icircumflex">
+          -297 90 0 rmoveto
+          84 0 rlineto
+          0 656 rlineto
+          -84 0 rlineto
+          -70 43 rmoveto
+          110 92 rlineto
+          4 0 rlineto
+          110 -92 rlineto
+          36 26 rlineto
+          -104 113 rlineto
+          -88 0 rlineto
+          -104 -113 rlineto
+          endchar
+        </CharString>
+        <CharString name="Idieresis">
+          -297 90 0 rmoveto
+          84 0 rlineto
+          0 656 rlineto
+          -84 0 rlineto
+          -61 59 rmoveto
+          29 0 20 21 0 28 rrcurveto
+          0 29 -20 21 -29 0 rrcurveto
+          -28 0 -21 -21 0 -29 rrcurveto
+          0 -28 21 -21 28 0 rrcurveto
+          206 0 rmoveto
+          28 0 21 21 0 28 rrcurveto
+          0 29 -21 21 -28 0 rrcurveto
+          -29 0 -20 -21 0 -29 rrcurveto
+          0 -28 20 -21 29 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="Igrave">
+          -297 90 0 rmoveto
+          84 0 rlineto
+          0 656 rlineto
+          -84 0 rlineto
+          98 41 rmoveto
+          32 41 rlineto
+          -179 130 rlineto
+          -39 -56 rlineto
+          endchar
+        </CharString>
+        <CharString name="J">
+          -80 207 -12 rmoveto
+          132 0 54 92 0 116 rrcurveto
+          0 460 rlineto
+          -84 0 rlineto
+          0 -453 rlineto
+          0 -101 -35 -40 -72 0 rrcurveto
+          -48 0 -37 21 -28 49 rrcurveto
+          -56 -38 rlineto
+          36 -71 59 -35 79 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="J.sups">
+          -238 140 386 rmoveto
+          89 0 37 62 0 77 rrcurveto
+          0 301 rlineto
+          -63 0 rlineto
+          0 -296 rlineto
+          0 -64 -23 -25 -45 0 rrcurveto
+          -30 0 -24 14 -19 33 rrcurveto
+          -44 -31 rlineto
+          26 -46 39 -25 57 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="K">
+          19 90 0 rmoveto
+          84 0 rlineto
+          0 207 rlineto
+          112 133 rlineto
+          195 -340 rlineto
+          94 0 rlineto
+          -237 406 rlineto
+          206 250 rlineto
+          -96 0 rlineto
+          -271 -328 rlineto
+          -3 0 rlineto
+          0 328 rlineto
+          -84 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="K.sups">
+          -173 57 394 rmoveto
+          63 0 rlineto
+          0 135 rlineto
+          72 84 rlineto
+          126 -219 rlineto
+          70 0 rlineto
+          -158 268 rlineto
+          136 164 rlineto
+          -71 0 rlineto
+          -173 -209 rlineto
+          -2 0 rlineto
+          0 209 rlineto
+          -63 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="L">
+          -74 90 0 rmoveto
+          370 0 rlineto
+          0 71 rlineto
+          -286 0 rlineto
+          0 585 rlineto
+          -84 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="L.sups">
+          -235 57 394 rmoveto
+          251 0 rlineto
+          0 53 rlineto
+          -188 0 rlineto
+          0 379 rlineto
+          -63 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="M">
+          167 89 0 rmoveto
+          77 0 rlineto
+          0 362 rlineto
+          0 58 -7 81 -5 57 rrcurveto
+          4 0 rlineto
+          52 -153 rlineto
+          122 -339 rlineto
+          61 0 rlineto
+          123 339 rlineto
+          51 153 rlineto
+          4 0 rlineto
+          -5 -57 -7 -81 0 -58 rrcurveto
+          0 -362 rlineto
+          79 0 rlineto
+          0 656 rlineto
+          -105 0 rlineto
+          -124 -351 rlineto
+          -16 -46 -12 -42 -15 -49 rrcurveto
+          -4 0 rlineto
+          -14 49 -14 42 -16 46 rrcurveto
+          -124 351 rlineto
+          -105 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="M.sups">
+          -75 57 395 rmoveto
+          58 0 rlineto
+          0 226 rlineto
+          0 38 -3 49 -4 42 rrcurveto
+          2 0 rlineto
+          33 -100 rlineto
+          79 -214 rlineto
+          42 0 rlineto
+          78 214 rlineto
+          33 100 rlineto
+          2 0 rlineto
+          -4 -42 -4 -49 0 -38 rrcurveto
+          0 -226 rlineto
+          60 0 rlineto
+          0 432 rlineto
+          -74 0 rlineto
+          -82 -225 rlineto
+          -27 -88 rlineto
+          -3 0 rlineto
+          -27 88 rlineto
+          -85 225 rlineto
+          -74 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="N">
+          86 90 0 rmoveto
+          79 0 rlineto
+          0 345 rlineto
+          0 68 -6 71 -5 66 rrcurveto
+          4 0 rlineto
+          22 -48 24 -49 25 -44 rrcurveto
+          234 -409 rlineto
+          90 0 rlineto
+          0 656 rlineto
+          -79 0 rlineto
+          0 -342 rlineto
+          0 -68 6 -72 5 -68 rrcurveto
+          -4 0 rlineto
+          -23 48 -23 49 -25 44 rrcurveto
+          -234 409 rlineto
+          -90 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="N.sups">
+          -130 57 395 rmoveto
+          58 0 rlineto
+          0 216 rlineto
+          0 45 -3 47 -4 46 rrcurveto
+          3 0 rlineto
+          47 -94 rlineto
+          148 -260 rlineto
+          68 0 rlineto
+          0 432 rlineto
+          -58 0 rlineto
+          0 -213 rlineto
+          0 -46 2 -50 5 -45 rrcurveto
+          -3 0 rlineto
+          -46 94 rlineto
+          -148 260 rlineto
+          -69 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="Ntilde">
+          87 90 0 rmoveto
+          79 0 rlineto
+          0 345 rlineto
+          0 68 -6 71 -5 66 rrcurveto
+          4 0 rlineto
+          22 -48 24 -49 25 -44 rrcurveto
+          234 -409 rlineto
+          90 0 rlineto
+          0 656 rlineto
+          -79 0 rlineto
+          0 -342 rlineto
+          0 -68 6 -72 5 -68 rrcurveto
+          -4 0 rlineto
+          -23 48 -23 49 -25 44 rrcurveto
+          -234 409 rlineto
+          -90 0 rlineto
+          319 53 rmoveto
+          60 0 39 46 3 77 rrcurveto
+          -56 4 rlineto
+          -5 -43 -18 -23 -25 0 rrcurveto
+          -47 0 -26 71 -75 0 rrcurveto
+          -60 0 -39 -46 -3 -77 rrcurveto
+          56 -4 rlineto
+          4 42 19 23 25 0 rrcurveto
+          47 0 26 -70 75 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="O">
+          104 332 -12 rmoveto
+          165 0 116 132 0 211 rrcurveto
+          0 209 -116 128 -165 0 rrcurveto
+          -165 0 -115 -127 0 -210 rrcurveto
+          0 -211 115 -132 165 0 rrcurveto
+          0 74 rmoveto
+          -117 0 -76 105 0 164 rrcurveto
+          0 163 76 100 117 0 rrcurveto
+          117 0 77 -100 0 -163 rrcurveto
+          0 -164 -77 -105 -117 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="O.sups">
+          -117 221 386 rmoveto
+          112 0 79 87 0 139 rrcurveto
+          0 139 -79 83 -112 0 rrcurveto
+          -110 0 -79 -83 0 -139 rrcurveto
+          0 -139 79 -87 110 0 rrcurveto
+          0 55 rmoveto
+          -75 0 -48 67 0 104 rrcurveto
+          0 105 48 63 75 0 rrcurveto
+          76 0 49 -63 0 -105 rrcurveto
+          0 -104 -49 -67 -76 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="Oacute">
+          104 332 -12 rmoveto
+          165 0 116 132 0 211 rrcurveto
+          0 209 -116 128 -165 0 rrcurveto
+          -165 0 -115 -127 0 -210 rrcurveto
+          0 -211 115 -132 165 0 rrcurveto
+          0 74 rmoveto
+          -117 0 -76 105 0 164 rrcurveto
+          0 163 76 100 117 0 rrcurveto
+          117 0 77 -100 0 -163 rrcurveto
+          0 -164 -77 -105 -117 0 rrcurveto
+          -56 635 rmoveto
+          186 115 rlineto
+          -39 56 rlineto
+          -179 -130 rlineto
+          endchar
+        </CharString>
+        <CharString name="Ocircumflex">
+          104 332 -12 rmoveto
+          165 0 116 132 0 211 rrcurveto
+          0 209 -116 128 -165 0 rrcurveto
+          -165 0 -115 -127 0 -210 rrcurveto
+          0 -211 115 -132 165 0 rrcurveto
+          0 74 rmoveto
+          -117 0 -76 105 0 164 rrcurveto
+          0 163 76 100 117 0 rrcurveto
+          117 0 77 -100 0 -163 rrcurveto
+          0 -164 -77 -105 -117 0 rrcurveto
+          -112 637 rmoveto
+          110 92 rlineto
+          4 0 rlineto
+          110 -92 rlineto
+          36 26 rlineto
+          -104 113 rlineto
+          -88 0 rlineto
+          -104 -113 rlineto
+          endchar
+        </CharString>
+        <CharString name="Odieresis">
+          104 332 -12 rmoveto
+          165 0 116 132 0 211 rrcurveto
+          0 209 -116 128 -165 0 rrcurveto
+          -165 0 -115 -127 0 -210 rrcurveto
+          0 -211 115 -132 165 0 rrcurveto
+          0 74 rmoveto
+          -117 0 -76 105 0 164 rrcurveto
+          0 163 76 100 117 0 rrcurveto
+          117 0 77 -100 0 -163 rrcurveto
+          0 -164 -77 -105 -117 0 rrcurveto
+          -103 653 rmoveto
+          29 0 20 21 0 28 rrcurveto
+          0 29 -20 21 -29 0 rrcurveto
+          -28 0 -21 -21 0 -29 rrcurveto
+          0 -28 21 -21 28 0 rrcurveto
+          206 0 rmoveto
+          28 0 21 21 0 28 rrcurveto
+          0 29 -21 21 -28 0 rrcurveto
+          -29 0 -20 -21 0 -29 rrcurveto
+          0 -28 20 -21 29 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="Ograve">
+          104 332 -12 rmoveto
+          165 0 116 132 0 211 rrcurveto
+          0 209 -116 128 -165 0 rrcurveto
+          -165 0 -115 -127 0 -210 rrcurveto
+          0 -211 115 -132 165 0 rrcurveto
+          0 74 rmoveto
+          -117 0 -76 105 0 164 rrcurveto
+          0 163 76 100 117 0 rrcurveto
+          117 0 77 -100 0 -163 rrcurveto
+          0 -164 -77 -105 -117 0 rrcurveto
+          56 635 rmoveto
+          32 41 rlineto
+          -179 130 rlineto
+          -39 -56 rlineto
+          endchar
+        </CharString>
+        <CharString name="Oslash">
+          104 98 -32 rmoveto
+          64 83 rlineto
+          46 -41 59 -22 68 0 rrcurveto
+          165 0 116 132 0 211 rrcurveto
+          0 94 -23 77 -41 57 rrcurveto
+          69 89 rlineto
+          -51 40 rlineto
+          -62 -81 rlineto
+          -46 40 -60 21 -67 0 rrcurveto
+          -165 0 -115 -127 0 -210 rrcurveto
+          0 -95 23 -78 40 -58 rrcurveto
+          -70 -92 rlineto
+          94 323 rmoveto
+          0 163 76 100 117 0 rrcurveto
+          49 0 43 -18 32 -33 rrcurveto
+          -286 -372 rlineto
+          -20 43 -11 54 0 63 rrcurveto
+          193 -269 rmoveto
+          -50 0 -42 19 -32 34 rrcurveto
+          287 373 rlineto
+          20 -42 11 -53 0 -62 rrcurveto
+          0 -164 -77 -105 -117 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="Otilde">
+          104 332 -12 rmoveto
+          165 0 116 132 0 211 rrcurveto
+          0 209 -116 128 -165 0 rrcurveto
+          -165 0 -115 -127 0 -210 rrcurveto
+          0 -211 115 -132 165 0 rrcurveto
+          0 74 rmoveto
+          -117 0 -76 105 0 164 rrcurveto
+          0 163 76 100 117 0 rrcurveto
+          117 0 77 -100 0 -163 rrcurveto
+          0 -164 -77 -105 -117 0 rrcurveto
+          75 647 rmoveto
+          60 0 39 46 3 77 rrcurveto
+          -56 4 rlineto
+          -5 -43 -18 -23 -25 0 rrcurveto
+          -47 0 -26 71 -75 0 rrcurveto
+          -60 0 -39 -46 -3 -77 rrcurveto
+          56 -4 rlineto
+          4 42 19 23 25 0 rrcurveto
+          47 0 26 -70 75 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="P">
+          7 90 0 rmoveto
+          84 0 rlineto
+          0 260 rlineto
+          107 0 rlineto
+          144 0 99 64 0 139 rrcurveto
+          0 144 -100 49 -147 0 rrcurveto
+          -187 0 rlineto
+          84 -328 rmoveto
+          0 260 rlineto
+          93 0 rlineto
+          115 0 58 -31 0 -94 rrcurveto
+          0 -93 -55 -42 -114 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="P.sups">
+          -175 57 394 rmoveto
+          63 0 rlineto
+          0 167 rlineto
+          77 0 rlineto
+          94 0 69 43 0 94 rrcurveto
+          0 95 -67 33 -96 0 rrcurveto
+          -140 0 rlineto
+          63 -214 rmoveto
+          0 163 rlineto
+          69 0 rlineto
+          72 0 36 -19 0 -58 rrcurveto
+          0 -59 -35 -27 -73 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="Q">
+          104 332 58 rmoveto
+          -117 0 -76 106 0 167 rrcurveto
+          0 163 76 100 117 0 rrcurveto
+          117 0 77 -100 0 -163 rrcurveto
+          0 -167 -77 -106 -117 0 rrcurveto
+          201 -223 rmoveto
+          40 0 35 7 19 9 rrcurveto
+          -16 63 rlineto
+          -17 -5 -23 -4 -29 0 rrcurveto
+          -70 0 -60 29 -30 58 rrcurveto
+          138 24 93 126 0 189 rrcurveto
+          0 209 -116 128 -165 0 rrcurveto
+          -165 0 -115 -127 0 -210 rrcurveto
+          0 -193 96 -127 143 -20 rrcurveto
+          38 -90 83 -66 121 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="Q.sups">
+          -117 220 439 rmoveto
+          -75 0 -49 68 0 106 rrcurveto
+          0 103 49 64 75 0 rrcurveto
+          76 0 49 -64 0 -103 rrcurveto
+          0 -106 -49 -68 -76 0 rrcurveto
+          136 -154 rmoveto
+          28 0 24 6 14 5 rrcurveto
+          -12 48 rlineto
+          -12 -4 -15 -3 -20 0 rrcurveto
+          -46 0 -39 16 -20 37 rrcurveto
+          91 17 61 83 0 123 rrcurveto
+          0 137 -78 84 -112 0 rrcurveto
+          -111 0 -78 -83 0 -138 rrcurveto
+          0 -128 65 -83 95 -14 rrcurveto
+          26 -61 57 -42 82 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="R">
+          10 90 0 rmoveto
+          84 0 rlineto
+          0 277 rlineto
+          118 0 rlineto
+          158 -277 rlineto
+          95 0 rlineto
+          -167 286 rlineto
+          89 23 58 60 0 102 rrcurveto
+          0 137 -96 48 -134 0 rrcurveto
+          -205 0 rlineto
+          84 -311 rmoveto
+          0 243 rlineto
+          109 0 rlineto
+          102 0 56 -31 0 -86 rrcurveto
+          0 -84 -56 -42 -102 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="R.sups">
+          -171 57 394 rmoveto
+          63 0 rlineto
+          0 178 rlineto
+          76 0 rlineto
+          101 -178 rlineto
+          71 0 rlineto
+          -108 186 rlineto
+          56 17 38 41 0 66 rrcurveto
+          0 90 -67 32 -89 0 rrcurveto
+          -141 0 rlineto
+          63 -203 rmoveto
+          0 152 rlineto
+          70 0 rlineto
+          66 0 35 -19 0 -54 rrcurveto
+          0 -53 -35 -26 -66 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="S">
+          -26 272 -12 rmoveto
+          138 0 86 83 0 104 rrcurveto
+          0 97 -59 46 -76 32 rrcurveto
+          -94 41 rlineto
+          -51 21 -57 24 0 63 rrcurveto
+          0 58 48 37 73 0 rrcurveto
+          57 0 51 -23 40 -38 rrcurveto
+          46 56 rlineto
+          -46 46 -68 33 -80 0 rrcurveto
+          -119 0 -87 -74 0 -100 rrcurveto
+          0 -97 71 -46 61 -26 rrcurveto
+          95 -42 rlineto
+          61 -27 48 -21 0 -67 rrcurveto
+          0 -63 -51 -43 -86 0 rrcurveto
+          -69 0 -67 30 -48 49 rrcurveto
+          -47 -55 rlineto
+          57 -61 79 -37 94 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="S.sups">
+          -204 182 386 rmoveto
+          93 0 57 56 0 73 rrcurveto
+          0 60 -34 28 -55 23 rrcurveto
+          -62 27 rlineto
+          -34 15 -37 15 0 39 rrcurveto
+          0 36 29 24 47 0 rrcurveto
+          41 0 31 -17 28 -24 rrcurveto
+          33 40 rlineto
+          -32 32 -48 21 -51 0 rrcurveto
+          -82 0 -60 -50 0 -66 rrcurveto
+          0 -63 45 -29 44 -20 rrcurveto
+          63 -27 rlineto
+          41 -18 30 -13 0 -42 rrcurveto
+          0 -39 -31 -27 -54 0 rrcurveto
+          -45 0 -45 18 -32 34 rrcurveto
+          -35 -42 rlineto
+          40 -39 54 -25 61 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="T">
+          -24 226 0 rmoveto
+          84 0 rlineto
+          0 585 rlineto
+          199 0 rlineto
+          0 71 rlineto
+          -481 0 rlineto
+          0 -71 rlineto
+          198 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="T.sups">
+          -203 147 394 rmoveto
+          63 0 rlineto
+          0 380 rlineto
+          130 0 rlineto
+          0 52 rlineto
+          -323 0 rlineto
+          0 -52 rlineto
+          130 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="Thorn">
+          24 90 0 rmoveto
+          84 0 rlineto
+          0 150 rlineto
+          117 0 rlineto
+          144 0 99 64 0 139 rrcurveto
+          0 143 -98 50 -145 0 rrcurveto
+          -117 0 rlineto
+          0 110 rlineto
+          -84 0 rlineto
+          84 -438 rmoveto
+          0 260 rlineto
+          107 0 rlineto
+          113 0 56 -31 0 -94 rrcurveto
+          0 -94 -55 -41 -114 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="U">
+          86 323 -12 rmoveto
+          134 0 102 73 0 210 rrcurveto
+          0 385 rlineto
+          -81 0 rlineto
+          0 -387 rlineto
+          0 -157 -68 -50 -87 0 rrcurveto
+          -86 0 -66 50 0 157 rrcurveto
+          0 387 rlineto
+          -84 0 rlineto
+          0 -385 rlineto
+          0 -210 102 -73 134 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="U.sups">
+          -129 217 386 rmoveto
+          93 0 66 51 0 140 rrcurveto
+          0 249 rlineto
+          -60 0 rlineto
+          0 -252 rlineto
+          0 -101 -43 -32 -56 0 rrcurveto
+          -57 0 -41 32 0 101 rrcurveto
+          0 252 rlineto
+          -63 0 rlineto
+          0 -249 rlineto
+          0 -140 65 -51 96 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="Uacute">
+          86 323 -12 rmoveto
+          134 0 102 73 0 210 rrcurveto
+          0 385 rlineto
+          -81 0 rlineto
+          0 -387 rlineto
+          0 -157 -68 -50 -87 0 rrcurveto
+          -86 0 -66 50 0 157 rrcurveto
+          0 387 rlineto
+          -84 0 rlineto
+          0 -385 rlineto
+          0 -210 102 -73 134 0 rrcurveto
+          -57 709 rmoveto
+          186 115 rlineto
+          -39 56 rlineto
+          -179 -130 rlineto
+          endchar
+        </CharString>
+        <CharString name="Ucircumflex">
+          86 323 -12 rmoveto
+          134 0 102 73 0 210 rrcurveto
+          0 385 rlineto
+          -81 0 rlineto
+          0 -387 rlineto
+          0 -157 -68 -50 -87 0 rrcurveto
+          -86 0 -66 50 0 157 rrcurveto
+          0 387 rlineto
+          -84 0 rlineto
+          0 -385 rlineto
+          0 -210 102 -73 134 0 rrcurveto
+          -113 711 rmoveto
+          110 92 rlineto
+          4 0 rlineto
+          110 -92 rlineto
+          36 26 rlineto
+          -104 113 rlineto
+          -88 0 rlineto
+          -104 -113 rlineto
+          endchar
+        </CharString>
+        <CharString name="Udieresis">
+          86 323 -12 rmoveto
+          134 0 102 73 0 210 rrcurveto
+          0 385 rlineto
+          -81 0 rlineto
+          0 -387 rlineto
+          0 -157 -68 -50 -87 0 rrcurveto
+          -86 0 -66 50 0 157 rrcurveto
+          0 387 rlineto
+          -84 0 rlineto
+          0 -385 rlineto
+          0 -210 102 -73 134 0 rrcurveto
+          -104 727 rmoveto
+          29 0 20 21 0 28 rrcurveto
+          0 29 -20 21 -29 0 rrcurveto
+          -28 0 -21 -21 0 -29 rrcurveto
+          0 -28 21 -21 28 0 rrcurveto
+          206 0 rmoveto
+          28 0 21 21 0 28 rrcurveto
+          0 29 -21 21 -28 0 rrcurveto
+          -29 0 -20 -21 0 -29 rrcurveto
+          0 -28 20 -21 29 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="Ugrave">
+          86 323 -12 rmoveto
+          134 0 102 73 0 210 rrcurveto
+          0 385 rlineto
+          -81 0 rlineto
+          0 -387 rlineto
+          0 -157 -68 -50 -87 0 rrcurveto
+          -86 0 -66 50 0 157 rrcurveto
+          0 387 rlineto
+          -84 0 rlineto
+          0 -385 rlineto
+          0 -210 102 -73 134 0 rrcurveto
+          55 709 rmoveto
+          32 41 rlineto
+          -179 130 rlineto
+          -39 -56 rlineto
+          endchar
+        </CharString>
+        <CharString name="V">
+          -44 206 0 rmoveto
+          97 0 rlineto
+          213 656 rlineto
+          -86 0 rlineto
+          -109 -354 rlineto
+          -23 -77 -16 -63 -24 -76 rrcurveto
+          -4 0 rlineto
+          -24 76 -17 63 -22 77 rrcurveto
+          -102 354 rlineto
+          -89 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="V.sups">
+          -214 137 394 rmoveto
+          74 0 rlineto
+          138 432 rlineto
+          -65 0 rlineto
+          -67 -227 rlineto
+          -15 -50 -9 -41 -16 -51 rrcurveto
+          -3 0 rlineto
+          -15 51 -11 41 -15 50 rrcurveto
+          -68 227 rlineto
+          -67 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="W">
+          226 162 0 rmoveto
+          103 0 rlineto
+          95 396 rlineto
+          11 52 10 45 10 57 rrcurveto
+          4 0 rlineto
+          9 -57 8 -45 12 -52 rrcurveto
+          97 -396 rlineto
+          104 0 rlineto
+          137 656 rlineto
+          -81 0 rlineto
+          -70 -357 rlineto
+          -12 -71 -12 -70 -11 -74 rrcurveto
+          -4 0 rlineto
+          -14 74 -17 71 -16 70 rrcurveto
+          -89 357 rlineto
+          -83 0 rlineto
+          -91 -357 rlineto
+          -16 -71 -15 -70 -13 -74 rrcurveto
+          -4 0 rlineto
+          -12 74 -11 70 -13 71 rrcurveto
+          -68 357 rlineto
+          -87 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="W.sups">
+          -34 105 395 rmoveto
+          78 0 rlineto
+          59 250 rlineto
+          8 33 6 32 6 33 rrcurveto
+          2 0 rlineto
+          6 -33 6 -32 8 -33 rrcurveto
+          61 -250 rlineto
+          78 0 rlineto
+          89 432 rlineto
+          -60 0 rlineto
+          -45 -229 rlineto
+          -9 -47 -6 -39 -6 -54 rrcurveto
+          -4 0 rlineto
+          -10 54 -8 39 -12 47 rrcurveto
+          -58 229 rlineto
+          -59 0 rlineto
+          -58 -229 rlineto
+          -12 -47 -8 -39 -9 -54 rrcurveto
+          -4 0 rlineto
+          -7 54 -6 39 -9 47 rrcurveto
+          -44 229 rlineto
+          -65 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="X">
+          -46 15 0 rmoveto
+          89 0 rlineto
+          94 176 rlineto
+          17 33 16 33 19 40 rrcurveto
+          4 0 rlineto
+          21 -40 18 -33 17 -33 rrcurveto
+          96 -176 rlineto
+          93 0 rlineto
+          -191 335 rlineto
+          179 321 rlineto
+          -89 0 rlineto
+          -87 -167 rlineto
+          -16 -30 -13 -27 -17 -39 rrcurveto
+          -4 0 rlineto
+          -21 39 -14 27 -16 30 rrcurveto
+          -89 167 rlineto
+          -93 0 rlineto
+          178 -317 rlineto
+          endchar
+        </CharString>
+        <CharString name="X.sups">
+          -213 8 394 rmoveto
+          67 0 rlineto
+          59 112 rlineto
+          11 22 12 21 12 27 rrcurveto
+          3 0 rlineto
+          14 -27 12 -21 11 -22 rrcurveto
+          60 -112 rlineto
+          69 0 rlineto
+          -126 221 rlineto
+          118 211 rlineto
+          -67 0 rlineto
+          -54 -105 rlineto
+          -9 -20 -9 -18 -12 -26 rrcurveto
+          -3 0 rlineto
+          -14 26 -10 18 -10 20 rrcurveto
+          -55 105 rlineto
+          -70 0 rlineto
+          118 -208 rlineto
+          endchar
+        </CharString>
+        <CharString name="Y">
+          -84 196 0 rmoveto
+          84 0 rlineto
+          0 254 rlineto
+          198 402 rlineto
+          -88 0 rlineto
+          -84 -185 rlineto
+          -20 -48 -23 -46 -22 -49 rrcurveto
+          -4 0 rlineto
+          -23 49 -20 46 -21 48 rrcurveto
+          -84 185 rlineto
+          -90 0 rlineto
+          197 -402 rlineto
+          endchar
+        </CharString>
+        <CharString name="Y.sups">
+          -239 129 394 rmoveto
+          63 0 rlineto
+          0 166 rlineto
+          132 266 rlineto
+          -66 0 rlineto
+          -53 -117 rlineto
+          -13 -32 -14 -30 -15 -33 rrcurveto
+          -3 0 rlineto
+          -15 33 -13 30 -14 32 rrcurveto
+          -54 117 rlineto
+          -67 0 rlineto
+          132 -266 rlineto
+          endchar
+        </CharString>
+        <CharString name="Yacute">
+          -84 196 0 rmoveto
+          84 0 rlineto
+          0 254 rlineto
+          198 402 rlineto
+          -88 0 rlineto
+          -84 -185 rlineto
+          -20 -48 -23 -46 -22 -49 rrcurveto
+          -4 0 rlineto
+          -23 49 -20 46 -21 48 rrcurveto
+          -84 185 rlineto
+          -90 0 rlineto
+          197 -402 rlineto
+          -14 443 rmoveto
+          186 115 rlineto
+          -39 56 rlineto
+          -179 -130 rlineto
+          endchar
+        </CharString>
+        <CharString name="Z">
+          -21 45 0 rmoveto
+          452 0 rlineto
+          0 71 rlineto
+          -348 0 rlineto
+          345 535 rlineto
+          0 50 rlineto
+          -418 0 rlineto
+          0 -71 rlineto
+          313 0 rlineto
+          -344 -535 rlineto
+          endchar
+        </CharString>
+        <CharString name="Z.sups">
+          -202 27 394 rmoveto
+          305 0 rlineto
+          0 53 rlineto
+          -227 0 rlineto
+          225 342 rlineto
+          0 37 rlineto
+          -283 0 rlineto
+          0 -52 rlineto
+          205 0 rlineto
+          -225 -342 rlineto
+          endchar
+        </CharString>
+        <CharString name="a">
+          -56 194 -12 rmoveto
+          61 0 53 31 46 39 rrcurveto
+          3 0 rlineto
+          8 -58 rlineto
+          68 0 rlineto
+          0 299 rlineto
+          0 120 -51 79 -118 0 rrcurveto
+          -78 0 -68 -33 -45 -30 rrcurveto
+          32 -56 rlineto
+          38 25 51 25 56 0 rrcurveto
+          79 0 20 -59 1 -61 rrcurveto
+          -208 -23 -90 -52 0 -108 rrcurveto
+          0 -88 61 -50 81 0 rrcurveto
+          23 68 rmoveto
+          -47 0 -37 21 0 54 rrcurveto
+          0 63 53 37 164 19 rrcurveto
+          0 -132 rlineto
+          -47 -41 -39 -21 -47 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="a.sups">
+          -215 136 387 rmoveto
+          41 0 33 21 27 24 rrcurveto
+          4 0 rlineto
+          7 -37 rlineto
+          49 0 rlineto
+          0 196 rlineto
+          0 85 -34 48 -80 0 rrcurveto
+          -52 0 -48 -22 -33 -20 rrcurveto
+          23 -42 rlineto
+          27 16 39 18 35 0 rrcurveto
+          47 0 14 -31 1 -43 rrcurveto
+          -139 -12 -60 -36 0 -71 rrcurveto
+          0 -57 40 -37 59 0 rrcurveto
+          18 49 rmoveto
+          -35 0 -21 16 0 34 rrcurveto
+          0 36 35 25 103 12 rrcurveto
+          0 -83 rlineto
+          -29 -27 -26 -13 -27 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="aacute">
+          -55 194 -12 rmoveto
+          61 0 53 31 46 39 rrcurveto
+          3 0 rlineto
+          8 -58 rlineto
+          68 0 rlineto
+          0 299 rlineto
+          0 120 -51 79 -118 0 rrcurveto
+          -78 0 -68 -33 -45 -30 rrcurveto
+          32 -56 rlineto
+          38 25 51 25 56 0 rrcurveto
+          79 0 20 -59 1 -61 rrcurveto
+          -208 -23 -90 -52 0 -108 rrcurveto
+          0 -88 61 -50 81 0 rrcurveto
+          23 68 rmoveto
+          -47 0 -37 21 0 54 rrcurveto
+          0 63 53 37 164 19 rrcurveto
+          0 -132 rlineto
+          -47 -41 -39 -21 -47 0 rrcurveto
+          7 517 rmoveto
+          179 153 rlineto
+          -51 55 rlineto
+          -170 -166 rlineto
+          endchar
+        </CharString>
+        <CharString name="acircumflex">
+          -55 194 -12 rmoveto
+          61 0 53 31 46 39 rrcurveto
+          3 0 rlineto
+          8 -58 rlineto
+          68 0 rlineto
+          0 299 rlineto
+          0 120 -51 79 -118 0 rrcurveto
+          -78 0 -68 -33 -45 -30 rrcurveto
+          32 -56 rlineto
+          38 25 51 25 56 0 rrcurveto
+          79 0 20 -59 1 -61 rrcurveto
+          -208 -23 -90 -52 0 -108 rrcurveto
+          0 -88 61 -50 81 0 rrcurveto
+          23 68 rmoveto
+          -47 0 -37 21 0 54 rrcurveto
+          0 63 53 37 164 19 rrcurveto
+          0 -132 rlineto
+          -47 -41 -39 -21 -47 0 rrcurveto
+          -70 512 rmoveto
+          118 113 rlineto
+          4 0 rlineto
+          118 -113 rlineto
+          35 32 rlineto
+          -113 140 rlineto
+          -84 0 rlineto
+          -113 -140 rlineto
+          endchar
+        </CharString>
+        <CharString name="acute">
+          -18 228 573 rmoveto
+          179 153 rlineto
+          -51 55 rlineto
+          -170 -166 rlineto
+          endchar
+        </CharString>
+        <CharString name="adieresis">
+          -55 194 -12 rmoveto
+          61 0 53 31 46 39 rrcurveto
+          3 0 rlineto
+          8 -58 rlineto
+          68 0 rlineto
+          0 299 rlineto
+          0 120 -51 79 -118 0 rrcurveto
+          -78 0 -68 -33 -45 -30 rrcurveto
+          32 -56 rlineto
+          38 25 51 25 56 0 rrcurveto
+          79 0 20 -59 1 -61 rrcurveto
+          -208 -23 -90 -52 0 -108 rrcurveto
+          0 -88 61 -50 81 0 rrcurveto
+          23 68 rmoveto
+          -47 0 -37 21 0 54 rrcurveto
+          0 63 53 37 164 19 rrcurveto
+          0 -132 rlineto
+          -47 -41 -39 -21 -47 0 rrcurveto
+          -46 531 rmoveto
+          28 0 21 22 0 28 rrcurveto
+          0 28 -21 22 -28 0 rrcurveto
+          -29 0 -21 -22 0 -28 rrcurveto
+          0 -28 21 -22 29 0 rrcurveto
+          192 0 rmoveto
+          29 0 21 22 0 28 rrcurveto
+          0 28 -21 22 -29 0 rrcurveto
+          -28 0 -21 -22 0 -28 rrcurveto
+          0 -28 21 -22 28 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="ae">
+          218 194 -12 rmoveto
+          63 0 70 32 65 59 rrcurveto
+          38 -49 52 -42 82 0 rrcurveto
+          66 0 48 20 44 30 rrcurveto
+          -30 53 rlineto
+          -35 -24 -37 -12 -46 0 rrcurveto
+          -83 0 -62 63 -7 103 rrcurveto
+          315 0 rlineto
+          2 12 2 19 0 17 rrcurveto
+          0 139 -66 90 -119 0 rrcurveto
+          -67 0 -57 -40 -36 -64 rrcurveto
+          -19 64 -49 40 -72 0 rrcurveto
+          -69 0 -69 -33 -45 -30 rrcurveto
+          32 -56 rlineto
+          38 25 51 25 52 0 rrcurveto
+          80 0 20 -58 0 -62 rrcurveto
+          -202 -22 -92 -53 0 -108 rrcurveto
+          0 -88 61 -50 81 0 rrcurveto
+          23 68 rmoveto
+          -47 0 -37 21 0 55 rrcurveto
+          0 63 57 36 155 19 rrcurveto
+          1 -24 rlineto
+          2 -37 6 -35 11 -26 rrcurveto
+          -44 -47 -59 -25 -45 0 rrcurveto
+          206 227 rmoveto
+          10 87 53 62 68 0 rrcurveto
+          71 0 42 -53 0 -96 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="agrave">
+          -55 194 -12 rmoveto
+          61 0 53 31 46 39 rrcurveto
+          3 0 rlineto
+          8 -58 rlineto
+          68 0 rlineto
+          0 299 rlineto
+          0 120 -51 79 -118 0 rrcurveto
+          -78 0 -68 -33 -45 -30 rrcurveto
+          32 -56 rlineto
+          38 25 51 25 56 0 rrcurveto
+          79 0 20 -59 1 -61 rrcurveto
+          -208 -23 -90 -52 0 -108 rrcurveto
+          0 -88 61 -50 81 0 rrcurveto
+          23 68 rmoveto
+          -47 0 -37 21 0 54 rrcurveto
+          0 63 53 37 164 19 rrcurveto
+          0 -132 rlineto
+          -47 -41 -39 -21 -47 0 rrcurveto
+          93 517 rmoveto
+          42 42 rlineto
+          -170 166 rlineto
+          -51 -55 rlineto
+          endchar
+        </CharString>
+        <CharString name="ampersand">
+          50 190 514 rmoveto
+          0 54 31 41 49 0 rrcurveto
+          44 0 18 -34 0 -38 rrcurveto
+          0 -58 -51 -40 -60 -40 rrcurveto
+          -20 40 -11 39 0 36 rrcurveto
+          42 -526 rmoveto
+          77 0 62 30 51 45 rrcurveto
+          53 -37 51 -25 46 -13 rrcurveto
+          23 69 rlineto
+          -36 10 -42 22 -45 30 rrcurveto
+          52 69 38 80 25 86 rrcurveto
+          -78 0 rlineto
+          -20 -75 -31 -65 -41 -53 rrcurveto
+          -62 51 -60 65 -43 67 rrcurveto
+          72 53 75 55 0 86 rrcurveto
+          0 77 -48 53 -81 0 rrcurveto
+          -91 0 -61 -68 0 -88 rrcurveto
+          0 -47 16 -53 27 -52 rrcurveto
+          -67 -47 -62 -55 0 -88 rrcurveto
+          0 -106 81 -76 119 0 rrcurveto
+          -119 187 rmoveto
+          0 51 36 39 46 37 rrcurveto
+          45 -71 62 -68 65 -56 rrcurveto
+          -39 -32 -42 -21 -44 0 rrcurveto
+          -72 0 -57 48 0 73 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="aring">
+          -55 194 -12 rmoveto
+          61 0 53 31 46 39 rrcurveto
+          3 0 rlineto
+          8 -58 rlineto
+          68 0 rlineto
+          0 299 rlineto
+          0 120 -51 79 -118 0 rrcurveto
+          -78 0 -68 -33 -45 -30 rrcurveto
+          32 -56 rlineto
+          38 25 51 25 56 0 rrcurveto
+          79 0 20 -59 1 -61 rrcurveto
+          -208 -23 -90 -52 0 -108 rrcurveto
+          0 -88 61 -50 81 0 rrcurveto
+          23 68 rmoveto
+          -47 0 -37 21 0 54 rrcurveto
+          0 63 53 37 164 19 rrcurveto
+          0 -132 rlineto
+          -47 -41 -39 -21 -47 0 rrcurveto
+          50 498 rmoveto
+          68 0 42 42 0 57 rrcurveto
+          0 56 -42 42 -68 0 rrcurveto
+          -68 0 -42 -42 0 -56 rrcurveto
+          0 -57 42 -42 68 0 rrcurveto
+          0 37 rmoveto
+          -32 0 -25 24 0 38 rrcurveto
+          0 37 25 24 32 0 rrcurveto
+          32 0 25 -24 0 -37 rrcurveto
+          0 -38 -25 -24 -32 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="asciicircum">
+          -63 60 284 rmoveto
+          72 0 rlineto
+          66 175 rlineto
+          49 133 rlineto
+          4 0 rlineto
+          49 -133 rlineto
+          65 -175 rlineto
+          73 0 rlineto
+          -153 386 rlineto
+          -73 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="asciitilde">
+          -63 336 257 rmoveto
+          44 0 45 26 36 63 rrcurveto
+          -46 34 rlineto
+          -23 -43 -25 -18 -29 0 rrcurveto
+          -56 0 -42 84 -79 0 rrcurveto
+          -43 0 -46 -26 -36 -64 rrcurveto
+          47 -33 rlineto
+          22 43 25 18 29 0 rrcurveto
+          56 0 42 -84 79 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="asterisk">
+          -142 138 419 rmoveto
+          72 86 rlineto
+          70 -86 rlineto
+          40 29 rlineto
+          -57 94 rlineto
+          98 41 rlineto
+          -15 46 rlineto
+          -103 -24 rlineto
+          -9 107 rlineto
+          -50 0 rlineto
+          -9 -108 rlineto
+          -102 25 rlineto
+          -15 -46 rlineto
+          97 -41 rlineto
+          -57 -94 rlineto
+          endchar
+        </CharString>
+        <CharString name="at">
+          286 402 -155 rmoveto
+          70 0 62 17 59 34 rrcurveto
+          -25 54 rlineto
+          -44 -25 -55 -17 -60 0 rrcurveto
+          -166 0 -124 108 0 190 rrcurveto
+          0 228 168 149 174 0 rrcurveto
+          176 0 93 -115 0 -156 rrcurveto
+          0 -127 -68 -76 -58 0 rrcurveto
+          -52 0 -17 36 17 77 rrcurveto
+          40 203 rlineto
+          -58 0 rlineto
+          -11 -40 rlineto
+          -3 0 rlineto
+          -18 34 -24 15 -41 0 rrcurveto
+          -116 0 -77 -128 0 -108 rrcurveto
+          0 -95 55 -50 69 0 rrcurveto
+          45 0 45 29 31 40 rrcurveto
+          3 0 rlineto
+          8 -50 41 -26 55 0 rrcurveto
+          92 0 110 92 0 177 rrcurveto
+          0 197 -127 134 -204 0 rrcurveto
+          -225 0 -194 -175 0 -268 rrcurveto
+          0 -233 158 -125 196 0 rrcurveto
+          -18 271 rmoveto
+          -37 0 -29 26 0 61 rrcurveto
+          0 74 48 93 75 0 rrcurveto
+          27 0 18 -10 20 -31 rrcurveto
+          -29 -155 rlineto
+          -35 -41 -29 -17 -29 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="atilde">
+          -55 194 -12 rmoveto
+          61 0 53 31 46 39 rrcurveto
+          3 0 rlineto
+          8 -58 rlineto
+          68 0 rlineto
+          0 299 rlineto
+          0 120 -51 79 -118 0 rrcurveto
+          -78 0 -68 -33 -45 -30 rrcurveto
+          32 -56 rlineto
+          38 25 51 25 56 0 rrcurveto
+          79 0 20 -59 1 -61 rrcurveto
+          -208 -23 -90 -52 0 -108 rrcurveto
+          0 -88 61 -50 81 0 rrcurveto
+          23 68 rmoveto
+          -47 0 -37 21 0 54 rrcurveto
+          0 63 53 37 164 19 rrcurveto
+          0 -132 rlineto
+          -47 -41 -39 -21 -47 0 rrcurveto
+          122 521 rmoveto
+          69 0 29 58 3 77 rrcurveto
+          -55 4 rlineto
+          -3 -46 -14 -33 -29 0 rrcurveto
+          -47 0 -26 84 -71 0 rrcurveto
+          -69 0 -29 -58 -3 -78 rrcurveto
+          55 -3 rlineto
+          3 47 14 32 30 0 rrcurveto
+          46 0 26 -84 71 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="b">
+          -6 297 -12 rmoveto
+          111 0 100 97 0 166 rrcurveto
+          0 150 -68 97 -125 0 rrcurveto
+          -54 0 -54 -29 -45 -38 rrcurveto
+          3 87 rlineto
+          0 194 rlineto
+          -83 0 rlineto
+          0 -712 rlineto
+          66 0 rlineto
+          8 50 rlineto
+          3 0 rlineto
+          43 -39 50 -23 45 0 rrcurveto
+          -14 70 rmoveto
+          -32 0 -44 13 -42 37 rrcurveto
+          0 254 rlineto
+          46 44 42 22 41 0 rrcurveto
+          91 0 37 -71 0 -107 rrcurveto
+          0 -120 -59 -72 -80 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="b.sups">
+          -186 202 386 rmoveto
+          73 0 66 64 0 111 rrcurveto
+          0 99 -46 64 -84 0 rrcurveto
+          -37 0 -33 -20 -30 -25 rrcurveto
+          3 58 rlineto
+          0 126 rlineto
+          -62 0 rlineto
+          0 -469 rlineto
+          48 0 rlineto
+          6 33 rlineto
+          4 0 rlineto
+          27 -27 35 -14 30 0 rrcurveto
+          -10 52 rmoveto
+          -23 0 -28 9 -27 22 rrcurveto
+          0 161 rlineto
+          28 27 28 15 26 0 rrcurveto
+          56 0 25 -42 0 -69 rrcurveto
+          0 -79 -37 -44 -48 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="backslash">
+          -210 280 -160 rmoveto
+          60 0 rlineto
+          -266 870 rlineto
+          -60 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="bar">
+          -318 92 -250 rmoveto
+          58 0 rlineto
+          0 1000 rlineto
+          -58 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="braceleft">
+          -256 228 -152 rmoveto
+          45 0 rlineto
+          0 47 rlineto
+          -26 0 rlineto
+          -54 0 -14 27 0 64 rrcurveto
+          0 61 5 52 0 68 rrcurveto
+          0 64 -16 33 -44 12 rrcurveto
+          0 4 rlineto
+          44 12 16 32 0 65 rrcurveto
+          0 68 -5 52 0 61 rrcurveto
+          0 64 14 27 54 0 rrcurveto
+          26 0 rlineto
+          0 47 rlineto
+          -45 0 rlineto
+          -79 0 -38 -30 0 -103 rrcurveto
+          0 -73 9 -53 0 -68 rrcurveto
+          0 -38 -18 -38 -68 -1 rrcurveto
+          0 -52 rlineto
+          68 -1 18 -38 0 -39 rrcurveto
+          0 -67 -9 -53 0 -73 rrcurveto
+          0 -103 38 -30 79 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="braceright">
+          -256 31 -152 rmoveto
+          45 0 rlineto
+          79 0 38 30 0 103 rrcurveto
+          0 73 -9 53 0 67 rrcurveto
+          0 39 18 38 68 1 rrcurveto
+          0 52 rlineto
+          -68 1 -18 38 0 38 rrcurveto
+          0 68 9 53 0 73 rrcurveto
+          0 103 -38 30 -79 0 rrcurveto
+          -45 0 rlineto
+          0 -47 rlineto
+          26 0 rlineto
+          54 0 14 -27 0 -64 rrcurveto
+          0 -61 -5 -52 0 -68 rrcurveto
+          0 -65 16 -32 43 -12 rrcurveto
+          0 -4 rlineto
+          -43 -12 -16 -33 0 -64 rrcurveto
+          0 -68 5 -52 0 -61 rrcurveto
+          0 -64 -14 -27 -54 0 rrcurveto
+          -26 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="bracketleft">
+          -256 94 -152 rmoveto
+          179 0 rlineto
+          0 47 rlineto
+          -116 0 rlineto
+          0 766 rlineto
+          116 0 rlineto
+          0 47 rlineto
+          -179 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="bracketright">
+          -256 31 -152 rmoveto
+          179 0 rlineto
+          0 860 rlineto
+          -179 0 rlineto
+          0 -47 rlineto
+          116 0 rlineto
+          0 -766 rlineto
+          -116 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="brokenbar">
+          -318 92 291 rmoveto
+          58 0 rlineto
+          0 459 rlineto
+          -58 0 rlineto
+          0 -1000 rmoveto
+          58 0 rlineto
+          0 464 rlineto
+          -58 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="c">
+          -104 274 -12 rmoveto
+          58 0 55 22 44 40 rrcurveto
+          -36 53 rlineto
+          -29 -26 -40 -20 -45 0 rrcurveto
+          -89 0 -60 74 0 111 rrcurveto
+          0 112 64 75 88 0 rrcurveto
+          39 0 31 -15 27 -25 rrcurveto
+          41 52 rlineto
+          -34 32 -44 25 -64 0 rrcurveto
+          -125 0 -109 -93 0 -163 rrcurveto
+          0 -161 99 -93 129 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="c.sups">
+          -254 184 386 rmoveto
+          50 0 33 19 23 19 rrcurveto
+          -26 41 rlineto
+          -19 -15 -21 -12 -34 0 rrcurveto
+          -57 0 -39 48 0 69 rrcurveto
+          0 70 41 48 55 0 rrcurveto
+          29 0 16 -9 20 -16 rrcurveto
+          30 41 rlineto
+          -20 17 -32 18 -47 0 rrcurveto
+          -83 0 -73 -62 0 -107 rrcurveto
+          0 -107 65 -62 89 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="ccedilla">
+          -104 179 -226 rmoveto
+          106 5 59 28 0 58 rrcurveto
+          0 41 -27 19 -46 11 rrcurveto
+          23 53 rlineto
+          51 4 47 22 39 35 rrcurveto
+          -36 53 rlineto
+          -29 -26 -40 -20 -45 0 rrcurveto
+          -89 0 -60 74 0 111 rrcurveto
+          0 112 64 75 88 0 rrcurveto
+          39 0 31 -15 27 -25 rrcurveto
+          41 52 rlineto
+          -34 32 -44 25 -64 0 rrcurveto
+          -125 0 -109 -93 0 -163 rrcurveto
+          0 -147 82 -90 112 -15 rrcurveto
+          -37 -78 rlineto
+          57 -8 20 -14 0 -26 rrcurveto
+          0 -29 -25 -15 -84 -6 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="cedilla">
+          -18 190 -226 rmoveto
+          106 5 59 28 0 58 rrcurveto
+          0 41 -27 19 -46 11 rrcurveto
+          29 67 rlineto
+          -54 0 rlineto
+          -43 -91 rlineto
+          57 -8 20 -14 0 -26 rrcurveto
+          0 -29 -25 -15 -84 -6 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="cent">
+          -63 262 -33 rmoveto
+          52 0 rlineto
+          0 103 rlineto
+          52 4 49 23 40 35 rrcurveto
+          -37 53 rlineto
+          -27 -23 -35 -21 -42 -3 rrcurveto
+          0 343 rlineto
+          35 -2 29 -16 27 -23 rrcurveto
+          40 52 rlineto
+          -31 29 -42 26 -58 3 rrcurveto
+          0 103 rlineto
+          -52 0 rlineto
+          0 -106 rlineto
+          -113 -16 -88 -83 0 -138 rrcurveto
+          0 -141 82 -84 119 -14 rrcurveto
+          -119 239 rmoveto
+          0 86 46 62 73 18 rrcurveto
+          0 -333 rlineto
+          -74 16 -45 63 0 88 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="colon">
+          -310 125 348 rmoveto
+          33 0 27 26 0 37 rrcurveto
+          0 38 -27 26 -33 0 rrcurveto
+          -33 0 -27 -26 0 -38 rrcurveto
+          0 -37 27 -26 33 0 rrcurveto
+          0 -360 rmoveto
+          33 0 27 26 0 37 rrcurveto
+          0 38 -27 26 -33 0 rrcurveto
+          -33 0 -27 -26 0 -38 rrcurveto
+          0 -37 27 -26 33 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="colon.sups">
+          -383 89 386 rmoveto
+          26 0 20 19 0 28 rrcurveto
+          0 29 -20 20 -26 0 rrcurveto
+          -27 0 -19 -20 0 -29 rrcurveto
+          0 -28 19 -19 27 0 rrcurveto
+          0 225 rmoveto
+          26 0 20 19 0 28 rrcurveto
+          0 29 -20 20 -26 0 rrcurveto
+          -27 0 -19 -20 0 -29 rrcurveto
+          0 -28 19 -19 27 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="comma">
+          -310 67 -170 rmoveto
+          82 33 50 68 0 86 rrcurveto
+          0 61 -26 37 -44 0 rrcurveto
+          -33 0 -28 -22 0 -36 rrcurveto
+          0 -38 27 -20 32 0 rrcurveto
+          4 0 3 0 4 1 rrcurveto
+          0 -53 -34 -44 -57 -25 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="comma.dnom">
+          -383 49 -116 rmoveto
+          59 22 37 49 0 59 rrcurveto
+          0 48 -21 26 -33 0 rrcurveto
+          -25 0 -22 -18 0 -28 rrcurveto
+          0 -29 22 -14 24 0 rrcurveto
+          2 0 3 0 2 1 rrcurveto
+          0 -37 -24 -27 -40 -15 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="comma.numr">
+          -383 49 150 rmoveto
+          59 22 37 49 0 59 rrcurveto
+          0 48 -21 26 -33 0 rrcurveto
+          -25 0 -22 -18 0 -28 rrcurveto
+          0 -29 22 -14 24 0 rrcurveto
+          2 0 3 0 2 1 rrcurveto
+          0 -37 -24 -27 -40 -15 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="comma.sups">
+          -383 49 278 rmoveto
+          59 22 37 49 0 59 rrcurveto
+          0 48 -21 26 -33 0 rrcurveto
+          -25 0 -22 -18 0 -28 rrcurveto
+          0 -29 22 -14 24 0 rrcurveto
+          2 0 3 0 2 1 rrcurveto
+          0 -37 -24 -27 -40 -15 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="copyright">
+          184 372 -11 rmoveto
+          174 0 149 130 0 204 rrcurveto
+          0 203 -149 127 -174 0 rrcurveto
+          -174 0 -149 -127 0 -203 rrcurveto
+          0 -204 149 -130 174 0 rrcurveto
+          0 42 rmoveto
+          -151 0 -125 117 0 175 rrcurveto
+          0 174 125 115 151 0 rrcurveto
+          151 0 125 -115 0 -174 rrcurveto
+          0 -175 -125 -117 -151 0 rrcurveto
+          8 94 rmoveto
+          60 0 38 23 36 35 rrcurveto
+          -32 40 rlineto
+          -29 -26 -24 -16 -46 0 rrcurveto
+          -72 0 -46 52 0 83 rrcurveto
+          0 83 49 57 72 0 rrcurveto
+          35 0 29 -14 23 -26 rrcurveto
+          36 37 rlineto
+          -30 33 -40 26 -56 0 rrcurveto
+          -97 0 -88 -75 0 -121 rrcurveto
+          0 -120 80 -71 102 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="currency">
+          -63 71 102 rmoveto
+          67 69 rlineto
+          32 -24 38 -13 41 0 rrcurveto
+          39 0 40 13 31 24 rrcurveto
+          68 -69 rlineto
+          44 46 rlineto
+          -64 65 rlineto
+          22 31 14 39 0 46 rrcurveto
+          0 46 -13 40 -23 31 rrcurveto
+          64 65 rlineto
+          -44 46 rlineto
+          -68 -69 rlineto
+          -31 23 -39 13 -40 0 rrcurveto
+          -41 0 -39 -13 -31 -23 rrcurveto
+          -67 69 rlineto
+          -45 -46 rlineto
+          64 -65 rlineto
+          -23 -31 -13 -40 0 -46 rrcurveto
+          0 -46 13 -39 23 -31 rrcurveto
+          -64 -65 rlineto
+          223 48 rmoveto
+          -65 0 -53 53 0 80 rrcurveto
+          0 79 53 55 65 0 rrcurveto
+          64 0 54 -55 0 -79 rrcurveto
+          0 -80 -54 -53 -64 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="d">
+          -5 248 -12 rmoveto
+          57 0 52 32 38 37 rrcurveto
+          3 0 rlineto
+          7 -57 rlineto
+          68 0 rlineto
+          0 712 rlineto
+          -83 0 rlineto
+          0 -187 rlineto
+          4 -83 rlineto
+          -43 35 -37 21 -56 0 rrcurveto
+          -111 0 -100 -98 0 -158 rrcurveto
+          0 -162 79 -92 122 0 rrcurveto
+          18 70 rmoveto
+          -85 0 -48 69 0 116 rrcurveto
+          0 111 62 74 77 0 rrcurveto
+          40 0 37 -13 41 -37 rrcurveto
+          0 -254 rlineto
+          -40 -44 -39 -22 -45 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="d.sups">
+          -186 170 386 rmoveto
+          37 0 29 20 26 23 rrcurveto
+          3 0 rlineto
+          7 -35 rlineto
+          50 0 rlineto
+          0 469 rlineto
+          -62 0 rlineto
+          0 -119 rlineto
+          3 -56 rlineto
+          -27 22 -28 14 -35 0 rrcurveto
+          -72 0 -68 -62 0 -101 rrcurveto
+          0 -111 52 -64 85 0 rrcurveto
+          14 52 rmoveto
+          -59 0 -28 44 0 79 rrcurveto
+          0 67 40 45 46 0 rrcurveto
+          24 0 26 -9 27 -23 rrcurveto
+          0 -162 rlineto
+          -27 -27 -23 -14 -26 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="degree">
+          -228 166 429 rmoveto
+          67 0 59 50 0 77 rrcurveto
+          0 79 -59 50 -67 0 rrcurveto
+          -67 0 -58 -50 0 -79 rrcurveto
+          0 -77 58 -50 67 0 rrcurveto
+          0 46 rmoveto
+          -44 0 -31 34 0 47 rrcurveto
+          0 48 31 35 44 0 rrcurveto
+          44 0 31 -35 0 -48 rrcurveto
+          0 -47 -31 -34 -44 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="dieresis">
+          -18 175 587 rmoveto
+          28 0 21 22 0 28 rrcurveto
+          0 28 -21 22 -28 0 rrcurveto
+          -29 0 -21 -22 0 -28 rrcurveto
+          0 -28 21 -22 29 0 rrcurveto
+          192 0 rmoveto
+          29 0 21 22 0 28 rrcurveto
+          0 28 -21 22 -29 0 rrcurveto
+          -28 0 -21 -22 0 -28 rrcurveto
+          0 -28 21 -22 28 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="divide">
+          -63 34 299 rmoveto
+          429 0 rlineto
+          0 62 rlineto
+          -429 0 rlineto
+          215 -266 rmoveto
+          30 0 24 23 0 32 rrcurveto
+          0 31 -24 22 -30 0 rrcurveto
+          -31 0 -24 -22 0 -31 rrcurveto
+          0 -32 24 -23 31 0 rrcurveto
+          0 360 rmoveto
+          30 0 24 23 0 32 rrcurveto
+          0 31 -24 22 -30 0 rrcurveto
+          -31 0 -24 -22 0 -31 rrcurveto
+          0 -32 24 -23 31 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="dollar">
+          -63 222 -110 rmoveto
+          61 0 rlineto
+          0 101 rlineto
+          94 14 60 69 0 97 rrcurveto
+          0 190 -279 -5 0 129 rrcurveto
+          0 57 39 39 60 0 rrcurveto
+          54 0 37 -20 32 -35 rrcurveto
+          45 45 rlineto
+          -34 41 -45 30 -63 7 rrcurveto
+          0 99 rlineto
+          -61 0 rlineto
+          0 -101 rlineto
+          -87 -13 -58 -64 0 -89 rrcurveto
+          0 -179 279 3 0 -140 rrcurveto
+          0 -65 -37 -43 -74 0 rrcurveto
+          -61 0 -51 24 -42 39 rrcurveto
+          -39 -51 rlineto
+          40 -46 62 -29 68 -5 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="e">
+          -64 278 -12 rmoveto
+          67 0 52 20 42 30 rrcurveto
+          -29 53 rlineto
+          -34 -23 -41 -13 -47 0 rrcurveto
+          -92 0 -61 66 -7 100 rrcurveto
+          327 0 rlineto
+          3 16 1 15 0 18 rrcurveto
+          0 140 -71 88 -124 0 rrcurveto
+          -111 0 -107 -97 0 -158 rrcurveto
+          0 -161 102 -94 130 0 rrcurveto
+          -150 297 rmoveto
+          10 93 60 54 68 0 rrcurveto
+          74 0 45 -51 0 -96 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="e.sups">
+          -224 186 386 rmoveto
+          44 0 37 16 31 21 rrcurveto
+          -22 39 rlineto
+          -22 -15 -30 -11 -31 0 rrcurveto
+          -59 0 -41 40 -3 63 rrcurveto
+          216 0 rlineto
+          3 14 1 9 0 15 rrcurveto
+          0 63 -31 84 -101 0 rrcurveto
+          -81 0 -69 -65 0 -103 rrcurveto
+          0 -108 70 -62 88 0 rrcurveto
+          -96 198 rmoveto
+          7 55 33 35 49 0 rrcurveto
+          56 0 19 -48 0 -42 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="eacute">
+          -64 278 -12 rmoveto
+          67 0 52 20 42 30 rrcurveto
+          -29 53 rlineto
+          -34 -23 -41 -13 -47 0 rrcurveto
+          -92 0 -61 66 -7 100 rrcurveto
+          327 0 rlineto
+          3 16 1 15 0 18 rrcurveto
+          0 140 -71 88 -124 0 rrcurveto
+          -111 0 -107 -97 0 -158 rrcurveto
+          0 -161 102 -94 130 0 rrcurveto
+          -150 297 rmoveto
+          10 93 60 54 68 0 rrcurveto
+          74 0 45 -51 0 -96 rrcurveto
+          -164 288 rmoveto
+          179 153 rlineto
+          -51 55 rlineto
+          -170 -166 rlineto
+          endchar
+        </CharString>
+        <CharString name="eacute.sups">
+          -224 139 766 rmoveto
+          131 110 rlineto
+          -39 40 rlineto
+          -123 -119 rlineto
+          78 -411 rmoveto
+          44 0 37 16 31 21 rrcurveto
+          -22 39 rlineto
+          -22 -15 -30 -11 -31 0 rrcurveto
+          -59 0 -41 40 -3 63 rrcurveto
+          216 0 rlineto
+          3 14 1 9 0 15 rrcurveto
+          0 63 -31 84 -101 0 rrcurveto
+          -81 0 -69 -65 0 -103 rrcurveto
+          0 -108 70 -62 88 0 rrcurveto
+          -96 198 rmoveto
+          7 55 33 35 49 0 rrcurveto
+          56 0 19 -48 0 -42 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="ecircumflex">
+          -64 278 -12 rmoveto
+          67 0 52 20 42 30 rrcurveto
+          -29 53 rlineto
+          -34 -23 -41 -13 -47 0 rrcurveto
+          -92 0 -61 66 -7 100 rrcurveto
+          327 0 rlineto
+          3 16 1 15 0 18 rrcurveto
+          0 140 -71 88 -124 0 rrcurveto
+          -111 0 -107 -97 0 -158 rrcurveto
+          0 -161 102 -94 130 0 rrcurveto
+          -150 297 rmoveto
+          10 93 60 54 68 0 rrcurveto
+          74 0 45 -51 0 -96 rrcurveto
+          -241 283 rmoveto
+          118 113 rlineto
+          4 0 rlineto
+          118 -113 rlineto
+          35 32 rlineto
+          -113 140 rlineto
+          -84 0 rlineto
+          -113 -140 rlineto
+          endchar
+        </CharString>
+        <CharString name="edieresis">
+          -64 278 -12 rmoveto
+          67 0 52 20 42 30 rrcurveto
+          -29 53 rlineto
+          -34 -23 -41 -13 -47 0 rrcurveto
+          -92 0 -61 66 -7 100 rrcurveto
+          327 0 rlineto
+          3 16 1 15 0 18 rrcurveto
+          0 140 -71 88 -124 0 rrcurveto
+          -111 0 -107 -97 0 -158 rrcurveto
+          0 -161 102 -94 130 0 rrcurveto
+          -150 297 rmoveto
+          10 93 60 54 68 0 rrcurveto
+          74 0 45 -51 0 -96 rrcurveto
+          -217 302 rmoveto
+          28 0 21 22 0 28 rrcurveto
+          0 28 -21 22 -28 0 rrcurveto
+          -29 0 -21 -22 0 -28 rrcurveto
+          0 -28 21 -22 29 0 rrcurveto
+          192 0 rmoveto
+          29 0 21 22 0 28 rrcurveto
+          0 28 -21 22 -29 0 rrcurveto
+          -28 0 -21 -22 0 -28 rrcurveto
+          0 -28 21 -22 28 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="egrave">
+          -64 278 -12 rmoveto
+          67 0 52 20 42 30 rrcurveto
+          -29 53 rlineto
+          -34 -23 -41 -13 -47 0 rrcurveto
+          -92 0 -61 66 -7 100 rrcurveto
+          327 0 rlineto
+          3 16 1 15 0 18 rrcurveto
+          0 140 -71 88 -124 0 rrcurveto
+          -111 0 -107 -97 0 -158 rrcurveto
+          0 -161 102 -94 130 0 rrcurveto
+          -150 297 rmoveto
+          10 93 60 54 68 0 rrcurveto
+          74 0 45 -51 0 -96 rrcurveto
+          -78 288 rmoveto
+          42 42 rlineto
+          -170 166 rlineto
+          -51 -55 rlineto
+          endchar
+        </CharString>
+        <CharString name="egrave.sups">
+          -224 211 766 rmoveto
+          31 31 rlineto
+          -123 119 rlineto
+          -39 -40 rlineto
+          106 -491 rmoveto
+          44 0 37 16 31 21 rrcurveto
+          -22 39 rlineto
+          -22 -15 -30 -11 -31 0 rrcurveto
+          -59 0 -41 40 -3 63 rrcurveto
+          216 0 rlineto
+          3 14 1 9 0 15 rrcurveto
+          0 63 -31 84 -101 0 rrcurveto
+          -81 0 -69 -65 0 -103 rrcurveto
+          0 -108 70 -62 88 0 rrcurveto
+          -96 198 rmoveto
+          7 55 33 35 49 0 rrcurveto
+          56 0 19 -48 0 -42 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="eight">
+          -63 250 -12 rmoveto
+          124 0 82 75 0 95 rrcurveto
+          0 86 -54 45 -57 33 rrcurveto
+          0 4 rlineto
+          40 30 48 57 0 67 rrcurveto
+          0 99 -69 71 -111 0 rrcurveto
+          -103 0 -78 -66 0 -98 rrcurveto
+          0 -67 42 -47 47 -33 rrcurveto
+          0 -4 rlineto
+          -60 -32 -60 -57 0 -83 rrcurveto
+          0 -101 89 -74 120 0 rrcurveto
+          45 360 rmoveto
+          -77 30 -70 32 0 76 rrcurveto
+          0 62 44 40 59 0 rrcurveto
+          70 0 41 -50 0 -62 rrcurveto
+          0 -47 -24 -43 -43 -38 rrcurveto
+          -43 -298 rmoveto
+          -78 0 -58 51 0 70 rrcurveto
+          0 58 38 47 50 33 rrcurveto
+          92 -37 81 -29 0 -82 rrcurveto
+          0 -66 -51 -45 -74 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="eight.dnom">
+          -193 182 -12 rmoveto
+          79 0 59 49 0 63 rrcurveto
+          0 47 -28 31 -44 23 rrcurveto
+          0 4 rlineto
+          26 18 33 31 0 45 rrcurveto
+          0 63 -55 40 -70 0 rrcurveto
+          -67 0 -54 -41 0 -62 rrcurveto
+          0 -41 24 -26 34 -22 rrcurveto
+          0 -4 rlineto
+          -38 -22 -36 -38 0 -49 rrcurveto
+          0 -59 55 -50 82 0 rrcurveto
+          23 235 rmoveto
+          -47 15 -38 20 0 40 rrcurveto
+          0 32 28 23 34 0 rrcurveto
+          36 0 29 -22 0 -34 rrcurveto
+          0 -26 -13 -26 -29 -22 rrcurveto
+          -23 -188 rmoveto
+          -46 0 -31 33 0 35 rrcurveto
+          0 32 19 28 35 21 rrcurveto
+          53 -22 48 -12 0 -48 rrcurveto
+          0 -37 -35 -30 -43 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="eight.numr">
+          -193 182 254 rmoveto
+          79 0 59 49 0 63 rrcurveto
+          0 47 -28 31 -44 23 rrcurveto
+          0 4 rlineto
+          26 18 33 31 0 45 rrcurveto
+          0 63 -55 40 -70 0 rrcurveto
+          -67 0 -54 -41 0 -62 rrcurveto
+          0 -41 24 -26 34 -22 rrcurveto
+          0 -4 rlineto
+          -38 -22 -36 -38 0 -49 rrcurveto
+          0 -59 55 -50 82 0 rrcurveto
+          23 235 rmoveto
+          -47 15 -38 20 0 40 rrcurveto
+          0 32 28 23 34 0 rrcurveto
+          36 0 29 -22 0 -34 rrcurveto
+          0 -26 -13 -26 -29 -22 rrcurveto
+          -23 -188 rmoveto
+          -46 0 -31 33 0 35 rrcurveto
+          0 32 19 28 35 21 rrcurveto
+          53 -22 48 -12 0 -48 rrcurveto
+          0 -37 -35 -30 -43 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="eight.sups">
+          -193 182 382 rmoveto
+          79 0 59 49 0 63 rrcurveto
+          0 47 -28 31 -44 23 rrcurveto
+          0 4 rlineto
+          26 18 33 31 0 45 rrcurveto
+          0 63 -55 40 -70 0 rrcurveto
+          -67 0 -54 -41 0 -62 rrcurveto
+          0 -41 24 -26 34 -22 rrcurveto
+          0 -4 rlineto
+          -38 -22 -36 -38 0 -49 rrcurveto
+          0 -59 55 -50 82 0 rrcurveto
+          23 235 rmoveto
+          -47 15 -38 20 0 40 rrcurveto
+          0 32 28 23 34 0 rrcurveto
+          36 0 29 -22 0 -34 rrcurveto
+          0 -26 -13 -26 -29 -22 rrcurveto
+          -23 -188 rmoveto
+          -46 0 -31 33 0 35 rrcurveto
+          0 32 19 28 35 21 rrcurveto
+          53 -22 48 -12 0 -48 rrcurveto
+          0 -37 -35 -30 -43 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="equal">
+          -63 34 406 rmoveto
+          429 0 rlineto
+          0 62 rlineto
+          -429 0 rlineto
+          0 -276 rmoveto
+          429 0 rlineto
+          0 62 rlineto
+          -429 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="equal.sups">
+          -193 30 651 rmoveto
+          307 0 rlineto
+          0 53 rlineto
+          -307 0 rlineto
+          0 -221 rmoveto
+          307 0 rlineto
+          0 53 rlineto
+          -307 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="eth">
+          -15 131 222 rmoveto
+          0 92 51 68 89 0 rrcurveto
+          45 0 44 -14 43 -57 rrcurveto
+          1 -18 1 -19 0 -20 rrcurveto
+          0 -117 -45 -80 -89 0 rrcurveto
+          -76 0 -64 65 0 100 rrcurveto
+          138 -234 rmoveto
+          130 0 86 109 0 160 rrcurveto
+          0 157 -56 110 -80 81 rrcurveto
+          129 66 rlineto
+          -24 41 rlineto
+          -142 -73 rlineto
+          -43 36 -47 29 -48 26 rrcurveto
+          -37 -52 rlineto
+          41 -22 37 -24 33 -26 rrcurveto
+          -127 -65 rlineto
+          24 -42 rlineto
+          142 73 rlineto
+          50 -49 36 -60 19 -80 rrcurveto
+          -34 44 -49 20 -50 0 rrcurveto
+          -116 0 -90 -89 0 -136 rrcurveto
+          0 -145 103 -89 113 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="exclam">
+          -270 116 199 rmoveto
+          57 0 rlineto
+          12 377 rlineto
+          2 94 rlineto
+          -84 0 rlineto
+          2 -94 rlineto
+          40 -588 rmoveto
+          33 0 27 26 0 37 rrcurveto
+          0 38 -27 26 -33 0 rrcurveto
+          -33 0 -27 -26 0 -38 rrcurveto
+          0 -37 27 -26 33 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="exclamdown">
+          -270 103 -184 rmoveto
+          84 0 rlineto
+          -2 94 rlineto
+          -12 377 rlineto
+          -57 0 rlineto
+          -11 -377 rlineto
+          40 462 rmoveto
+          33 0 27 26 0 38 rrcurveto
+          0 36 -27 26 -33 0 rrcurveto
+          -33 0 -27 -26 0 -36 rrcurveto
+          0 -38 27 -26 33 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="f">
+          -268 96 0 rmoveto
+          83 0 rlineto
+          0 419 rlineto
+          102 0 rlineto
+          0 67 rlineto
+          -102 0 rlineto
+          0 76 rlineto
+          0 62 22 33 46 0 rrcurveto
+          17 0 18 -4 19 -6 rrcurveto
+          18 61 rlineto
+          -20 9 -31 7 -30 0 rrcurveto
+          -97 0 -45 -63 0 -99 rrcurveto
+          0 -76 rlineto
+          -66 -5 rlineto
+          0 -62 rlineto
+          66 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="f.sups">
+          -359 64 394 rmoveto
+          63 0 rlineto
+          0 273 rlineto
+          68 0 rlineto
+          0 49 rlineto
+          -68 0 rlineto
+          0 46 rlineto
+          0 38 15 23 29 0 rrcurveto
+          15 0 12 -3 10 -3 rrcurveto
+          13 46 rlineto
+          -17 8 -18 3 -22 0 rrcurveto
+          -69 0 -31 -50 0 -66 rrcurveto
+          0 -42 rlineto
+          -45 -2 rlineto
+          0 -47 rlineto
+          45 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="f_f">
+          18 381 0 rmoveto
+          83 0 rlineto
+          0 419 rlineto
+          103 0 rlineto
+          0 67 rlineto
+          -103 0 rlineto
+          0 76 rlineto
+          0 63 23 32 45 0 rrcurveto
+          18 0 19 -4 18 -9 rrcurveto
+          18 64 rlineto
+          -22 9 -29 7 -30 0 rrcurveto
+          -98 0 -45 -63 0 -99 rrcurveto
+          0 -76 rlineto
+          -202 0 rlineto
+          0 62 rlineto
+          0 64 27 35 48 0 rrcurveto
+          25 0 19 -4 21 -10 rrcurveto
+          18 63 rlineto
+          -25 11 -32 7 -33 0 rrcurveto
+          -101 0 -50 -63 0 -101 rrcurveto
+          0 -64 rlineto
+          -66 -5 rlineto
+          0 -62 rlineto
+          66 0 rlineto
+          0 -419 rlineto
+          83 0 rlineto
+          0 419 rlineto
+          202 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="f_f_t">
+          321 381 0 rmoveto
+          83 0 rlineto
+          0 419 rlineto
+          174 0 rlineto
+          0 -268 rlineto
+          0 -97 35 -66 104 0 rrcurveto
+          31 0 32 9 28 9 rrcurveto
+          -16 63 rlineto
+          -16 -7 -22 -6 -18 0 rrcurveto
+          -55 0 -20 34 0 59 rrcurveto
+          0 270 rlineto
+          132 0 rlineto
+          0 67 rlineto
+          -132 0 rlineto
+          0 136 rlineto
+          -69 0 rlineto
+          -10 -136 rlineto
+          -178 0 rlineto
+          0 76 rlineto
+          0 63 23 32 45 0 rrcurveto
+          18 0 19 -4 18 -9 rrcurveto
+          18 64 rlineto
+          -22 9 -29 7 -30 0 rrcurveto
+          -98 0 -45 -63 0 -99 rrcurveto
+          0 -76 rlineto
+          -202 0 rlineto
+          0 62 rlineto
+          0 64 27 35 48 0 rrcurveto
+          25 0 19 -4 21 -10 rrcurveto
+          18 63 rlineto
+          -25 11 -32 7 -33 0 rrcurveto
+          -101 0 -50 -63 0 -101 rrcurveto
+          0 -64 rlineto
+          -66 -5 rlineto
+          0 -62 rlineto
+          66 0 rlineto
+          0 -419 rlineto
+          83 0 rlineto
+          0 419 rlineto
+          202 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="f_t">
+          35 96 0 rmoveto
+          83 0 rlineto
+          0 419 rlineto
+          174 0 rlineto
+          0 -268 rlineto
+          0 -97 35 -66 104 0 rrcurveto
+          30 0 33 9 27 9 rrcurveto
+          -16 63 rlineto
+          -16 -7 -22 -6 -17 0 rrcurveto
+          -56 0 -19 34 0 59 rrcurveto
+          0 270 rlineto
+          131 0 rlineto
+          0 67 rlineto
+          -131 0 rlineto
+          0 136 rlineto
+          -70 0 rlineto
+          -10 -136 rlineto
+          -177 0 rlineto
+          0 76 rlineto
+          0 63 22 32 46 0 rrcurveto
+          17 0 19 -4 19 -9 rrcurveto
+          17 64 rlineto
+          -22 9 -29 7 -30 0 rrcurveto
+          -97 0 -45 -63 0 -99 rrcurveto
+          0 -76 rlineto
+          -66 -5 rlineto
+          0 -62 rlineto
+          66 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="five">
+          -63 234 -12 rmoveto
+          111 0 104 78 0 138 rrcurveto
+          0 138 -89 62 -108 0 rrcurveto
+          -39 0 -29 -10 -30 -16 rrcurveto
+          17 188 rlineto
+          247 0 rlineto
+          0 72 rlineto
+          -320 0 rlineto
+          -21 -307 rlineto
+          44 -28 rlineto
+          38 25 27 13 44 0 rrcurveto
+          82 0 53 -51 0 -88 rrcurveto
+          0 -89 -61 -56 -78 0 rrcurveto
+          -75 0 -48 35 -38 38 rrcurveto
+          -40 -55 rlineto
+          44 -44 63 -43 102 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="five.dnom">
+          -193 183 -12 rmoveto
+          79 0 61 55 0 80 rrcurveto
+          0 84 -57 47 -71 0 rrcurveto
+          -22 0 -22 -7 -18 -8 rrcurveto
+          10 95 rlineto
+          160 0 rlineto
+          0 56 rlineto
+          -213 0 rlineto
+          -18 -188 rlineto
+          31 -23 rlineto
+          21 18 22 14 31 0 rrcurveto
+          47 0 34 -33 0 -53 rrcurveto
+          0 -49 -33 -37 -46 0 rrcurveto
+          -45 0 -31 22 -25 36 rrcurveto
+          -43 -33 rlineto
+          31 -44 48 -32 69 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="five.numr">
+          -193 183 254 rmoveto
+          79 0 61 55 0 80 rrcurveto
+          0 84 -57 47 -71 0 rrcurveto
+          -22 0 -22 -7 -18 -8 rrcurveto
+          10 95 rlineto
+          160 0 rlineto
+          0 56 rlineto
+          -213 0 rlineto
+          -18 -188 rlineto
+          31 -23 rlineto
+          21 18 22 14 31 0 rrcurveto
+          47 0 34 -33 0 -53 rrcurveto
+          0 -49 -33 -37 -46 0 rrcurveto
+          -45 0 -31 22 -25 36 rrcurveto
+          -43 -33 rlineto
+          31 -44 48 -32 69 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="five.sups">
+          -193 183 382 rmoveto
+          79 0 61 55 0 80 rrcurveto
+          0 84 -57 47 -71 0 rrcurveto
+          -22 0 -22 -7 -18 -8 rrcurveto
+          10 95 rlineto
+          160 0 rlineto
+          0 56 rlineto
+          -213 0 rlineto
+          -18 -188 rlineto
+          31 -23 rlineto
+          21 18 22 14 31 0 rrcurveto
+          47 0 34 -33 0 -53 rrcurveto
+          0 -49 -33 -37 -46 0 rrcurveto
+          -45 0 -31 22 -25 36 rrcurveto
+          -43 -33 rlineto
+          31 -44 48 -32 69 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="four">
+          -63 104 242 rmoveto
+          149 217 rlineto
+          18 32 18 28 16 30 rrcurveto
+          4 0 rlineto
+          -2 -34 -3 -55 0 -33 rrcurveto
+          0 -185 rlineto
+          0 -242 rmoveto
+          78 0 rlineto
+          0 176 rlineto
+          87 0 rlineto
+          0 66 rlineto
+          -87 0 rlineto
+          0 396 rlineto
+          -92 0 rlineto
+          -273 -407 rlineto
+          0 -55 rlineto
+          287 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="four.dnom">
+          -193 109 150 rmoveto
+          61 98 rlineto
+          50 81 rlineto
+          4 0 rlineto
+          -4 -109 rlineto
+          0 -70 rlineto
+          0 -150 rmoveto
+          58 0 rlineto
+          0 104 rlineto
+          58 0 rlineto
+          0 46 rlineto
+          -58 0 rlineto
+          0 240 rlineto
+          -73 0 rlineto
+          -163 -253 rlineto
+          0 -33 rlineto
+          178 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="four.numr">
+          -193 109 416 rmoveto
+          61 98 rlineto
+          50 81 rlineto
+          4 0 rlineto
+          -4 -109 rlineto
+          0 -70 rlineto
+          0 -150 rmoveto
+          58 0 rlineto
+          0 104 rlineto
+          58 0 rlineto
+          0 46 rlineto
+          -58 0 rlineto
+          0 240 rlineto
+          -73 0 rlineto
+          -163 -253 rlineto
+          0 -33 rlineto
+          178 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="four.sups">
+          -193 109 544 rmoveto
+          61 98 rlineto
+          50 81 rlineto
+          4 0 rlineto
+          -4 -109 rlineto
+          0 -70 rlineto
+          0 -150 rmoveto
+          58 0 rlineto
+          0 104 rlineto
+          58 0 rlineto
+          0 46 rlineto
+          -58 0 rlineto
+          0 240 rlineto
+          -73 0 rlineto
+          -163 -253 rlineto
+          0 -33 rlineto
+          178 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="g">
+          -55 246 -224 rmoveto
+          151 0 95 78 0 91 rrcurveto
+          0 80 -57 36 -113 0 rrcurveto
+          -94 0 rlineto
+          -65 0 -20 22 0 30 rrcurveto
+          0 27 13 16 18 15 rrcurveto
+          22 -11 26 -6 24 0 rrcurveto
+          99 0 79 65 0 104 rrcurveto
+          0 41 -16 36 -23 22 rrcurveto
+          99 0 rlineto
+          0 64 rlineto
+          -169 0 rlineto
+          -18 7 -24 5 -27 0 rrcurveto
+          -99 0 -84 -67 0 -106 rrcurveto
+          0 -58 31 -47 32 -26 rrcurveto
+          0 -4 rlineto
+          -25 -17 -28 -32 0 -41 rrcurveto
+          0 -38 19 -26 24 -15 rrcurveto
+          0 -4 rlineto
+          -44 -30 -27 -39 0 -41 rrcurveto
+          0 -84 82 -47 119 0 rrcurveto
+          0 434 rmoveto
+          -56 0 -47 44 0 71 rrcurveto
+          0 71 46 42 57 0 rrcurveto
+          57 0 46 -43 0 -70 rrcurveto
+          0 -71 -47 -44 -56 0 rrcurveto
+          12 -376 rmoveto
+          -88 0 -53 32 0 52 rrcurveto
+          0 28 15 29 35 25 rrcurveto
+          21 -6 23 -2 19 0 rrcurveto
+          83 0 rlineto
+          64 0 34 -15 0 -45 rrcurveto
+          0 -50 -61 -48 -92 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="g.sups">
+          -217 164 248 rmoveto
+          104 0 64 52 0 60 rrcurveto
+          0 56 -37 23 -78 0 rrcurveto
+          -62 0 rlineto
+          -41 0 -15 11 0 21 rrcurveto
+          0 15 8 10 11 9 rrcurveto
+          16 -8 17 -2 15 0 rrcurveto
+          67 0 55 42 0 70 rrcurveto
+          0 23 -10 24 -13 13 rrcurveto
+          62 0 rlineto
+          0 48 rlineto
+          -110 0 rlineto
+          -15 6 -16 3 -20 0 rrcurveto
+          -68 0 -58 -43 0 -72 rrcurveto
+          0 -38 21 -31 22 -17 rrcurveto
+          0 -4 rlineto
+          -18 -12 -18 -21 0 -25 rrcurveto
+          0 -25 12 -18 17 -10 rrcurveto
+          0 -4 rlineto
+          -30 -18 -16 -24 0 -28 rrcurveto
+          0 -56 54 -30 80 0 rrcurveto
+          2 289 rmoveto
+          -39 0 -28 28 0 44 rrcurveto
+          0 45 28 25 39 0 rrcurveto
+          36 0 30 -26 0 -44 rrcurveto
+          0 -44 -30 -28 -36 0 rrcurveto
+          8 -246 rmoveto
+          -57 0 -34 19 0 33 rrcurveto
+          0 18 11 16 20 14 rrcurveto
+          14 -4 17 0 11 0 rrcurveto
+          53 0 rlineto
+          40 0 23 -9 0 -27 rrcurveto
+          0 -31 -40 -29 -58 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="germandbls">
+          16 388 -12 rmoveto
+          98 0 62 65 0 84 rrcurveto
+          0 162 -185 -22 0 97 rrcurveto
+          0 69 99 33 0 100 rrcurveto
+          0 79 -65 67 -109 0 rrcurveto
+          -129 0 -77 -82 0 -125 rrcurveto
+          0 -515 rlineto
+          82 0 rlineto
+          0 499 rlineto
+          0 103 49 53 74 0 rrcurveto
+          58 0 35 -38 0 -50 rrcurveto
+          0 -84 -96 -29 0 -90 rrcurveto
+          0 -139 185 23 0 -116 rrcurveto
+          0 -42 -29 -37 -55 0 rrcurveto
+          -38 0 -33 11 -35 29 rrcurveto
+          -33 -56 rlineto
+          41 -33 46 -16 55 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="grave">
+          -18 314 573 rmoveto
+          42 42 rlineto
+          -170 166 rlineto
+          -51 -55 rlineto
+          endchar
+        </CharString>
+        <CharString name="greater">
+          -63 34 130 rmoveto
+          429 169 rlineto
+          0 66 rlineto
+          -429 169 rlineto
+          0 -73 rlineto
+          211 -77 rlineto
+          133 -50 rlineto
+          0 -4 rlineto
+          -133 -50 rlineto
+          -211 -77 rlineto
+          endchar
+        </CharString>
+        <CharString name="guillemotleft">
+          -130 181 66 rmoveto
+          36 28 rlineto
+          -118 158 rlineto
+          118 156 rlineto
+          -36 30 rlineto
+          -136 -155 rlineto
+          0 -62 rlineto
+          295 -155 rmoveto
+          36 28 rlineto
+          -118 158 rlineto
+          118 156 rlineto
+          -36 30 rlineto
+          -136 -155 rlineto
+          0 -62 rlineto
+          endchar
+        </CharString>
+        <CharString name="guillemotright">
+          -130 90 66 rmoveto
+          136 155 rlineto
+          0 62 rlineto
+          -136 155 rlineto
+          -36 -30 rlineto
+          118 -156 rlineto
+          -118 -158 rlineto
+          195 -28 rmoveto
+          136 155 rlineto
+          0 62 rlineto
+          -136 155 rlineto
+          -36 -30 rlineto
+          118 -156 rlineto
+          -118 -158 rlineto
+          endchar
+        </CharString>
+        <CharString name="h">
+          -16 82 0 rmoveto
+          83 0 rlineto
+          0 352 rlineto
+          48 49 35 25 49 0 rrcurveto
+          64 0 28 -38 0 -91 rrcurveto
+          0 -297 rlineto
+          83 0 rlineto
+          0 308 rlineto
+          0 124 -46 66 -103 0 rrcurveto
+          -67 0 -49 -36 -45 -44 rrcurveto
+          3 100 rlineto
+          0 194 rlineto
+          -83 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="h.sups">
+          -193 52 394 rmoveto
+          62 0 rlineto
+          0 230 rlineto
+          32 32 26 15 26 0 rrcurveto
+          50 0 11 -31 0 -51 rrcurveto
+          0 -195 rlineto
+          62 0 rlineto
+          0 204 rlineto
+          0 75 -26 51 -76 0 rrcurveto
+          -43 0 -38 -25 -27 -28 rrcurveto
+          3 67 rlineto
+          0 125 rlineto
+          -62 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="hyphen">
+          -249 41 219 rmoveto
+          230 0 rlineto
+          0 64 rlineto
+          -230 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="hyphen.sups">
+          -324 41 549 rmoveto
+          156 0 rlineto
+          0 45 rlineto
+          -156 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="i">
+          -313 82 0 rmoveto
+          83 0 rlineto
+          0 486 rlineto
+          -83 0 rlineto
+          42 100 rmoveto
+          32 0 23 21 0 33 rrcurveto
+          0 32 -23 22 -32 0 rrcurveto
+          -32 0 -23 -22 0 -32 rrcurveto
+          0 -33 23 -21 32 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="i.sups">
+          -394 52 394 rmoveto
+          62 0 rlineto
+          0 322 rlineto
+          -62 0 rlineto
+          32 62 rmoveto
+          24 0 18 17 0 22 rrcurveto
+          0 23 -18 17 -24 0 rrcurveto
+          -24 0 -18 -17 0 -23 rrcurveto
+          0 -22 18 -17 24 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="iacute">
+          -313 82 0 rmoveto
+          83 0 rlineto
+          0 486 rlineto
+          -83 0 rlineto
+          -1 87 rmoveto
+          179 153 rlineto
+          -51 55 rlineto
+          -170 -166 rlineto
+          endchar
+        </CharString>
+        <CharString name="icircumflex">
+          -313 82 0 rmoveto
+          83 0 rlineto
+          0 486 rlineto
+          -83 0 rlineto
+          -78 82 rmoveto
+          118 113 rlineto
+          4 0 rlineto
+          118 -113 rlineto
+          35 32 rlineto
+          -113 140 rlineto
+          -84 0 rlineto
+          -113 -140 rlineto
+          endchar
+        </CharString>
+        <CharString name="idieresis">
+          -313 82 0 rmoveto
+          83 0 rlineto
+          0 486 rlineto
+          -83 0 rlineto
+          -54 101 rmoveto
+          28 0 21 22 0 28 rrcurveto
+          0 28 -21 22 -28 0 rrcurveto
+          -29 0 -21 -22 0 -28 rrcurveto
+          0 -28 21 -22 29 0 rrcurveto
+          192 0 rmoveto
+          29 0 21 22 0 28 rrcurveto
+          0 28 -21 22 -29 0 rrcurveto
+          -28 0 -21 -22 0 -28 rrcurveto
+          0 -28 21 -22 28 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="igrave">
+          -313 82 0 rmoveto
+          83 0 rlineto
+          0 486 rlineto
+          -83 0 rlineto
+          85 87 rmoveto
+          42 42 rlineto
+          -170 166 rlineto
+          -51 -55 rlineto
+          endchar
+        </CharString>
+        <CharString name="j">
+          -313 32 -217 rmoveto
+          97 0 37 63 0 100 rrcurveto
+          0 540 rlineto
+          -83 0 rlineto
+          0 -540 rlineto
+          0 -59 -12 -36 -48 0 rrcurveto
+          -16 0 -18 4 -12 4 rrcurveto
+          -17 -62 rlineto
+          17 -8 26 -6 29 0 rrcurveto
+          91 803 rmoveto
+          32 0 23 21 0 33 rrcurveto
+          0 32 -23 22 -32 0 rrcurveto
+          -32 0 -23 -22 0 -32 rrcurveto
+          0 -33 23 -21 32 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="j.sups">
+          -391 23 250 rmoveto
+          67 0 26 43 0 72 rrcurveto
+          0 351 rlineto
+          -62 0 rlineto
+          0 -355 rlineto
+          0 -39 -8 -20 -31 0 rrcurveto
+          -13 0 -7 2 -8 3 rrcurveto
+          -13 -49 rlineto
+          15 -5 12 -3 22 0 rrcurveto
+          63 528 rmoveto
+          24 0 18 17 0 22 rrcurveto
+          0 23 -18 17 -24 0 rrcurveto
+          -24 0 -18 -17 0 -23 rrcurveto
+          0 -22 18 -17 24 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="k">
+          -65 82 0 rmoveto
+          82 0 rlineto
+          0 128 rlineto
+          90 105 rlineto
+          142 -233 rlineto
+          90 0 rlineto
+          -183 290 rlineto
+          162 196 rlineto
+          -93 0 rlineto
+          -205 -254 rlineto
+          -3 0 rlineto
+          0 480 rlineto
+          -82 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="k.sups">
+          -222 52 394 rmoveto
+          62 0 rlineto
+          0 82 rlineto
+          56 66 rlineto
+          93 -148 rlineto
+          69 0 rlineto
+          -125 190 rlineto
+          112 132 rlineto
+          -70 0 rlineto
+          -131 -160 rlineto
+          -4 0 rlineto
+          0 307 rlineto
+          -62 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="l">
+          -305 169 -12 rmoveto
+          21 0 15 3 12 6 rrcurveto
+          -11 62 rlineto
+          -8 -2 -4 0 -5 0 rrcurveto
+          -13 0 -11 9 0 26 rrcurveto
+          0 620 rlineto
+          -83 0 rlineto
+          0 -614 rlineto
+          0 -70 25 -40 62 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="l.sups">
+          -386 118 386 rmoveto
+          16 0 10 3 9 4 rrcurveto
+          -9 47 rlineto
+          -6 -2 -3 0 -4 0 rrcurveto
+          -10 0 -7 6 0 19 rrcurveto
+          0 400 rlineto
+          -62 0 rlineto
+          0 -395 rlineto
+          0 -51 17 -31 49 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="less">
+          -63 463 130 rmoveto
+          0 73 rlineto
+          -210 77 rlineto
+          -134 50 rlineto
+          0 4 rlineto
+          134 50 rlineto
+          210 77 rlineto
+          0 73 rlineto
+          -429 -169 rlineto
+          0 -66 rlineto
+          endchar
+        </CharString>
+        <CharString name="logicalnot">
+          -63 397 104 rmoveto
+          66 0 rlineto
+          0 257 rlineto
+          -429 0 rlineto
+          0 -62 rlineto
+          363 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="m">
+          269 82 0 rmoveto
+          83 0 rlineto
+          0 352 rlineto
+          45 50 40 24 36 0 rrcurveto
+          62 0 28 -38 0 -91 rrcurveto
+          0 -297 rlineto
+          83 0 rlineto
+          0 352 rlineto
+          45 50 39 24 38 0 rrcurveto
+          61 0 29 -38 0 -91 rrcurveto
+          0 -297 rlineto
+          83 0 rlineto
+          0 308 rlineto
+          0 124 -48 66 -100 0 rrcurveto
+          -59 0 -51 -38 -50 -54 rrcurveto
+          -20 57 -40 35 -75 0 rrcurveto
+          -58 0 -50 -36 -43 -46 rrcurveto
+          -3 0 rlineto
+          -7 70 rlineto
+          -68 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="m.sups">
+          -1 52 394 rmoveto
+          62 0 rlineto
+          0 230 rlineto
+          31 32 23 15 23 0 rrcurveto
+          46 0 13 -31 0 -51 rrcurveto
+          0 -195 rlineto
+          63 0 rlineto
+          0 230 rlineto
+          31 32 22 15 24 0 rrcurveto
+          46 0 13 -31 0 -51 rrcurveto
+          0 -195 rlineto
+          62 0 rlineto
+          0 204 rlineto
+          0 75 -29 51 -71 0 rrcurveto
+          -44 0 -35 -28 -30 -32 rrcurveto
+          -15 40 -30 20 -45 0 rrcurveto
+          -43 0 -31 -24 -27 -29 rrcurveto
+          -3 0 rlineto
+          -6 45 rlineto
+          -50 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="macron">
+          -18 138 601 rmoveto
+          266 0 rlineto
+          0 57 rlineto
+          -266 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="mu">
+          2 82 -179 rmoveto
+          84 0 rlineto
+          -6 77 -1 43 0 96 rrcurveto
+          22 -38 32 -9 39 0 rrcurveto
+          53 0 47 30 35 62 rrcurveto
+          2 0 rlineto
+          7 -65 26 -29 55 0 rrcurveto
+          27 0 18 5 14 7 rrcurveto
+          -11 63 rlineto
+          -11 -4 -10 -2 -9 0 rrcurveto
+          -21 0 -14 11 0 28 rrcurveto
+          0 116 4 143 2 131 rrcurveto
+          -84 0 rlineto
+          0 -332 rlineto
+          -45 -79 -40 -15 -43 0 rrcurveto
+          -63 0 -26 44 0 85 rrcurveto
+          0 297 rlineto
+          -83 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="multiply">
+          -63 94 126 rmoveto
+          155 159 rlineto
+          154 -159 rlineto
+          44 46 rlineto
+          -154 158 rlineto
+          154 158 rlineto
+          -44 45 rlineto
+          -154 -159 rlineto
+          -155 159 rlineto
+          -44 -45 rlineto
+          154 -158 rlineto
+          -154 -158 rlineto
+          endchar
+        </CharString>
+        <CharString name="n">
+          -13 82 0 rmoveto
+          83 0 rlineto
+          0 352 rlineto
+          48 49 35 25 49 0 rrcurveto
+          64 0 28 -38 0 -91 rrcurveto
+          0 -297 rlineto
+          83 0 rlineto
+          0 308 rlineto
+          0 124 -46 66 -103 0 rrcurveto
+          -67 0 -50 -36 -46 -46 rrcurveto
+          -3 0 rlineto
+          -7 70 rlineto
+          -68 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="n.sups">
+          -191 52 394 rmoveto
+          62 0 rlineto
+          0 230 rlineto
+          32 32 26 15 27 0 rrcurveto
+          49 0 11 -31 0 -51 rrcurveto
+          0 -195 rlineto
+          62 0 rlineto
+          0 204 rlineto
+          0 75 -26 51 -76 0 rrcurveto
+          -43 0 -37 -24 -28 -29 rrcurveto
+          -3 0 rlineto
+          -7 45 rlineto
+          -49 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="nine">
+          -63 118 445 rmoveto
+          0 84 48 55 62 0 rrcurveto
+          81 0 49 -66 10 -124 rrcurveto
+          -40 -59 -51 -25 -42 0 rrcurveto
+          -78 0 -39 52 0 83 rrcurveto
+          87 -457 rmoveto
+          128 0 116 99 0 256 rrcurveto
+          0 205 -95 102 -126 0 rrcurveto
+          -102 0 -86 -83 0 -122 rrcurveto
+          0 -131 71 -66 110 0 rrcurveto
+          52 0 57 30 40 50 rrcurveto
+          -4 -202 -74 -69 -90 0 rrcurveto
+          -40 0 -39 20 -26 30 rrcurveto
+          -46 -52 rlineto
+          35 -38 51 -29 68 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="nine.dnom">
+          -193 99 271 rmoveto
+          0 47 30 33 40 0 rrcurveto
+          49 0 35 -39 6 -77 rrcurveto
+          -30 -32 -26 -11 -30 0 rrcurveto
+          -48 0 -26 33 0 46 rrcurveto
+          51 -283 rmoveto
+          96 0 74 70 0 147 rrcurveto
+          0 123 -59 74 -93 0 rrcurveto
+          -73 0 -56 -57 0 -75 rrcurveto
+          0 -74 44 -51 78 0 rrcurveto
+          37 0 33 14 28 27 rrcurveto
+          -6 -100 -47 -47 -58 0 rrcurveto
+          -27 0 -21 11 -19 13 rrcurveto
+          -27 -44 rlineto
+          23 -17 28 -14 45 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="nine.numr">
+          -193 99 537 rmoveto
+          0 47 30 33 40 0 rrcurveto
+          49 0 35 -39 6 -77 rrcurveto
+          -30 -32 -26 -11 -30 0 rrcurveto
+          -48 0 -26 33 0 46 rrcurveto
+          51 -283 rmoveto
+          96 0 74 70 0 147 rrcurveto
+          0 123 -59 74 -93 0 rrcurveto
+          -73 0 -56 -57 0 -75 rrcurveto
+          0 -74 44 -51 78 0 rrcurveto
+          37 0 33 14 28 27 rrcurveto
+          -6 -100 -47 -47 -58 0 rrcurveto
+          -27 0 -21 11 -19 13 rrcurveto
+          -27 -44 rlineto
+          23 -17 28 -14 45 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="nine.sups">
+          -193 99 665 rmoveto
+          0 47 30 33 40 0 rrcurveto
+          49 0 35 -39 6 -77 rrcurveto
+          -30 -32 -26 -11 -30 0 rrcurveto
+          -48 0 -26 33 0 46 rrcurveto
+          51 -283 rmoveto
+          96 0 74 70 0 147 rrcurveto
+          0 123 -59 74 -93 0 rrcurveto
+          -73 0 -56 -57 0 -75 rrcurveto
+          0 -74 44 -51 78 0 rrcurveto
+          37 0 33 14 28 27 rrcurveto
+          -6 -100 -47 -47 -58 0 rrcurveto
+          -27 0 -21 11 -19 13 rrcurveto
+          -27 -44 rlineto
+          23 -17 28 -14 45 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="ntilde">
+          -13 82 0 rmoveto
+          83 0 rlineto
+          0 352 rlineto
+          48 49 35 25 49 0 rrcurveto
+          64 0 28 -38 0 -91 rrcurveto
+          0 -297 rlineto
+          83 0 rlineto
+          0 308 rlineto
+          0 124 -46 66 -103 0 rrcurveto
+          -67 0 -50 -36 -46 -46 rrcurveto
+          -3 0 rlineto
+          -7 70 rlineto
+          -68 0 rlineto
+          285 91 rmoveto
+          69 0 29 58 3 77 rrcurveto
+          -55 4 rlineto
+          -3 -46 -14 -33 -29 0 rrcurveto
+          -47 0 -26 84 -71 0 rrcurveto
+          -69 0 -29 -58 -3 -78 rrcurveto
+          55 -3 rlineto
+          3 47 14 32 30 0 rrcurveto
+          46 0 26 -84 71 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="numbersign">
+          -63 88 0 rmoveto
+          59 0 rlineto
+          25 201 rlineto
+          125 0 rlineto
+          -24 -201 rlineto
+          60 0 rlineto
+          24 201 rlineto
+          92 0 rlineto
+          0 63 rlineto
+          -85 0 rlineto
+          18 143 rlineto
+          87 0 rlineto
+          0 63 rlineto
+          -81 0 rlineto
+          25 180 rlineto
+          -60 0 rlineto
+          -24 -180 rlineto
+          -125 0 rlineto
+          23 180 rlineto
+          -59 0 rlineto
+          -24 -180 rlineto
+          -90 0 rlineto
+          0 -63 rlineto
+          84 0 rlineto
+          -19 -143 rlineto
+          -85 0 rlineto
+          0 -63 rlineto
+          79 0 rlineto
+          66 63 rmoveto
+          18 143 rlineto
+          126 0 rlineto
+          -19 -143 rlineto
+          endchar
+        </CharString>
+        <CharString name="o">
+          -18 271 -12 rmoveto
+          119 0 107 93 0 161 rrcurveto
+          0 163 -107 93 -119 0 rrcurveto
+          -119 0 -106 -93 0 -163 rrcurveto
+          0 -161 106 -93 119 0 rrcurveto
+          0 69 rmoveto
+          -83 0 -56 74 0 111 rrcurveto
+          0 112 56 75 83 0 rrcurveto
+          84 0 56 -75 0 -112 rrcurveto
+          0 -111 -56 -74 -84 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="o.sups">
+          -195 182 386 rmoveto
+          82 0 70 63 0 106 rrcurveto
+          0 107 -70 62 -82 0 rrcurveto
+          -83 0 -69 -62 0 -107 rrcurveto
+          0 -106 69 -63 83 0 rrcurveto
+          0 52 rmoveto
+          -55 0 -33 48 0 69 rrcurveto
+          0 71 33 47 55 0 rrcurveto
+          55 0 33 -47 0 -71 rrcurveto
+          0 -69 -33 -48 -55 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="oacute">
+          -18 271 -12 rmoveto
+          119 0 107 93 0 161 rrcurveto
+          0 163 -107 93 -119 0 rrcurveto
+          -119 0 -106 -93 0 -163 rrcurveto
+          0 -161 106 -93 119 0 rrcurveto
+          0 69 rmoveto
+          -83 0 -56 74 0 111 rrcurveto
+          0 112 56 75 83 0 rrcurveto
+          84 0 56 -75 0 -112 rrcurveto
+          0 -111 -56 -74 -84 0 rrcurveto
+          -43 516 rmoveto
+          179 153 rlineto
+          -51 55 rlineto
+          -170 -166 rlineto
+          endchar
+        </CharString>
+        <CharString name="ocircumflex">
+          -18 271 -12 rmoveto
+          119 0 107 93 0 161 rrcurveto
+          0 163 -107 93 -119 0 rrcurveto
+          -119 0 -106 -93 0 -163 rrcurveto
+          0 -161 106 -93 119 0 rrcurveto
+          0 69 rmoveto
+          -83 0 -56 74 0 111 rrcurveto
+          0 112 56 75 83 0 rrcurveto
+          84 0 56 -75 0 -112 rrcurveto
+          0 -111 -56 -74 -84 0 rrcurveto
+          -120 511 rmoveto
+          118 113 rlineto
+          4 0 rlineto
+          118 -113 rlineto
+          35 32 rlineto
+          -113 140 rlineto
+          -84 0 rlineto
+          -113 -140 rlineto
+          endchar
+        </CharString>
+        <CharString name="odieresis">
+          -18 271 -12 rmoveto
+          119 0 107 93 0 161 rrcurveto
+          0 163 -107 93 -119 0 rrcurveto
+          -119 0 -106 -93 0 -163 rrcurveto
+          0 -161 106 -93 119 0 rrcurveto
+          0 69 rmoveto
+          -83 0 -56 74 0 111 rrcurveto
+          0 112 56 75 83 0 rrcurveto
+          84 0 56 -75 0 -112 rrcurveto
+          0 -111 -56 -74 -84 0 rrcurveto
+          -96 530 rmoveto
+          28 0 21 22 0 28 rrcurveto
+          0 28 -21 22 -28 0 rrcurveto
+          -29 0 -21 -22 0 -28 rrcurveto
+          0 -28 21 -22 29 0 rrcurveto
+          192 0 rmoveto
+          29 0 21 22 0 28 rrcurveto
+          0 28 -21 22 -29 0 rrcurveto
+          -28 0 -21 -22 0 -28 rrcurveto
+          0 -28 21 -22 28 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="ograve">
+          -18 271 -12 rmoveto
+          119 0 107 93 0 161 rrcurveto
+          0 163 -107 93 -119 0 rrcurveto
+          -119 0 -106 -93 0 -163 rrcurveto
+          0 -161 106 -93 119 0 rrcurveto
+          0 69 rmoveto
+          -83 0 -56 74 0 111 rrcurveto
+          0 112 56 75 83 0 rrcurveto
+          84 0 56 -75 0 -112 rrcurveto
+          0 -111 -56 -74 -84 0 rrcurveto
+          43 516 rmoveto
+          42 42 rlineto
+          -170 166 rlineto
+          -51 -55 rlineto
+          endchar
+        </CharString>
+        <CharString name="one">
+          -63 79 0 rmoveto
+          360 0 rlineto
+          0 69 rlineto
+          -131 0 rlineto
+          0 569 rlineto
+          -64 0 rlineto
+          -35 -21 -42 -16 -59 -10 rrcurveto
+          0 -54 rlineto
+          117 0 rlineto
+          0 -468 rlineto
+          -146 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="one.dnom">
+          -193 172 0 rmoveto
+          65 0 rlineto
+          0 390 rlineto
+          -53 0 rlineto
+          -27 -20 -26 -12 -44 -8 rrcurveto
+          0 -42 rlineto
+          85 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="one.numr">
+          -193 172 266 rmoveto
+          65 0 rlineto
+          0 390 rlineto
+          -53 0 rlineto
+          -27 -20 -26 -12 -44 -8 rrcurveto
+          0 -42 rlineto
+          85 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="one.sups">
+          -193 172 394 rmoveto
+          65 0 rlineto
+          0 390 rlineto
+          -53 0 rlineto
+          -27 -20 -26 -12 -44 -8 rrcurveto
+          0 -42 rlineto
+          85 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="onehalf">
+          249 148 266 rmoveto
+          65 0 rlineto
+          0 390 rlineto
+          -53 0 rlineto
+          -27 -20 -26 -12 -44 -8 rrcurveto
+          0 -42 rlineto
+          85 0 rlineto
+          12 -586 rmoveto
+          56 0 rlineto
+          362 680 rlineto
+          -56 0 rlineto
+          -29 -668 rmoveto
+          268 0 rlineto
+          0 55 rlineto
+          -164 0 rlineto
+          83 85 61 61 0 75 rrcurveto
+          0 82 -52 44 -78 0 rrcurveto
+          -53 0 -47 -31 -30 -45 rrcurveto
+          38 -35 rlineto
+          22 32 29 25 33 0 rrcurveto
+          46 0 29 -32 0 -50 rrcurveto
+          0 -59 -64 -61 -121 -109 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="onequarter">
+          221 148 266 rmoveto
+          65 0 rlineto
+          0 390 rlineto
+          -53 0 rlineto
+          -27 -20 -26 -12 -44 -8 rrcurveto
+          0 -42 rlineto
+          85 0 rlineto
+          32 -586 rmoveto
+          56 0 rlineto
+          362 680 rlineto
+          -56 0 rlineto
+          -19 -518 rmoveto
+          61 98 rlineto
+          50 81 rlineto
+          4 0 rlineto
+          -4 -109 rlineto
+          0 -70 rlineto
+          0 -150 rmoveto
+          58 0 rlineto
+          0 104 rlineto
+          58 0 rlineto
+          0 46 rlineto
+          -58 0 rlineto
+          0 240 rlineto
+          -73 0 rlineto
+          -163 -253 rlineto
+          0 -33 rlineto
+          178 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="ordfeminine">
+          -215 136 387 rmoveto
+          41 0 33 21 27 24 rrcurveto
+          4 0 rlineto
+          7 -37 rlineto
+          49 0 rlineto
+          0 196 rlineto
+          0 85 -34 48 -80 0 rrcurveto
+          -52 0 -48 -22 -33 -20 rrcurveto
+          23 -42 rlineto
+          27 16 39 18 35 0 rrcurveto
+          47 0 14 -31 1 -43 rrcurveto
+          -139 -12 -60 -36 0 -71 rrcurveto
+          0 -57 40 -37 59 0 rrcurveto
+          18 49 rmoveto
+          -35 0 -21 16 0 34 rrcurveto
+          0 36 35 25 103 12 rrcurveto
+          0 -83 rlineto
+          -29 -27 -26 -13 -27 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="ordmasculine">
+          -195 182 386 rmoveto
+          82 0 70 63 0 106 rrcurveto
+          0 107 -70 62 -82 0 rrcurveto
+          -83 0 -69 -62 0 -107 rrcurveto
+          0 -106 69 -63 83 0 rrcurveto
+          0 52 rmoveto
+          -55 0 -33 48 0 69 rrcurveto
+          0 71 33 47 55 0 rrcurveto
+          55 0 33 -47 0 -71 rrcurveto
+          0 -69 -33 -48 -55 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="oslash">
+          -17 126 246 rmoveto
+          0 110 61 76 84 0 rrcurveto
+          35 0 30 -12 24 -23 rrcurveto
+          -213 -259 rlineto
+          -14 30 -7 36 0 42 rrcurveto
+          -40 -275 rmoveto
+          51 62 rlineto
+          38 -29 47 -16 49 0 rrcurveto
+          119 0 106 93 0 161 rrcurveto
+          0 68 -19 56 -30 42 rrcurveto
+          56 68 rlineto
+          -46 39 rlineto
+          -52 -63 rlineto
+          -38 30 -47 16 -49 0 rrcurveto
+          -119 0 -106 -93 0 -163 rrcurveto
+          0 -68 19 -56 31 -42 rrcurveto
+          -56 -67 rlineto
+          231 44 rmoveto
+          -35 0 -30 12 -24 22 rrcurveto
+          214 259 rlineto
+          13 -29 7 -36 0 -42 rrcurveto
+          0 -111 -61 -75 -84 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="otilde">
+          -18 271 -12 rmoveto
+          119 0 107 93 0 161 rrcurveto
+          0 163 -107 93 -119 0 rrcurveto
+          -119 0 -106 -93 0 -163 rrcurveto
+          0 -161 106 -93 119 0 rrcurveto
+          0 69 rmoveto
+          -83 0 -56 74 0 111 rrcurveto
+          0 112 56 75 83 0 rrcurveto
+          84 0 56 -75 0 -112 rrcurveto
+          0 -111 -56 -74 -84 0 rrcurveto
+          72 520 rmoveto
+          69 0 29 58 3 77 rrcurveto
+          -55 4 rlineto
+          -3 -46 -14 -33 -29 0 rrcurveto
+          -47 0 -26 84 -71 0 rrcurveto
+          -69 0 -29 -58 -3 -78 rrcurveto
+          55 -3 rlineto
+          3 47 14 32 30 0 rrcurveto
+          46 0 26 -84 71 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="p">
+          -5 82 -205 rmoveto
+          83 0 rlineto
+          0 164 rlineto
+          -2 85 rlineto
+          44 -35 46 -21 44 0 rrcurveto
+          111 0 100 97 0 165 rrcurveto
+          0 151 -68 97 -125 0 rrcurveto
+          -56 0 -55 -31 -44 -37 rrcurveto
+          -3 0 rlineto
+          -7 56 rlineto
+          -68 0 rlineto
+          201 -428 rmoveto
+          -32 0 -42 13 -44 37 rrcurveto
+          0 254 rlineto
+          47 44 41 22 41 0 rrcurveto
+          91 0 37 -71 0 -107 rrcurveto
+          0 -120 -59 -72 -80 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="p.sups">
+          -186 52 257 rmoveto
+          62 0 rlineto
+          0 104 rlineto
+          -3 62 rlineto
+          27 -23 34 -14 30 0 rrcurveto
+          73 0 66 64 0 111 rrcurveto
+          0 99 -46 64 -84 0 rrcurveto
+          -38 0 -36 -21 -26 -24 rrcurveto
+          -3 0 rlineto
+          -7 37 rlineto
+          -49 0 rlineto
+          140 -278 rmoveto
+          -23 0 -28 9 -27 22 rrcurveto
+          0 161 rlineto
+          28 27 28 15 26 0 rrcurveto
+          56 0 25 -42 0 -69 rrcurveto
+          0 -79 -37 -44 -48 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="paragraph">
+          1 380 -80 rmoveto
+          85 0 rlineto
+          0 736 rlineto
+          -85 0 rlineto
+          -87 -430 rmoveto
+          33 0 rlineto
+          0 430 rlineto
+          -44 0 rlineto
+          -138 0 -103 -56 0 -157 rrcurveto
+          0 -151 107 -66 145 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="parenleft">
+          -256 214 -176 rmoveto
+          51 24 rlineto
+          -77 127 -37 151 0 152 rrcurveto
+          0 152 37 151 77 127 rrcurveto
+          -51 24 rlineto
+          -83 -134 -49 -144 0 -176 rrcurveto
+          0 -176 49 -144 83 -134 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="parenleft.dnom">
+          -323 153 -79 rmoveto
+          45 22 rlineto
+          -50 80 -21 83 0 89 rrcurveto
+          0 88 21 84 50 78 rrcurveto
+          -45 22 rlineto
+          -57 -81 -31 -79 0 -112 rrcurveto
+          0 -113 31 -80 57 -81 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="parenleft.numr">
+          -323 153 187 rmoveto
+          45 22 rlineto
+          -50 80 -21 83 0 89 rrcurveto
+          0 88 21 84 50 78 rrcurveto
+          -45 22 rlineto
+          -57 -81 -31 -79 0 -112 rrcurveto
+          0 -113 31 -80 57 -81 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="parenleft.sups">
+          -323 153 315 rmoveto
+          45 22 rlineto
+          -50 80 -21 83 0 89 rrcurveto
+          0 88 21 84 50 78 rrcurveto
+          -45 22 rlineto
+          -57 -81 -31 -79 0 -112 rrcurveto
+          0 -113 31 -80 57 -81 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="parenright">
+          -256 90 -176 rmoveto
+          83 134 49 144 0 176 rrcurveto
+          0 176 -49 144 -83 134 rrcurveto
+          -52 -24 rlineto
+          77 -127 38 -151 0 -152 rrcurveto
+          0 -152 -38 -151 -77 -127 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="parenright.dnom">
+          -323 86 -79 rmoveto
+          55 81 32 80 0 113 rrcurveto
+          0 112 -32 79 -55 81 rrcurveto
+          -47 -22 rlineto
+          51 -78 20 -84 0 -88 rrcurveto
+          0 -89 -20 -83 -51 -80 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="parenright.numr">
+          -323 86 187 rmoveto
+          55 81 32 80 0 113 rrcurveto
+          0 112 -32 79 -55 81 rrcurveto
+          -47 -22 rlineto
+          51 -78 20 -84 0 -88 rrcurveto
+          0 -89 -20 -83 -51 -80 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="parenright.sups">
+          -323 86 315 rmoveto
+          55 81 32 80 0 113 rrcurveto
+          0 112 -32 79 -55 81 rrcurveto
+          -47 -22 rlineto
+          51 -78 20 -84 0 -88 rrcurveto
+          0 -89 -20 -83 -51 -80 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="percent">
+          265 184 254 rmoveto
+          89 0 60 75 0 133 rrcurveto
+          0 131 -60 75 -89 0 rrcurveto
+          -90 0 -59 -75 0 -131 rrcurveto
+          0 -133 59 -75 90 0 rrcurveto
+          0 51 rmoveto
+          -51 0 -36 53 0 104 rrcurveto
+          0 104 36 51 51 0 rrcurveto
+          51 0 35 -51 0 -104 rrcurveto
+          0 -104 -35 -53 -51 0 rrcurveto
+          19 -317 rmoveto
+          56 0 rlineto
+          362 680 rlineto
+          -56 0 rlineto
+          76 -680 rmoveto
+          89 0 60 75 0 133 rrcurveto
+          0 131 -60 75 -89 0 rrcurveto
+          -90 0 -59 -75 0 -131 rrcurveto
+          0 -133 59 -75 90 0 rrcurveto
+          0 51 rmoveto
+          -51 0 -36 53 0 104 rrcurveto
+          0 104 36 51 51 0 rrcurveto
+          51 0 35 -51 0 -104 rrcurveto
+          0 -104 -35 -53 -51 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="period">
+          -310 125 -12 rmoveto
+          33 0 27 26 0 37 rrcurveto
+          0 38 -27 26 -33 0 rrcurveto
+          -33 0 -27 -26 0 -38 rrcurveto
+          0 -37 27 -26 33 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="period.dnom">
+          -383 89 -8 rmoveto
+          26 0 20 19 0 28 rrcurveto
+          0 29 -20 20 -26 0 rrcurveto
+          -27 0 -19 -20 0 -29 rrcurveto
+          0 -28 19 -19 27 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="period.numr">
+          -383 89 258 rmoveto
+          26 0 20 19 0 28 rrcurveto
+          0 29 -20 20 -26 0 rrcurveto
+          -27 0 -19 -20 0 -29 rrcurveto
+          0 -28 19 -19 27 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="period.sups">
+          -383 89 386 rmoveto
+          26 0 20 19 0 28 rrcurveto
+          0 29 -20 20 -26 0 rrcurveto
+          -27 0 -19 -20 0 -29 rrcurveto
+          0 -28 19 -19 27 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="periodcentered">
+          -310 125 259 rmoveto
+          33 0 27 26 0 37 rrcurveto
+          0 38 -27 26 -33 0 rrcurveto
+          -33 0 -27 -26 0 -38 rrcurveto
+          0 -37 27 -26 33 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="plus">
+          -63 216 104 rmoveto
+          66 0 rlineto
+          0 195 rlineto
+          181 0 rlineto
+          0 62 rlineto
+          -181 0 rlineto
+          0 195 rlineto
+          -66 0 rlineto
+          0 -195 rlineto
+          -182 0 rlineto
+          0 -62 rlineto
+          182 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="plus.sups">
+          -193 155 430 rmoveto
+          56 0 rlineto
+          0 137 rlineto
+          126 0 rlineto
+          0 53 rlineto
+          -126 0 rlineto
+          0 136 rlineto
+          -56 0 rlineto
+          0 -136 rlineto
+          -125 0 rlineto
+          0 -53 rlineto
+          125 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="plusminus">
+          -63 216 127 rmoveto
+          66 0 rlineto
+          0 177 rlineto
+          181 0 rlineto
+          0 62 rlineto
+          -181 0 rlineto
+          0 190 rlineto
+          -66 0 rlineto
+          0 -190 rlineto
+          -182 0 rlineto
+          0 -62 rlineto
+          182 0 rlineto
+          -182 -304 rmoveto
+          429 0 rlineto
+          0 62 rlineto
+          -429 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="q">
+          -5 390 -205 rmoveto
+          83 0 rlineto
+          0 691 rlineto
+          -66 0 rlineto
+          -8 -46 rlineto
+          -3 0 rlineto
+          -43 38 -39 20 -56 0 rrcurveto
+          -111 0 -100 -98 0 -158 rrcurveto
+          0 -162 79 -92 122 0 rrcurveto
+          56 0 51 30 39 38 rrcurveto
+          -4 -88 rlineto
+          -124 90 rmoveto
+          -85 0 -48 69 0 116 rrcurveto
+          0 111 62 74 77 0 rrcurveto
+          40 0 37 -13 41 -37 rrcurveto
+          0 -254 rlineto
+          -40 -44 -39 -22 -45 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="q.sups">
+          -186 260 257 rmoveto
+          62 0 rlineto
+          0 459 rlineto
+          -48 0 rlineto
+          -6 -32 rlineto
+          -4 0 rlineto
+          -25 26 -30 14 -35 0 rrcurveto
+          -73 0 -68 -63 0 -106 rrcurveto
+          0 -105 53 -64 85 0 rrcurveto
+          35 0 33 17 24 24 rrcurveto
+          -3 -59 rlineto
+          -76 70 rmoveto
+          -59 0 -28 45 0 73 rrcurveto
+          0 72 40 44 46 0 rrcurveto
+          24 0 27 -10 26 -22 rrcurveto
+          0 -165 rlineto
+          -26 -25 -24 -12 -26 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="question">
+          -135 160 199 rmoveto
+          73 0 rlineto
+          -16 139 161 53 0 131 rrcurveto
+          0 99 -67 61 -101 0 rrcurveto
+          -73 0 -57 -35 -42 -48 rrcurveto
+          48 -43 rlineto
+          31 35 39 22 44 0 rrcurveto
+          64 0 33 -43 0 -53 rrcurveto
+          0 -106 -159 -57 22 -155 rrcurveto
+          38 -211 rmoveto
+          33 0 27 26 0 37 rrcurveto
+          0 38 -27 26 -33 0 rrcurveto
+          -33 0 -26 -26 0 -38 rrcurveto
+          0 -37 26 -26 33 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="questiondown">
+          -135 215 -196 rmoveto
+          73 0 57 36 42 47 rrcurveto
+          -48 43 rlineto
+          -31 -35 -39 -22 -44 0 rrcurveto
+          -64 0 -32 43 0 54 rrcurveto
+          0 105 158 57 -21 155 rrcurveto
+          -74 0 rlineto
+          17 -139 -161 -53 0 -131 rrcurveto
+          0 -99 66 -61 101 0 rrcurveto
+          12 568 rmoveto
+          33 0 27 26 0 38 rrcurveto
+          0 36 -27 26 -33 0 rrcurveto
+          -33 0 -27 -26 0 -36 rrcurveto
+          0 -38 27 -26 33 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="quotedbl">
+          -133 99 430 rmoveto
+          51 0 rlineto
+          16 167 rlineto
+          2 93 rlineto
+          -88 0 rlineto
+          3 -93 rlineto
+          193 -167 rmoveto
+          51 0 rlineto
+          16 167 rlineto
+          2 93 rlineto
+          -88 0 rlineto
+          3 -93 rlineto
+          endchar
+        </CharString>
+        <CharString name="quotesingle">
+          -310 99 430 rmoveto
+          51 0 rlineto
+          16 167 rlineto
+          2 93 rlineto
+          -88 0 rlineto
+          3 -93 rlineto
+          endchar
+        </CharString>
+        <CharString name="r">
+          -212 82 0 rmoveto
+          83 0 rlineto
+          0 312 rlineto
+          33 82 49 29 41 0 rrcurveto
+          19 0 11 -2 14 -4 rrcurveto
+          18 71 rlineto
+          -15 7 -15 3 -22 0 rrcurveto
+          -54 0 -50 -39 -34 -61 rrcurveto
+          -3 0 rlineto
+          -7 88 rlineto
+          -68 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="r.sups">
+          -320 52 394 rmoveto
+          63 0 rlineto
+          0 204 rlineto
+          23 51 31 18 28 0 rrcurveto
+          12 0 12 -3 8 -2 rrcurveto
+          12 56 rlineto
+          -8 4 -14 2 -15 0 rrcurveto
+          -36 0 -31 -22 -25 -42 rrcurveto
+          -3 0 rlineto
+          -7 56 rlineto
+          -50 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="registered">
+          -136 212 319 rmoveto
+          103 0 85 80 0 117 rrcurveto
+          0 117 -85 80 -103 0 rrcurveto
+          -104 0 -85 -80 0 -117 rrcurveto
+          0 -117 85 -80 104 0 rrcurveto
+          0 37 rmoveto
+          -84 0 -65 65 0 95 rrcurveto
+          0 94 65 67 84 0 rrcurveto
+          84 0 64 -67 0 -94 rrcurveto
+          0 -95 -64 -65 -84 0 rrcurveto
+          -73 61 rmoveto
+          41 0 rlineto
+          0 70 rlineto
+          41 0 rlineto
+          35 -70 rlineto
+          46 0 rlineto
+          -46 83 rlineto
+          23 8 15 23 0 24 rrcurveto
+          0 48 -37 17 -42 0 rrcurveto
+          -76 0 rlineto
+          41 -101 rmoveto
+          0 67 rlineto
+          28 0 rlineto
+          30 0 11 -14 0 -19 rrcurveto
+          0 -22 -16 -12 -27 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="s">
+          -141 209 -12 rmoveto
+          115 0 63 66 0 79 rrcurveto
+          0 88 -73 33 -76 27 rrcurveto
+          -61 21 -42 18 0 44 rrcurveto
+          0 36 27 34 62 0 rrcurveto
+          43 0 35 -14 34 -25 rrcurveto
+          38 48 rlineto
+          -38 32 -52 23 -61 0 rrcurveto
+          -106 0 -62 -60 0 -78 rrcurveto
+          0 -80 70 -35 73 -26 rrcurveto
+          55 -20 54 -21 0 -50 rrcurveto
+          0 -42 -31 -33 -64 0 rrcurveto
+          -60 0 -44 18 -42 35 rrcurveto
+          -38 -48 rlineto
+          45 -44 65 -26 71 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="s.sups">
+          -277 144 386 rmoveto
+          73 0 46 42 0 57 rrcurveto
+          0 60 -51 19 -46 17 rrcurveto
+          -37 15 -34 10 0 29 rrcurveto
+          0 21 17 20 36 0 rrcurveto
+          30 0 20 -11 24 -17 rrcurveto
+          31 40 rlineto
+          -26 19 -35 17 -46 0 rrcurveto
+          -70 0 -41 -42 0 -50 rrcurveto
+          0 -55 50 -23 45 -18 rrcurveto
+          37 -14 36 -12 0 -30 rrcurveto
+          0 -25 -21 -20 -37 0 rrcurveto
+          -36 0 -31 15 -29 22 rrcurveto
+          -30 -42 rlineto
+          32 -24 45 -20 48 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="section">
+          -63 236 -64 rmoveto
+          95 0 66 58 0 79 rrcurveto
+          0 34 -11 27 -18 21 rrcurveto
+          50 29 34 37 0 63 rrcurveto
+          0 184 -277 -19 0 108 rrcurveto
+          0 34 24 29 55 0 rrcurveto
+          45 0 35 -21 31 -26 rrcurveto
+          41 54 rlineto
+          -39 31 -53 26 -63 0 rrcurveto
+          -100 0 -52 -61 0 -69 rrcurveto
+          0 -35 12 -26 20 -21 rrcurveto
+          -50 -28 -36 -44 0 -57 rrcurveto
+          0 -185 276 25 0 -114 rrcurveto
+          0 -38 -32 -31 -53 0 rrcurveto
+          -53 0 -37 20 -33 33 rrcurveto
+          -50 -46 rlineto
+          41 -45 61 -26 71 0 rrcurveto
+          -118 412 rmoveto
+          0 41 24 25 37 20 rrcurveto
+          83 -47 118 -20 0 -89 rrcurveto
+          0 -44 -21 -22 -39 -19 rrcurveto
+          -83 49 -119 18 0 88 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="semicolon">
+          -310 125 348 rmoveto
+          33 0 27 26 0 37 rrcurveto
+          0 38 -27 26 -33 0 rrcurveto
+          -33 0 -27 -26 0 -38 rrcurveto
+          0 -37 27 -26 33 0 rrcurveto
+          -58 -518 rmoveto
+          82 33 50 68 0 86 rrcurveto
+          0 61 -26 37 -44 0 rrcurveto
+          -33 0 -28 -22 0 -36 rrcurveto
+          0 -38 27 -20 32 0 rrcurveto
+          4 0 3 0 4 1 rrcurveto
+          0 -53 -34 -44 -57 -25 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="seven">
+          -63 171 0 rmoveto
+          85 0 rlineto
+          11 249 35 144 153 194 rrcurveto
+          0 51 rlineto
+          -411 0 rlineto
+          0 -72 rlineto
+          318 0 rlineto
+          -129 -176 -51 -150 -11 -240 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="seven.dnom">
+          -193 131 0 rmoveto
+          68 0 rlineto
+          7 136 22 97 95 121 rrcurveto
+          0 36 rlineto
+          -273 0 rlineto
+          0 -55 rlineto
+          200 0 rlineto
+          -79 -109 -32 -91 -8 -135 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="seven.numr">
+          -193 131 266 rmoveto
+          68 0 rlineto
+          7 136 22 97 95 121 rrcurveto
+          0 36 rlineto
+          -273 0 rlineto
+          0 -55 rlineto
+          200 0 rlineto
+          -79 -109 -32 -91 -8 -135 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="seven.sups">
+          -193 131 394 rmoveto
+          68 0 rlineto
+          7 136 22 97 95 121 rrcurveto
+          0 36 rlineto
+          -273 0 rlineto
+          0 -55 rlineto
+          200 0 rlineto
+          -79 -109 -32 -91 -8 -135 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="six">
+          -63 261 328 rmoveto
+          79 0 39 -52 0 -83 rrcurveto
+          0 -84 -48 -56 -63 0 rrcurveto
+          -80 0 -49 66 -11 124 rrcurveto
+          40 60 52 25 41 0 rrcurveto
+          7 -340 rmoveto
+          103 0 86 83 0 122 rrcurveto
+          0 131 -71 66 -111 0 rrcurveto
+          -52 0 -57 -32 -40 -50 rrcurveto
+          3 203 76 70 89 0 rrcurveto
+          40 0 40 -20 25 -31 rrcurveto
+          46 52 rlineto
+          -35 39 -50 29 -69 0 rrcurveto
+          -127 0 -116 -99 0 -256 rrcurveto
+          0 -205 95 -102 125 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="six.dnom">
+          -193 191 198 rmoveto
+          49 0 26 -33 0 -46 rrcurveto
+          0 -47 -30 -33 -41 0 rrcurveto
+          -48 0 -35 39 -6 77 rrcurveto
+          30 32 26 11 29 0 rrcurveto
+          5 -210 rmoveto
+          74 0 56 57 0 75 rrcurveto
+          0 74 -44 51 -78 0 rrcurveto
+          -37 0 -33 -14 -28 -27 rrcurveto
+          6 100 47 47 58 0 rrcurveto
+          27 0 21 -11 19 -13 rrcurveto
+          27 44 rlineto
+          -23 17 -28 14 -45 0 rrcurveto
+          -96 0 -74 -70 0 -147 rrcurveto
+          0 -123 59 -74 92 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="six.numr">
+          -193 191 464 rmoveto
+          49 0 26 -33 0 -46 rrcurveto
+          0 -47 -30 -33 -41 0 rrcurveto
+          -48 0 -35 39 -6 77 rrcurveto
+          30 32 26 11 29 0 rrcurveto
+          5 -210 rmoveto
+          74 0 56 57 0 75 rrcurveto
+          0 74 -44 51 -78 0 rrcurveto
+          -37 0 -33 -14 -28 -27 rrcurveto
+          6 100 47 47 58 0 rrcurveto
+          27 0 21 -11 19 -13 rrcurveto
+          27 44 rlineto
+          -23 17 -28 14 -45 0 rrcurveto
+          -96 0 -74 -70 0 -147 rrcurveto
+          0 -123 59 -74 92 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="six.sups">
+          -193 191 592 rmoveto
+          49 0 26 -33 0 -46 rrcurveto
+          0 -47 -30 -33 -41 0 rrcurveto
+          -48 0 -35 39 -6 77 rrcurveto
+          30 32 26 11 29 0 rrcurveto
+          5 -210 rmoveto
+          74 0 56 57 0 75 rrcurveto
+          0 74 -44 51 -78 0 rrcurveto
+          -37 0 -33 -14 -28 -27 rrcurveto
+          6 100 47 47 58 0 rrcurveto
+          27 0 21 -11 19 -13 rrcurveto
+          27 44 rlineto
+          -23 17 -28 14 -45 0 rrcurveto
+          -96 0 -74 -70 0 -147 rrcurveto
+          0 -123 59 -74 92 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="slash">
+          -210 10 -160 rmoveto
+          60 0 rlineto
+          266 870 rlineto
+          -60 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="slash.frac">
+          -474 -167 -12 rmoveto
+          56 0 rlineto
+          362 680 rlineto
+          -56 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="space">
+          -360 endchar
+        </CharString>
+        <CharString name="space.frac">
+          -426 endchar
+        </CharString>
+        <CharString name="sterling">
+          -63 54 0 rmoveto
+          400 0 rlineto
+          0 71 rlineto
+          -281 0 rlineto
+          0 4 rlineto
+          40 42 21 43 0 69 rrcurveto
+          0 20 -2 18 -3 18 rrcurveto
+          146 0 rlineto
+          0 56 rlineto
+          -159 0 rlineto
+          -11 41 -12 39 0 42 rrcurveto
+          0 68 39 50 72 0 rrcurveto
+          46 0 31 -18 26 -33 rrcurveto
+          46 42 rlineto
+          -33 46 -50 32 -73 0 rrcurveto
+          -111 0 -75 -71 0 -113 rrcurveto
+          0 -42 14 -41 13 -42 rrcurveto
+          -18 0 rlineto
+          -67 -3 rlineto
+          0 -53 rlineto
+          100 0 rlineto
+          4 -18 3 -18 0 -19 rrcurveto
+          0 -75 -38 -68 -68 -36 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="t">
+          -221 235 -12 rmoveto
+          33 0 33 9 26 12 rrcurveto
+          -17 59 rlineto
+          -20 -9 -18 -3 -18 0 rrcurveto
+          -55 0 -20 34 0 59 rrcurveto
+          0 270 rlineto
+          132 0 rlineto
+          0 67 rlineto
+          -132 0 rlineto
+          0 156 rlineto
+          -69 0 rlineto
+          -10 -156 rlineto
+          -76 -5 rlineto
+          0 -62 rlineto
+          72 0 rlineto
+          0 -268 rlineto
+          0 -97 35 -66 104 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="t.sups">
+          -328 160 386 rmoveto
+          23 0 24 6 18 6 rrcurveto
+          -13 47 rlineto
+          -12 -6 -12 -2 -12 0 rrcurveto
+          -34 0 -16 22 0 40 rrcurveto
+          0 167 rlineto
+          88 0 rlineto
+          0 50 rlineto
+          -88 0 rlineto
+          0 97 rlineto
+          -52 0 rlineto
+          -8 -97 rlineto
+          -50 -2 rlineto
+          0 -48 rlineto
+          48 0 rlineto
+          0 -167 rlineto
+          0 -67 25 -46 71 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="thorn">
+          -5 82 -205 rmoveto
+          83 0 rlineto
+          0 164 rlineto
+          -2 83 rlineto
+          44 -34 43 -20 47 0 rrcurveto
+          111 0 100 97 0 165 rrcurveto
+          0 151 -69 97 -128 0 rrcurveto
+          -53 0 -52 -28 -43 -35 rrcurveto
+          2 84 rlineto
+          0 193 rlineto
+          -83 0 rlineto
+          201 -654 rmoveto
+          -32 0 -42 13 -44 37 rrcurveto
+          0 254 rlineto
+          47 44 41 22 41 0 rrcurveto
+          91 0 37 -71 0 -107 rrcurveto
+          0 -120 -59 -72 -80 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="three">
+          -63 236 -12 rmoveto
+          117 0 94 69 0 113 rrcurveto
+          0 88 -61 56 -77 18 rrcurveto
+          0 4 rlineto
+          69 26 46 49 0 77 rrcurveto
+          0 103 -80 59 -111 0 rrcurveto
+          -75 0 -59 -34 -49 -46 rrcurveto
+          44 -52 rlineto
+          38 37 45 27 53 0 rrcurveto
+          68 0 42 -39 0 -61 rrcurveto
+          0 -67 -46 -52 -135 0 rrcurveto
+          0 -63 rlineto
+          152 0 52 -51 0 -76 rrcurveto
+          0 -71 -55 -45 -77 0 rrcurveto
+          -75 0 -50 35 -38 40 rrcurveto
+          -42 -54 rlineto
+          43 -47 65 -43 102 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="three.dnom">
+          -193 180 -12 rmoveto
+          76 0 63 45 0 72 rrcurveto
+          0 52 -39 33 -45 11 rrcurveto
+          41 19 28 31 0 46 rrcurveto
+          0 66 -58 39 -67 0 rrcurveto
+          -54 0 -40 -25 -34 -39 rrcurveto
+          39 -35 rlineto
+          22 28 28 20 29 0 rrcurveto
+          43 0 27 -25 0 -37 rrcurveto
+          0 -40 -39 -30 -66 0 rrcurveto
+          0 -41 rlineto
+          76 0 45 -24 0 -45 rrcurveto
+          0 -44 -36 -26 -42 0 rrcurveto
+          -41 0 -34 22 -24 36 rrcurveto
+          -43 -33 rlineto
+          30 -44 52 -32 63 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="three.numr">
+          -193 180 254 rmoveto
+          76 0 63 45 0 72 rrcurveto
+          0 52 -39 33 -45 11 rrcurveto
+          41 19 28 31 0 46 rrcurveto
+          0 66 -58 39 -67 0 rrcurveto
+          -54 0 -40 -25 -34 -39 rrcurveto
+          39 -35 rlineto
+          22 28 28 20 29 0 rrcurveto
+          43 0 27 -25 0 -37 rrcurveto
+          0 -40 -39 -30 -66 0 rrcurveto
+          0 -41 rlineto
+          76 0 45 -24 0 -45 rrcurveto
+          0 -44 -36 -26 -42 0 rrcurveto
+          -41 0 -34 22 -24 36 rrcurveto
+          -43 -33 rlineto
+          30 -44 52 -32 63 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="three.sups">
+          -193 180 382 rmoveto
+          76 0 63 45 0 72 rrcurveto
+          0 52 -39 33 -45 11 rrcurveto
+          41 19 28 31 0 46 rrcurveto
+          0 66 -58 39 -67 0 rrcurveto
+          -54 0 -40 -25 -34 -39 rrcurveto
+          39 -35 rlineto
+          22 28 28 20 29 0 rrcurveto
+          43 0 27 -25 0 -37 rrcurveto
+          0 -40 -39 -30 -66 0 rrcurveto
+          0 -41 rlineto
+          76 0 45 -24 0 -45 rrcurveto
+          0 -44 -36 -26 -42 0 rrcurveto
+          -41 0 -34 22 -24 36 rrcurveto
+          -43 -33 rlineto
+          30 -44 52 -32 63 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="threequarters">
+          236 179 254 rmoveto
+          76 0 63 45 0 72 rrcurveto
+          0 52 -39 33 -45 11 rrcurveto
+          41 19 28 31 0 46 rrcurveto
+          0 66 -58 39 -67 0 rrcurveto
+          -54 0 -40 -25 -34 -39 rrcurveto
+          39 -35 rlineto
+          22 28 28 20 29 0 rrcurveto
+          43 0 27 -25 0 -37 rrcurveto
+          0 -40 -39 -30 -66 0 rrcurveto
+          0 -41 rlineto
+          76 0 45 -24 0 -45 rrcurveto
+          0 -44 -36 -26 -42 0 rrcurveto
+          -41 0 -34 22 -24 36 rrcurveto
+          -43 -33 rlineto
+          30 -44 52 -32 63 0 rrcurveto
+          39 -266 rmoveto
+          56 0 rlineto
+          362 680 rlineto
+          -56 0 rlineto
+          -43 -518 rmoveto
+          61 98 rlineto
+          50 81 rlineto
+          4 0 rlineto
+          -4 -109 rlineto
+          0 -70 rlineto
+          0 -150 rmoveto
+          58 0 rlineto
+          0 104 rlineto
+          58 0 rlineto
+          0 46 rlineto
+          -58 0 rlineto
+          0 240 rlineto
+          -73 0 rlineto
+          -163 -253 rlineto
+          0 -33 rlineto
+          178 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="two">
+          -63 40 0 rmoveto
+          412 0 rlineto
+          0 71 rlineto
+          -191 0 rlineto
+          -33 0 -39 -2 -35 -3 rrcurveto
+          155 158 112 115 0 124 rrcurveto
+          0 112 -74 75 -118 0 rrcurveto
+          -82 0 -57 -39 -53 -60 rrcurveto
+          47 -45 rlineto
+          36 42 46 34 53 0 rrcurveto
+          81 0 40 -51 0 -73 rrcurveto
+          0 -103 -110 -118 -190 -186 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="two.dnom">
+          -193 52 0 rmoveto
+          268 0 rlineto
+          0 55 rlineto
+          -164 0 rlineto
+          83 85 61 61 0 75 rrcurveto
+          0 82 -52 44 -78 0 rrcurveto
+          -53 0 -47 -31 -30 -45 rrcurveto
+          38 -35 rlineto
+          22 32 29 25 33 0 rrcurveto
+          46 0 29 -32 0 -50 rrcurveto
+          0 -59 -64 -61 -121 -109 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="two.numr">
+          -193 52 266 rmoveto
+          268 0 rlineto
+          0 55 rlineto
+          -164 0 rlineto
+          83 85 61 61 0 75 rrcurveto
+          0 82 -52 44 -78 0 rrcurveto
+          -53 0 -47 -31 -30 -45 rrcurveto
+          38 -35 rlineto
+          22 32 29 25 33 0 rrcurveto
+          46 0 29 -32 0 -50 rrcurveto
+          0 -59 -64 -61 -121 -109 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="two.sups">
+          -193 52 394 rmoveto
+          268 0 rlineto
+          0 55 rlineto
+          -164 0 rlineto
+          83 85 61 61 0 75 rrcurveto
+          0 82 -52 44 -78 0 rrcurveto
+          -53 0 -47 -31 -30 -45 rrcurveto
+          38 -35 rlineto
+          22 32 29 25 33 0 rrcurveto
+          46 0 29 -32 0 -50 rrcurveto
+          0 -59 -64 -61 -121 -109 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="u">
+          -16 224 -12 rmoveto
+          67 0 48 35 45 53 rrcurveto
+          3 0 rlineto
+          7 -76 rlineto
+          68 0 rlineto
+          0 486 rlineto
+          -83 0 rlineto
+          0 -344 rlineto
+          -45 -57 -35 -25 -49 0 rrcurveto
+          -64 0 -28 39 0 90 rrcurveto
+          0 297 rlineto
+          -83 0 rlineto
+          0 -308 rlineto
+          0 -124 46 -66 103 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="u.sups">
+          -190 153 386 rmoveto
+          43 0 37 25 27 28 rrcurveto
+          3 0 rlineto
+          7 -45 rlineto
+          49 0 rlineto
+          0 322 rlineto
+          -62 0 rlineto
+          0 -229 rlineto
+          -31 -33 -27 -14 -26 0 rrcurveto
+          -50 0 -10 30 0 51 rrcurveto
+          0 195 rlineto
+          -63 0 rlineto
+          0 -204 rlineto
+          0 -75 28 -51 75 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="uacute">
+          -16 224 -12 rmoveto
+          67 0 48 35 45 53 rrcurveto
+          3 0 rlineto
+          7 -76 rlineto
+          68 0 rlineto
+          0 486 rlineto
+          -83 0 rlineto
+          0 -344 rlineto
+          -45 -57 -35 -25 -49 0 rrcurveto
+          -64 0 -28 39 0 90 rrcurveto
+          0 297 rlineto
+          -83 0 rlineto
+          0 -308 rlineto
+          0 -124 46 -66 103 0 rrcurveto
+          4 585 rmoveto
+          179 153 rlineto
+          -51 55 rlineto
+          -170 -166 rlineto
+          endchar
+        </CharString>
+        <CharString name="ucircumflex">
+          -16 224 -12 rmoveto
+          67 0 48 35 45 53 rrcurveto
+          3 0 rlineto
+          7 -76 rlineto
+          68 0 rlineto
+          0 486 rlineto
+          -83 0 rlineto
+          0 -344 rlineto
+          -45 -57 -35 -25 -49 0 rrcurveto
+          -64 0 -28 39 0 90 rrcurveto
+          0 297 rlineto
+          -83 0 rlineto
+          0 -308 rlineto
+          0 -124 46 -66 103 0 rrcurveto
+          -73 580 rmoveto
+          118 113 rlineto
+          4 0 rlineto
+          118 -113 rlineto
+          35 32 rlineto
+          -113 140 rlineto
+          -84 0 rlineto
+          -113 -140 rlineto
+          endchar
+        </CharString>
+        <CharString name="udieresis">
+          -16 224 -12 rmoveto
+          67 0 48 35 45 53 rrcurveto
+          3 0 rlineto
+          7 -76 rlineto
+          68 0 rlineto
+          0 486 rlineto
+          -83 0 rlineto
+          0 -344 rlineto
+          -45 -57 -35 -25 -49 0 rrcurveto
+          -64 0 -28 39 0 90 rrcurveto
+          0 297 rlineto
+          -83 0 rlineto
+          0 -308 rlineto
+          0 -124 46 -66 103 0 rrcurveto
+          -49 599 rmoveto
+          28 0 21 22 0 28 rrcurveto
+          0 28 -21 22 -28 0 rrcurveto
+          -29 0 -21 -22 0 -28 rrcurveto
+          0 -28 21 -22 29 0 rrcurveto
+          192 0 rmoveto
+          29 0 21 22 0 28 rrcurveto
+          0 28 -21 22 -29 0 rrcurveto
+          -28 0 -21 -22 0 -28 rrcurveto
+          0 -28 21 -22 28 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="ugrave">
+          -16 224 -12 rmoveto
+          67 0 48 35 45 53 rrcurveto
+          3 0 rlineto
+          7 -76 rlineto
+          68 0 rlineto
+          0 486 rlineto
+          -83 0 rlineto
+          0 -344 rlineto
+          -45 -57 -35 -25 -49 0 rrcurveto
+          -64 0 -28 39 0 90 rrcurveto
+          0 297 rlineto
+          -83 0 rlineto
+          0 -308 rlineto
+          0 -124 46 -66 103 0 rrcurveto
+          90 585 rmoveto
+          42 42 rlineto
+          -170 166 rlineto
+          -51 -55 rlineto
+          endchar
+        </CharString>
+        <CharString name="underscore">
+          -60 12 -126 rmoveto
+          476 0 rlineto
+          0 55 rlineto
+          -476 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni004C00B7004C">
+          412 90 0 rmoveto
+          370 0 rlineto
+          0 71 rlineto
+          -286 0 rlineto
+          0 585 rlineto
+          -84 0 rlineto
+          287 -394 rmoveto
+          33 0 27 26 0 37 rrcurveto
+          0 38 -27 26 -33 0 rrcurveto
+          -33 0 -27 -26 0 -38 rrcurveto
+          0 -37 27 -26 33 0 rrcurveto
+          199 -262 rmoveto
+          370 0 rlineto
+          0 71 rlineto
+          -286 0 rlineto
+          0 585 rlineto
+          -84 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni006C00B7006C">
+          58 169 -12 rmoveto
+          21 0 15 3 12 6 rrcurveto
+          -11 62 rlineto
+          -8 -2 -4 0 -5 0 rrcurveto
+          -13 0 -11 9 0 26 rrcurveto
+          0 620 rlineto
+          -83 0 rlineto
+          0 -614 rlineto
+          0 -70 25 -40 62 0 rrcurveto
+          135 274 rmoveto
+          33 0 27 26 0 37 rrcurveto
+          0 38 -27 26 -33 0 rrcurveto
+          -33 0 -27 -26 0 -38 rrcurveto
+          0 -37 27 -26 33 0 rrcurveto
+          228 -274 rmoveto
+          21 0 15 3 12 6 rrcurveto
+          -11 62 rlineto
+          -8 -2 -4 0 -5 0 rrcurveto
+          -13 0 -11 9 0 26 rrcurveto
+          0 620 rlineto
+          -83 0 rlineto
+          0 -614 rlineto
+          0 -70 25 -40 62 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="v">
+          -92 187 0 rmoveto
+          97 0 rlineto
+          172 486 rlineto
+          -82 0 rlineto
+          -91 -275 rlineto
+          -15 -48 -16 -49 -14 -47 rrcurveto
+          -4 0 rlineto
+          -15 47 -15 49 -15 48 rrcurveto
+          -91 275 rlineto
+          -86 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="v.sups">
+          -238 124 394 rmoveto
+          74 0 rlineto
+          116 322 rlineto
+          -62 0 rlineto
+          -58 -176 rlineto
+          -31 -96 rlineto
+          -3 0 rlineto
+          -31 96 rlineto
+          -58 176 rlineto
+          -63 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="w">
+          158 160 0 rmoveto
+          100 0 rlineto
+          65 261 rlineto
+          13 44 9 43 9 57 rrcurveto
+          4 0 rlineto
+          11 -57 9 -42 12 -45 rrcurveto
+          66 -261 rlineto
+          105 0 rlineto
+          131 486 rlineto
+          -79 0 rlineto
+          -71 -282 rlineto
+          -11 -44 -8 -42 -10 -52 rrcurveto
+          -4 0 rlineto
+          -10 52 -11 42 -11 44 rrcurveto
+          -74 282 rlineto
+          -89 0 rlineto
+          -73 -282 rlineto
+          -11 -44 -9 -42 -10 -52 rrcurveto
+          -4 0 rlineto
+          -8 52 -10 42 -11 44 rrcurveto
+          -71 282 rlineto
+          -85 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="w.sups">
+          -72 105 394 rmoveto
+          74 0 rlineto
+          44 164 rlineto
+          20 91 rlineto
+          2 0 rlineto
+          21 -91 rlineto
+          43 -164 rlineto
+          76 0 rlineto
+          87 322 rlineto
+          -60 0 rlineto
+          -43 -178 rlineto
+          -21 -92 rlineto
+          -4 0 rlineto
+          -21 92 rlineto
+          -50 178 rlineto
+          -57 0 rlineto
+          -47 -178 rlineto
+          -22 -92 rlineto
+          -3 0 rlineto
+          -20 92 rlineto
+          -44 178 rlineto
+          -64 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="x">
+          -113 14 0 rmoveto
+          87 0 rlineto
+          65 113 rlineto
+          17 29 16 30 16 28 rrcurveto
+          4 0 rlineto
+          18 -28 18 -30 17 -29 rrcurveto
+          71 -113 rlineto
+          90 0 rlineto
+          -158 245 rlineto
+          147 241 rlineto
+          -87 0 rlineto
+          -59 -106 rlineto
+          -15 -27 -14 -27 -15 -27 rrcurveto
+          -4 0 rlineto
+          -16 27 -16 27 -15 27 rrcurveto
+          -65 106 rlineto
+          -90 0 rlineto
+          147 -232 rlineto
+          endchar
+        </CharString>
+        <CharString name="x.sups">
+          -252 8 394 rmoveto
+          66 0 rlineto
+          41 69 rlineto
+          33 55 rlineto
+          4 0 rlineto
+          35 -55 rlineto
+          43 -69 rlineto
+          68 0 rlineto
+          -105 162 rlineto
+          99 160 rlineto
+          -67 0 rlineto
+          -37 -66 rlineto
+          -27 -51 rlineto
+          -4 0 rlineto
+          -31 51 rlineto
+          -40 66 rlineto
+          -69 0 rlineto
+          99 -153 rlineto
+          endchar
+        </CharString>
+        <CharString name="y">
+          -92 91 -209 rmoveto
+          97 0 51 73 34 96 rrcurveto
+          183 526 rlineto
+          -81 0 rlineto
+          -87 -268 rlineto
+          -13 -43 -14 -50 -13 -44 rrcurveto
+          -4 0 rlineto
+          -16 45 -16 50 -16 42 rrcurveto
+          -98 268 rlineto
+          -86 0 rlineto
+          195 -487 rlineto
+          -11 -36 rlineto
+          -20 -60 -35 -43 -54 0 rrcurveto
+          -12 0 -12 2 -12 4 rrcurveto
+          -18 -65 rlineto
+          16 -6 19 -4 23 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="y.sups">
+          -240 65 261 rmoveto
+          68 0 35 48 25 67 rrcurveto
+          119 340 rlineto
+          -62 0 rlineto
+          -52 -169 rlineto
+          -10 -31 -10 -30 -9 -32 rrcurveto
+          -4 0 rlineto
+          -10 33 -10 31 -10 29 rrcurveto
+          -63 169 rlineto
+          -64 0 rlineto
+          131 -320 rlineto
+          -7 -20 rlineto
+          -12 -38 -24 -26 -35 0 rrcurveto
+          -8 0 -7 1 -9 4 rrcurveto
+          -13 -50 rlineto
+          12 -4 13 -2 16 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="yacute">
+          -92 91 -209 rmoveto
+          97 0 51 73 34 96 rrcurveto
+          183 526 rlineto
+          -81 0 rlineto
+          -87 -268 rlineto
+          -13 -43 -14 -50 -13 -44 rrcurveto
+          -4 0 rlineto
+          -16 45 -16 50 -16 42 rrcurveto
+          -98 268 rlineto
+          -86 0 rlineto
+          195 -487 rlineto
+          -11 -36 rlineto
+          -20 -60 -35 -43 -54 0 rrcurveto
+          -12 0 -12 2 -12 4 rrcurveto
+          -18 -65 rlineto
+          16 -6 19 -4 23 0 rrcurveto
+          109 782 rmoveto
+          179 153 rlineto
+          -51 55 rlineto
+          -170 -166 rlineto
+          endchar
+        </CharString>
+        <CharString name="ydieresis">
+          -92 91 -209 rmoveto
+          97 0 51 73 34 96 rrcurveto
+          183 526 rlineto
+          -81 0 rlineto
+          -87 -268 rlineto
+          -13 -43 -14 -50 -13 -44 rrcurveto
+          -4 0 rlineto
+          -16 45 -16 50 -16 42 rrcurveto
+          -98 268 rlineto
+          -86 0 rlineto
+          195 -487 rlineto
+          -11 -36 rlineto
+          -20 -60 -35 -43 -54 0 rrcurveto
+          -12 0 -12 2 -12 4 rrcurveto
+          -18 -65 rlineto
+          16 -6 19 -4 23 0 rrcurveto
+          56 796 rmoveto
+          28 0 21 22 0 28 rrcurveto
+          0 28 -21 22 -28 0 rrcurveto
+          -29 0 -21 -22 0 -28 rrcurveto
+          0 -28 21 -22 29 0 rrcurveto
+          192 0 rmoveto
+          29 0 21 22 0 28 rrcurveto
+          0 28 -21 22 -29 0 rrcurveto
+          -28 0 -21 -22 0 -28 rrcurveto
+          0 -28 21 -22 28 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="yen">
+          -63 207 0 rmoveto
+          82 0 rlineto
+          0 151 rlineto
+          162 0 rlineto
+          0 52 rlineto
+          -162 0 rlineto
+          0 67 rlineto
+          162 0 rlineto
+          0 52 rlineto
+          -140 0 rlineto
+          162 316 rlineto
+          -82 0 rlineto
+          -79 -172 rlineto
+          -19 -44 -20 -44 -22 -47 rrcurveto
+          -4 0 rlineto
+          -21 47 -19 44 -20 44 rrcurveto
+          -78 172 rlineto
+          -85 0 rlineto
+          160 -316 rlineto
+          -139 0 rlineto
+          0 -52 rlineto
+          162 0 rlineto
+          0 -67 rlineto
+          -162 0 rlineto
+          0 -52 rlineto
+          162 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="z">
+          -135 31 0 rmoveto
+          369 0 rlineto
+          0 68 rlineto
+          -264 0 rlineto
+          255 374 rlineto
+          0 44 rlineto
+          -332 0 rlineto
+          0 -67 rlineto
+          227 0 rlineto
+          -255 -375 rlineto
+          endchar
+        </CharString>
+        <CharString name="z.sups">
+          -270 21 394 rmoveto
+          252 0 rlineto
+          0 51 rlineto
+          -172 0 rlineto
+          166 236 rlineto
+          0 35 rlineto
+          -226 0 rlineto
+          0 -50 rlineto
+          147 0 rlineto
+          -167 -238 rlineto
+          endchar
+        </CharString>
+        <CharString name="zero">
+          -63 249 -12 rmoveto
+          127 0 77 119 0 214 rrcurveto
+          0 214 -77 115 -127 0 rrcurveto
+          -128 0 -77 -115 0 -214 rrcurveto
+          0 -214 77 -119 128 0 rrcurveto
+          0 67 rmoveto
+          -74 0 -50 79 0 187 rrcurveto
+          0 187 50 75 74 0 rrcurveto
+          74 0 50 -75 0 -187 rrcurveto
+          0 -187 -50 -79 -74 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="zero.dnom">
+          -193 184 -12 rmoveto
+          89 0 60 75 0 133 rrcurveto
+          0 131 -60 75 -89 0 rrcurveto
+          -90 0 -59 -75 0 -131 rrcurveto
+          0 -133 59 -75 90 0 rrcurveto
+          0 51 rmoveto
+          -51 0 -36 53 0 104 rrcurveto
+          0 104 36 51 51 0 rrcurveto
+          51 0 35 -51 0 -104 rrcurveto
+          0 -104 -35 -53 -51 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="zero.numr">
+          -193 184 254 rmoveto
+          89 0 60 75 0 133 rrcurveto
+          0 131 -60 75 -89 0 rrcurveto
+          -90 0 -59 -75 0 -131 rrcurveto
+          0 -133 59 -75 90 0 rrcurveto
+          0 51 rmoveto
+          -51 0 -36 53 0 104 rrcurveto
+          0 104 36 51 51 0 rrcurveto
+          51 0 35 -51 0 -104 rrcurveto
+          0 -104 -35 -53 -51 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="zero.sups">
+          -193 184 382 rmoveto
+          89 0 60 75 0 133 rrcurveto
+          0 131 -60 75 -89 0 rrcurveto
+          -90 0 -59 -75 0 -131 rrcurveto
+          0 -133 59 -75 90 0 rrcurveto
+          0 51 rmoveto
+          -51 0 -36 53 0 104 rrcurveto
+          0 104 36 51 51 0 rrcurveto
+          51 0 35 -51 0 -104 rrcurveto
+          0 -104 -35 -53 -51 0 rrcurveto
+          endchar
+        </CharString>
+      </CharStrings>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF>
+
+  <BASE>
+    <Version value="0x00010000"/>
+    <HorizAxis>
+      <BaseTagList>
+        <!-- BaseTagCount=2 -->
+        <BaselineTag index="0" value="ideo"/>
+        <BaselineTag index="1" value="romn"/>
+      </BaseTagList>
+      <BaseScriptList>
+        <!-- BaseScriptCount=4 -->
+        <BaseScriptRecord index="0">
+          <BaseScriptTag value="DFLT"/>
+          <BaseScript>
+            <BaseValues>
+              <DefaultIndex value="1"/>
+              <!-- BaseCoordCount=2 -->
+              <BaseCoord index="0" Format="1">
+                <Coordinate value="-170"/>
+              </BaseCoord>
+              <BaseCoord index="1" Format="1">
+                <Coordinate value="0"/>
+              </BaseCoord>
+            </BaseValues>
+            <!-- BaseLangSysCount=0 -->
+          </BaseScript>
+        </BaseScriptRecord>
+        <BaseScriptRecord index="1">
+          <BaseScriptTag value="cyrl"/>
+          <BaseScript>
+            <BaseValues>
+              <DefaultIndex value="1"/>
+              <!-- BaseCoordCount=2 -->
+              <BaseCoord index="0" Format="1">
+                <Coordinate value="-170"/>
+              </BaseCoord>
+              <BaseCoord index="1" Format="1">
+                <Coordinate value="0"/>
+              </BaseCoord>
+            </BaseValues>
+            <!-- BaseLangSysCount=0 -->
+          </BaseScript>
+        </BaseScriptRecord>
+        <BaseScriptRecord index="2">
+          <BaseScriptTag value="grek"/>
+          <BaseScript>
+            <BaseValues>
+              <DefaultIndex value="1"/>
+              <!-- BaseCoordCount=2 -->
+              <BaseCoord index="0" Format="1">
+                <Coordinate value="-170"/>
+              </BaseCoord>
+              <BaseCoord index="1" Format="1">
+                <Coordinate value="0"/>
+              </BaseCoord>
+            </BaseValues>
+            <!-- BaseLangSysCount=0 -->
+          </BaseScript>
+        </BaseScriptRecord>
+        <BaseScriptRecord index="3">
+          <BaseScriptTag value="latn"/>
+          <BaseScript>
+            <BaseValues>
+              <DefaultIndex value="1"/>
+              <!-- BaseCoordCount=2 -->
+              <BaseCoord index="0" Format="1">
+                <Coordinate value="-170"/>
+              </BaseCoord>
+              <BaseCoord index="1" Format="1">
+                <Coordinate value="0"/>
+              </BaseCoord>
+            </BaseValues>
+            <!-- BaseLangSysCount=0 -->
+          </BaseScript>
+        </BaseScriptRecord>
+      </BaseScriptList>
+    </HorizAxis>
+  </BASE>
+
+  <GDEF>
+    <Version value="0x00010000"/>
+    <GlyphClassDef Format="2">
+      <ClassDef glyph="A" class="1"/>
+      <ClassDef glyph="AE" class="1"/>
+      <ClassDef glyph="Aacute" class="4"/>
+      <ClassDef glyph="B" class="1"/>
+      <ClassDef glyph="C" class="1"/>
+      <ClassDef glyph="D" class="1"/>
+      <ClassDef glyph="E" class="1"/>
+      <ClassDef glyph="Eacute" class="4"/>
+      <ClassDef glyph="F" class="1"/>
+      <ClassDef glyph="G" class="1"/>
+      <ClassDef glyph="H" class="1"/>
+      <ClassDef glyph="I" class="1"/>
+      <ClassDef glyph="Iacute" class="4"/>
+      <ClassDef glyph="J" class="1"/>
+      <ClassDef glyph="K" class="1"/>
+      <ClassDef glyph="L" class="1"/>
+      <ClassDef glyph="M" class="1"/>
+      <ClassDef glyph="N" class="1"/>
+      <ClassDef glyph="O" class="1"/>
+      <ClassDef glyph="Oacute" class="4"/>
+      <ClassDef glyph="Oslash" class="1"/>
+      <ClassDef glyph="P" class="1"/>
+      <ClassDef glyph="Q" class="1"/>
+      <ClassDef glyph="R" class="1"/>
+      <ClassDef glyph="S" class="1"/>
+      <ClassDef glyph="T" class="1"/>
+      <ClassDef glyph="U" class="1"/>
+      <ClassDef glyph="Uacute" class="4"/>
+      <ClassDef glyph="V" class="1"/>
+      <ClassDef glyph="W" class="1"/>
+      <ClassDef glyph="X" class="1"/>
+      <ClassDef glyph="Y" class="1"/>
+      <ClassDef glyph="Z" class="1"/>
+      <ClassDef glyph="a" class="1"/>
+      <ClassDef glyph="aacute" class="4"/>
+      <ClassDef glyph="ae" class="1"/>
+      <ClassDef glyph="b" class="1"/>
+      <ClassDef glyph="c" class="1"/>
+      <ClassDef glyph="d" class="1"/>
+      <ClassDef glyph="e" class="1"/>
+      <ClassDef glyph="eacute" class="4"/>
+      <ClassDef glyph="eth" class="1"/>
+      <ClassDef glyph="f" class="1"/>
+      <ClassDef glyph="f_f" class="2"/>
+      <ClassDef glyph="f_f_t" class="2"/>
+      <ClassDef glyph="f_t" class="2"/>
+      <ClassDef glyph="g" class="1"/>
+      <ClassDef glyph="h" class="1"/>
+      <ClassDef glyph="i" class="1"/>
+      <ClassDef glyph="iacute" class="4"/>
+      <ClassDef glyph="j" class="1"/>
+      <ClassDef glyph="k" class="1"/>
+      <ClassDef glyph="l" class="1"/>
+      <ClassDef glyph="m" class="1"/>
+      <ClassDef glyph="n" class="1"/>
+      <ClassDef glyph="o" class="1"/>
+      <ClassDef glyph="oacute" class="4"/>
+      <ClassDef glyph="oslash" class="1"/>
+      <ClassDef glyph="p" class="1"/>
+      <ClassDef glyph="periodcentered" class="4"/>
+      <ClassDef glyph="q" class="1"/>
+      <ClassDef glyph="r" class="1"/>
+      <ClassDef glyph="s" class="1"/>
+      <ClassDef glyph="t" class="1"/>
+      <ClassDef glyph="thorn" class="1"/>
+      <ClassDef glyph="u" class="1"/>
+      <ClassDef glyph="uacute" class="4"/>
+      <ClassDef glyph="uni004C00B7004C" class="2"/>
+      <ClassDef glyph="uni006C00B7006C" class="2"/>
+      <ClassDef glyph="v" class="1"/>
+      <ClassDef glyph="w" class="1"/>
+      <ClassDef glyph="w.sups" class="1"/>
+      <ClassDef glyph="x" class="1"/>
+      <ClassDef glyph="y" class="1"/>
+      <ClassDef glyph="z" class="1"/>
+    </GlyphClassDef>
+  </GDEF>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=4 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="cyrl"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="2">
+        <ScriptTag value="grek"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="2"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="3">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="3"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=4 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="2">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="3">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="9"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
+        <!-- SubTableCount=6 -->
+        <ExtensionPos index="0" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="1">
+            <Coverage Format="1">
+              <Glyph value="F"/>
+              <Glyph value="V"/>
+              <Glyph value="f"/>
+              <Glyph value="h"/>
+              <Glyph value="m"/>
+              <Glyph value="n"/>
+              <Glyph value="r"/>
+              <Glyph value="x"/>
+              <Glyph value="ntilde"/>
+              <Glyph value="f_f"/>
+              <Glyph value="slash"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <!-- PairSetCount=11 -->
+            <PairSet index="0">
+              <!-- PairValueCount=2 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="icircumflex"/>
+                <Value1 XAdvance="29"/>
+              </PairValueRecord>
+              <PairValueRecord index="1">
+                <SecondGlyph value="idieresis"/>
+                <Value1 XAdvance="36"/>
+              </PairValueRecord>
+            </PairSet>
+            <PairSet index="1">
+              <!-- PairValueCount=4 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="igrave"/>
+                <Value1 XAdvance="20"/>
+              </PairValueRecord>
+              <PairValueRecord index="1">
+                <SecondGlyph value="iacute"/>
+                <Value1 XAdvance="13"/>
+              </PairValueRecord>
+              <PairValueRecord index="2">
+                <SecondGlyph value="icircumflex"/>
+                <Value1 XAdvance="53"/>
+              </PairValueRecord>
+              <PairValueRecord index="3">
+                <SecondGlyph value="idieresis"/>
+                <Value1 XAdvance="64"/>
+              </PairValueRecord>
+            </PairSet>
+            <PairSet index="2">
+              <!-- PairValueCount=3 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="igrave"/>
+                <Value1 XAdvance="60"/>
+              </PairValueRecord>
+              <PairValueRecord index="1">
+                <SecondGlyph value="icircumflex"/>
+                <Value1 XAdvance="60"/>
+              </PairValueRecord>
+              <PairValueRecord index="2">
+                <SecondGlyph value="idieresis"/>
+                <Value1 XAdvance="60"/>
+              </PairValueRecord>
+            </PairSet>
+            <PairSet index="3">
+              <!-- PairValueCount=1 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="j.sups"/>
+                <Value1 XAdvance="27"/>
+              </PairValueRecord>
+            </PairSet>
+            <PairSet index="4">
+              <!-- PairValueCount=1 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="j.sups"/>
+                <Value1 XAdvance="27"/>
+              </PairValueRecord>
+            </PairSet>
+            <PairSet index="5">
+              <!-- PairValueCount=1 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="j.sups"/>
+                <Value1 XAdvance="27"/>
+              </PairValueRecord>
+            </PairSet>
+            <PairSet index="6">
+              <!-- PairValueCount=1 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="y.sups"/>
+                <Value1 XAdvance="20"/>
+              </PairValueRecord>
+            </PairSet>
+            <PairSet index="7">
+              <!-- PairValueCount=2 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="comma"/>
+                <Value1 XAdvance="7"/>
+              </PairValueRecord>
+              <PairValueRecord index="1">
+                <SecondGlyph value="semicolon"/>
+                <Value1 XAdvance="7"/>
+              </PairValueRecord>
+            </PairSet>
+            <PairSet index="8">
+              <!-- PairValueCount=1 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="j.sups"/>
+                <Value1 XAdvance="27"/>
+              </PairValueRecord>
+            </PairSet>
+            <PairSet index="9">
+              <!-- PairValueCount=3 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="igrave"/>
+                <Value1 XAdvance="60"/>
+              </PairValueRecord>
+              <PairValueRecord index="1">
+                <SecondGlyph value="icircumflex"/>
+                <Value1 XAdvance="60"/>
+              </PairValueRecord>
+              <PairValueRecord index="2">
+                <SecondGlyph value="idieresis"/>
+                <Value1 XAdvance="60"/>
+              </PairValueRecord>
+            </PairSet>
+            <PairSet index="10">
+              <!-- PairValueCount=3 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="igrave"/>
+                <Value1 XAdvance="40"/>
+              </PairValueRecord>
+              <PairValueRecord index="1">
+                <SecondGlyph value="icircumflex"/>
+                <Value1 XAdvance="65"/>
+              </PairValueRecord>
+              <PairValueRecord index="2">
+                <SecondGlyph value="idieresis"/>
+                <Value1 XAdvance="65"/>
+              </PairValueRecord>
+            </PairSet>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="1" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="2">
+            <Coverage Format="1">
+              <Glyph value="exclamdown"/>
+              <Glyph value="questiondown"/>
+              <Glyph value="periodcentered"/>
+              <Glyph value="slash"/>
+              <Glyph value="backslash"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <ClassDef1 Format="2">
+              <ClassDef glyph="backslash" class="1"/>
+              <ClassDef glyph="exclamdown" class="2"/>
+              <ClassDef glyph="periodcentered" class="3"/>
+              <ClassDef glyph="questiondown" class="4"/>
+              <ClassDef glyph="slash" class="5"/>
+            </ClassDef1>
+            <ClassDef2 Format="1">
+              <ClassDef glyph="A" class="2"/>
+              <ClassDef glyph="Aacute" class="2"/>
+              <ClassDef glyph="Acircumflex" class="2"/>
+              <ClassDef glyph="Adieresis" class="2"/>
+              <ClassDef glyph="Agrave" class="2"/>
+              <ClassDef glyph="Aring" class="2"/>
+              <ClassDef glyph="Atilde" class="2"/>
+              <ClassDef glyph="C" class="30"/>
+              <ClassDef glyph="Ccedilla" class="30"/>
+              <ClassDef glyph="Eth" class="6"/>
+              <ClassDef glyph="G" class="30"/>
+              <ClassDef glyph="J" class="4"/>
+              <ClassDef glyph="O" class="30"/>
+              <ClassDef glyph="Oacute" class="30"/>
+              <ClassDef glyph="Ocircumflex" class="30"/>
+              <ClassDef glyph="Odieresis" class="30"/>
+              <ClassDef glyph="Ograve" class="30"/>
+              <ClassDef glyph="Oslash" class="30"/>
+              <ClassDef glyph="Otilde" class="30"/>
+              <ClassDef glyph="Q" class="30"/>
+              <ClassDef glyph="S" class="27"/>
+              <ClassDef glyph="T" class="8"/>
+              <ClassDef glyph="U" class="9"/>
+              <ClassDef glyph="Uacute" class="9"/>
+              <ClassDef glyph="Ucircumflex" class="9"/>
+              <ClassDef glyph="Udieresis" class="9"/>
+              <ClassDef glyph="Ugrave" class="9"/>
+              <ClassDef glyph="V" class="11"/>
+              <ClassDef glyph="W" class="13"/>
+              <ClassDef glyph="X" class="28"/>
+              <ClassDef glyph="Y" class="15"/>
+              <ClassDef glyph="Yacute" class="15"/>
+              <ClassDef glyph="Z" class="29"/>
+              <ClassDef glyph="a" class="1"/>
+              <ClassDef glyph="aacute" class="1"/>
+              <ClassDef glyph="acircumflex" class="1"/>
+              <ClassDef glyph="adieresis" class="1"/>
+              <ClassDef glyph="ae" class="1"/>
+              <ClassDef glyph="agrave" class="1"/>
+              <ClassDef glyph="aring" class="1"/>
+              <ClassDef glyph="atilde" class="1"/>
+              <ClassDef glyph="b" class="33"/>
+              <ClassDef glyph="c" class="16"/>
+              <ClassDef glyph="ccedilla" class="16"/>
+              <ClassDef glyph="colon" class="26"/>
+              <ClassDef glyph="comma" class="21"/>
+              <ClassDef glyph="d" class="16"/>
+              <ClassDef glyph="e" class="16"/>
+              <ClassDef glyph="eacute" class="16"/>
+              <ClassDef glyph="ecircumflex" class="16"/>
+              <ClassDef glyph="edieresis" class="16"/>
+              <ClassDef glyph="egrave" class="16"/>
+              <ClassDef glyph="f" class="23"/>
+              <ClassDef glyph="f_f" class="23"/>
+              <ClassDef glyph="f_f_t" class="23"/>
+              <ClassDef glyph="f_t" class="23"/>
+              <ClassDef glyph="g" class="3"/>
+              <ClassDef glyph="germandbls" class="33"/>
+              <ClassDef glyph="guillemotleft" class="32"/>
+              <ClassDef glyph="guillemotright" class="5"/>
+              <ClassDef glyph="h" class="33"/>
+              <ClassDef glyph="hyphen" class="22"/>
+              <ClassDef glyph="i" class="31"/>
+              <ClassDef glyph="iacute" class="31"/>
+              <ClassDef glyph="icircumflex" class="31"/>
+              <ClassDef glyph="idieresis" class="31"/>
+              <ClassDef glyph="igrave" class="31"/>
+              <ClassDef glyph="j" class="7"/>
+              <ClassDef glyph="k" class="33"/>
+              <ClassDef glyph="l" class="33"/>
+              <ClassDef glyph="m" class="17"/>
+              <ClassDef glyph="n" class="17"/>
+              <ClassDef glyph="ntilde" class="17"/>
+              <ClassDef glyph="o" class="16"/>
+              <ClassDef glyph="oacute" class="16"/>
+              <ClassDef glyph="ocircumflex" class="16"/>
+              <ClassDef glyph="odieresis" class="16"/>
+              <ClassDef glyph="ograve" class="16"/>
+              <ClassDef glyph="oslash" class="16"/>
+              <ClassDef glyph="otilde" class="16"/>
+              <ClassDef glyph="p" class="17"/>
+              <ClassDef glyph="period" class="21"/>
+              <ClassDef glyph="q" class="16"/>
+              <ClassDef glyph="r" class="17"/>
+              <ClassDef glyph="s" class="18"/>
+              <ClassDef glyph="semicolon" class="26"/>
+              <ClassDef glyph="t" class="24"/>
+              <ClassDef glyph="thorn" class="33"/>
+              <ClassDef glyph="u" class="19"/>
+              <ClassDef glyph="uacute" class="19"/>
+              <ClassDef glyph="ucircumflex" class="19"/>
+              <ClassDef glyph="udieresis" class="19"/>
+              <ClassDef glyph="ugrave" class="19"/>
+              <ClassDef glyph="uni006C00B7006C" class="33"/>
+              <ClassDef glyph="v" class="10"/>
+              <ClassDef glyph="w" class="12"/>
+              <ClassDef glyph="x" class="25"/>
+              <ClassDef glyph="y" class="14"/>
+              <ClassDef glyph="yacute" class="14"/>
+              <ClassDef glyph="ydieresis" class="14"/>
+              <ClassDef glyph="z" class="20"/>
+            </ClassDef2>
+            <!-- Class1Count=6 -->
+            <!-- Class2Count=34 -->
+            <Class1Record index="0">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-13"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-6"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-13"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="-50"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="1">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="33"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-29"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="73"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-85"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-29"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-53"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-29"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="13"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-73"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="2">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="33"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-32"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-45"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="3">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-64"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-59"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-38"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="4">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-35"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-62"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="59"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-87"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-59"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-90"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-21"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="-62"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-35"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-42"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-45"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="5">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="-80"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="25"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-31"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="9"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="25"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="2" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="2">
+            <Coverage Format="1">
+              <Glyph value="mu"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <ClassDef1 Format="1">
+              <ClassDef glyph="mu" class="1"/>
+            </ClassDef1>
+            <ClassDef2 Format="2">
+              <ClassDef glyph="asterisk" class="12"/>
+              <ClassDef glyph="backslash" class="13"/>
+              <ClassDef glyph="braceright" class="2"/>
+              <ClassDef glyph="bracketright" class="2"/>
+              <ClassDef glyph="colon" class="3"/>
+              <ClassDef glyph="comma" class="4"/>
+              <ClassDef glyph="exclam" class="14"/>
+              <ClassDef glyph="guillemotleft" class="9"/>
+              <ClassDef glyph="guillemotright" class="10"/>
+              <ClassDef glyph="hyphen" class="5"/>
+              <ClassDef glyph="i" class="1"/>
+              <ClassDef glyph="iacute" class="1"/>
+              <ClassDef glyph="icircumflex" class="1"/>
+              <ClassDef glyph="idieresis" class="1"/>
+              <ClassDef glyph="igrave" class="1"/>
+              <ClassDef glyph="mu" class="16"/>
+              <ClassDef glyph="parenright" class="2"/>
+              <ClassDef glyph="period" class="4"/>
+              <ClassDef glyph="periodcentered" class="8"/>
+              <ClassDef glyph="question" class="6"/>
+              <ClassDef glyph="quotedbl" class="7"/>
+              <ClassDef glyph="quotesingle" class="7"/>
+              <ClassDef glyph="registered" class="15"/>
+              <ClassDef glyph="semicolon" class="3"/>
+              <ClassDef glyph="slash" class="11"/>
+            </ClassDef2>
+            <!-- Class1Count=2 -->
+            <!-- Class2Count=17 -->
+            <Class1Record index="0">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="7"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="1">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="7"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="7"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="3" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="2">
+            <Coverage Format="2">
+              <Glyph value="A"/>
+              <Glyph value="B"/>
+              <Glyph value="C"/>
+              <Glyph value="E"/>
+              <Glyph value="F"/>
+              <Glyph value="a"/>
+              <Glyph value="c"/>
+              <Glyph value="d"/>
+              <Glyph value="e"/>
+              <Glyph value="f"/>
+              <Glyph value="g"/>
+              <Glyph value="Agrave"/>
+              <Glyph value="Aacute"/>
+              <Glyph value="Acircumflex"/>
+              <Glyph value="Atilde"/>
+              <Glyph value="Adieresis"/>
+              <Glyph value="Aring"/>
+              <Glyph value="AE"/>
+              <Glyph value="Ccedilla"/>
+              <Glyph value="Egrave"/>
+              <Glyph value="Eacute"/>
+              <Glyph value="Ecircumflex"/>
+              <Glyph value="Edieresis"/>
+              <Glyph value="agrave"/>
+              <Glyph value="aacute"/>
+              <Glyph value="acircumflex"/>
+              <Glyph value="atilde"/>
+              <Glyph value="adieresis"/>
+              <Glyph value="aring"/>
+              <Glyph value="ae"/>
+              <Glyph value="ccedilla"/>
+              <Glyph value="egrave"/>
+              <Glyph value="eacute"/>
+              <Glyph value="ecircumflex"/>
+              <Glyph value="edieresis"/>
+              <Glyph value="germandbls"/>
+              <Glyph value="f_f"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <ClassDef1 Format="2">
+              <ClassDef glyph="A" class="2"/>
+              <ClassDef glyph="AE" class="8"/>
+              <ClassDef glyph="Aacute" class="2"/>
+              <ClassDef glyph="Acircumflex" class="2"/>
+              <ClassDef glyph="Adieresis" class="2"/>
+              <ClassDef glyph="Agrave" class="2"/>
+              <ClassDef glyph="Aring" class="2"/>
+              <ClassDef glyph="Atilde" class="2"/>
+              <ClassDef glyph="B" class="3"/>
+              <ClassDef glyph="C" class="5"/>
+              <ClassDef glyph="Ccedilla" class="5"/>
+              <ClassDef glyph="E" class="8"/>
+              <ClassDef glyph="Eacute" class="8"/>
+              <ClassDef glyph="Ecircumflex" class="8"/>
+              <ClassDef glyph="Edieresis" class="8"/>
+              <ClassDef glyph="Egrave" class="8"/>
+              <ClassDef glyph="F" class="10"/>
+              <ClassDef glyph="a" class="1"/>
+              <ClassDef glyph="aacute" class="1"/>
+              <ClassDef glyph="acircumflex" class="1"/>
+              <ClassDef glyph="adieresis" class="1"/>
+              <ClassDef glyph="ae" class="7"/>
+              <ClassDef glyph="agrave" class="1"/>
+              <ClassDef glyph="aring" class="1"/>
+              <ClassDef glyph="atilde" class="1"/>
+              <ClassDef glyph="c" class="4"/>
+              <ClassDef glyph="ccedilla" class="4"/>
+              <ClassDef glyph="d" class="6"/>
+              <ClassDef glyph="e" class="7"/>
+              <ClassDef glyph="eacute" class="7"/>
+              <ClassDef glyph="ecircumflex" class="7"/>
+              <ClassDef glyph="edieresis" class="7"/>
+              <ClassDef glyph="egrave" class="7"/>
+              <ClassDef glyph="f" class="9"/>
+              <ClassDef glyph="f_f" class="9"/>
+              <ClassDef glyph="g" class="12"/>
+              <ClassDef glyph="germandbls" class="11"/>
+            </ClassDef1>
+            <ClassDef2 Format="2">
+              <ClassDef glyph="A" class="20"/>
+              <ClassDef glyph="Aacute" class="20"/>
+              <ClassDef glyph="Acircumflex" class="20"/>
+              <ClassDef glyph="Adieresis" class="20"/>
+              <ClassDef glyph="Agrave" class="20"/>
+              <ClassDef glyph="Aring" class="20"/>
+              <ClassDef glyph="Atilde" class="20"/>
+              <ClassDef glyph="C" class="22"/>
+              <ClassDef glyph="Ccedilla" class="22"/>
+              <ClassDef glyph="G" class="22"/>
+              <ClassDef glyph="J" class="34"/>
+              <ClassDef glyph="O" class="22"/>
+              <ClassDef glyph="Oacute" class="22"/>
+              <ClassDef glyph="Ocircumflex" class="22"/>
+              <ClassDef glyph="Odieresis" class="22"/>
+              <ClassDef glyph="Ograve" class="22"/>
+              <ClassDef glyph="Oslash" class="22"/>
+              <ClassDef glyph="Otilde" class="22"/>
+              <ClassDef glyph="Q" class="22"/>
+              <ClassDef glyph="S" class="35"/>
+              <ClassDef glyph="T" class="15"/>
+              <ClassDef glyph="U" class="25"/>
+              <ClassDef glyph="Uacute" class="25"/>
+              <ClassDef glyph="Ucircumflex" class="25"/>
+              <ClassDef glyph="Udieresis" class="25"/>
+              <ClassDef glyph="Ugrave" class="25"/>
+              <ClassDef glyph="V" class="16"/>
+              <ClassDef glyph="W" class="17"/>
+              <ClassDef glyph="X" class="29"/>
+              <ClassDef glyph="Y" class="18"/>
+              <ClassDef glyph="Yacute" class="18"/>
+              <ClassDef glyph="Z" class="31"/>
+              <ClassDef glyph="a" class="19"/>
+              <ClassDef glyph="aacute" class="19"/>
+              <ClassDef glyph="acircumflex" class="19"/>
+              <ClassDef glyph="adieresis" class="19"/>
+              <ClassDef glyph="ae" class="19"/>
+              <ClassDef glyph="agrave" class="19"/>
+              <ClassDef glyph="aring" class="19"/>
+              <ClassDef glyph="asterisk" class="3"/>
+              <ClassDef glyph="atilde" class="19"/>
+              <ClassDef glyph="b.sups" class="39"/>
+              <ClassDef glyph="backslash" class="32"/>
+              <ClassDef glyph="braceright" class="6"/>
+              <ClassDef glyph="bracketright" class="6"/>
+              <ClassDef glyph="c" class="37"/>
+              <ClassDef glyph="ccedilla" class="37"/>
+              <ClassDef glyph="colon" class="10"/>
+              <ClassDef glyph="comma" class="1"/>
+              <ClassDef glyph="d" class="37"/>
+              <ClassDef glyph="e" class="37"/>
+              <ClassDef glyph="eacute" class="37"/>
+              <ClassDef glyph="ecircumflex" class="37"/>
+              <ClassDef glyph="edieresis" class="37"/>
+              <ClassDef glyph="egrave" class="37"/>
+              <ClassDef glyph="exclam" class="43"/>
+              <ClassDef glyph="f" class="21"/>
+              <ClassDef glyph="f_f" class="21"/>
+              <ClassDef glyph="f_f_t" class="21"/>
+              <ClassDef glyph="f_t" class="21"/>
+              <ClassDef glyph="g" class="36"/>
+              <ClassDef glyph="g.sups" class="40"/>
+              <ClassDef glyph="guillemotleft" class="11"/>
+              <ClassDef glyph="guillemotright" class="2"/>
+              <ClassDef glyph="h.sups" class="39"/>
+              <ClassDef glyph="hyphen" class="7"/>
+              <ClassDef glyph="i" class="38"/>
+              <ClassDef glyph="i.sups" class="39"/>
+              <ClassDef glyph="iacute" class="38"/>
+              <ClassDef glyph="icircumflex" class="38"/>
+              <ClassDef glyph="idieresis" class="38"/>
+              <ClassDef glyph="igrave" class="38"/>
+              <ClassDef glyph="j" class="41"/>
+              <ClassDef glyph="j.sups" class="40"/>
+              <ClassDef glyph="k.sups" class="39"/>
+              <ClassDef glyph="l.sups" class="39"/>
+              <ClassDef glyph="m" class="44"/>
+              <ClassDef glyph="m.sups" class="39"/>
+              <ClassDef glyph="mu" class="5"/>
+              <ClassDef glyph="n" class="44"/>
+              <ClassDef glyph="n.sups" class="39"/>
+              <ClassDef glyph="ntilde" class="44"/>
+              <ClassDef glyph="o" class="37"/>
+              <ClassDef glyph="oacute" class="37"/>
+              <ClassDef glyph="ocircumflex" class="37"/>
+              <ClassDef glyph="odieresis" class="37"/>
+              <ClassDef glyph="ograve" class="37"/>
+              <ClassDef glyph="oslash" class="37"/>
+              <ClassDef glyph="otilde" class="37"/>
+              <ClassDef glyph="p" class="44"/>
+              <ClassDef glyph="p.sups" class="40"/>
+              <ClassDef glyph="parenright" class="6"/>
+              <ClassDef glyph="period" class="1"/>
+              <ClassDef glyph="periodcentered" class="9"/>
+              <ClassDef glyph="q" class="37"/>
+              <ClassDef glyph="question" class="12"/>
+              <ClassDef glyph="quotedbl" class="8"/>
+              <ClassDef glyph="quotesingle" class="8"/>
+              <ClassDef glyph="r" class="44"/>
+              <ClassDef glyph="r.sups" class="39"/>
+              <ClassDef glyph="registered" class="33"/>
+              <ClassDef glyph="s" class="23"/>
+              <ClassDef glyph="semicolon" class="10"/>
+              <ClassDef glyph="slash" class="4"/>
+              <ClassDef glyph="t" class="14"/>
+              <ClassDef glyph="u" class="24"/>
+              <ClassDef glyph="u.sups" class="39"/>
+              <ClassDef glyph="uacute" class="24"/>
+              <ClassDef glyph="ucircumflex" class="24"/>
+              <ClassDef glyph="udieresis" class="24"/>
+              <ClassDef glyph="ugrave" class="24"/>
+              <ClassDef glyph="v" class="26"/>
+              <ClassDef glyph="v.sups" class="13"/>
+              <ClassDef glyph="w" class="27"/>
+              <ClassDef glyph="w.sups" class="13"/>
+              <ClassDef glyph="x" class="28"/>
+              <ClassDef glyph="y" class="30"/>
+              <ClassDef glyph="y.sups" class="40"/>
+              <ClassDef glyph="yacute" class="30"/>
+              <ClassDef glyph="ydieresis" class="30"/>
+              <ClassDef glyph="z" class="42"/>
+            </ClassDef2>
+            <!-- Class1Count=13 -->
+            <!-- Class2Count=45 -->
+            <Class1Record index="0">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-27"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="1">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-54"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-60"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="2">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-94"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-55"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-55"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="23"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-6"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="23"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-6"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-15"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="4"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="-80"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="3">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-6"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="4">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="6"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="6"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="8"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="6"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-21"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="5">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-52"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-27"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="-29"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="6">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="7">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="5"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="5"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="5"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="8">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-31"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="9">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-50"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="49"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="26"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="46"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="66"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="46"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="59"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="13"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="33"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="61"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="75"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="14"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="10">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-72"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="-69"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="4"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="4"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-37"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="-138"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="11">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-67"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="6"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="-35"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="12">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-33"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="48"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="14"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-36"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="15"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="14"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="37"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="4" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="2">
+            <Coverage Format="2">
+              <Glyph value="D"/>
+              <Glyph value="G"/>
+              <Glyph value="H"/>
+              <Glyph value="I"/>
+              <Glyph value="J"/>
+              <Glyph value="K"/>
+              <Glyph value="L"/>
+              <Glyph value="M"/>
+              <Glyph value="N"/>
+              <Glyph value="O"/>
+              <Glyph value="P"/>
+              <Glyph value="Q"/>
+              <Glyph value="R"/>
+              <Glyph value="S"/>
+              <Glyph value="T"/>
+              <Glyph value="U"/>
+              <Glyph value="V"/>
+              <Glyph value="W"/>
+              <Glyph value="X"/>
+              <Glyph value="b"/>
+              <Glyph value="h"/>
+              <Glyph value="i"/>
+              <Glyph value="j"/>
+              <Glyph value="k"/>
+              <Glyph value="l"/>
+              <Glyph value="m"/>
+              <Glyph value="n"/>
+              <Glyph value="o"/>
+              <Glyph value="p"/>
+              <Glyph value="q"/>
+              <Glyph value="r"/>
+              <Glyph value="s"/>
+              <Glyph value="t"/>
+              <Glyph value="u"/>
+              <Glyph value="v"/>
+              <Glyph value="w"/>
+              <Glyph value="x"/>
+              <Glyph value="y"/>
+              <Glyph value="Igrave"/>
+              <Glyph value="Iacute"/>
+              <Glyph value="Icircumflex"/>
+              <Glyph value="Idieresis"/>
+              <Glyph value="Ntilde"/>
+              <Glyph value="Ograve"/>
+              <Glyph value="Oacute"/>
+              <Glyph value="Ocircumflex"/>
+              <Glyph value="Otilde"/>
+              <Glyph value="Odieresis"/>
+              <Glyph value="Oslash"/>
+              <Glyph value="Ugrave"/>
+              <Glyph value="Uacute"/>
+              <Glyph value="Ucircumflex"/>
+              <Glyph value="Udieresis"/>
+              <Glyph value="Eth"/>
+              <Glyph value="Thorn"/>
+              <Glyph value="uni004C00B7004C"/>
+              <Glyph value="igrave"/>
+              <Glyph value="iacute"/>
+              <Glyph value="icircumflex"/>
+              <Glyph value="idieresis"/>
+              <Glyph value="ntilde"/>
+              <Glyph value="ograve"/>
+              <Glyph value="oacute"/>
+              <Glyph value="ocircumflex"/>
+              <Glyph value="otilde"/>
+              <Glyph value="odieresis"/>
+              <Glyph value="oslash"/>
+              <Glyph value="ugrave"/>
+              <Glyph value="uacute"/>
+              <Glyph value="ucircumflex"/>
+              <Glyph value="udieresis"/>
+              <Glyph value="yacute"/>
+              <Glyph value="ydieresis"/>
+              <Glyph value="thorn"/>
+              <Glyph value="uni006C00B7006C"/>
+              <Glyph value="f_t"/>
+              <Glyph value="f_f_t"/>
+              <Glyph value="a.sups"/>
+              <Glyph value="d.sups"/>
+              <Glyph value="h.sups"/>
+              <Glyph value="i.sups"/>
+              <Glyph value="j.sups"/>
+              <Glyph value="l.sups"/>
+              <Glyph value="m.sups"/>
+              <Glyph value="n.sups"/>
+              <Glyph value="q.sups"/>
+              <Glyph value="u.sups"/>
+              <Glyph value="v.sups"/>
+              <Glyph value="w.sups"/>
+              <Glyph value="y.sups"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <ClassDef1 Format="2">
+              <ClassDef glyph="D" class="12"/>
+              <ClassDef glyph="Eth" class="12"/>
+              <ClassDef glyph="H" class="1"/>
+              <ClassDef glyph="I" class="3"/>
+              <ClassDef glyph="Iacute" class="3"/>
+              <ClassDef glyph="Icircumflex" class="3"/>
+              <ClassDef glyph="Idieresis" class="3"/>
+              <ClassDef glyph="Igrave" class="3"/>
+              <ClassDef glyph="J" class="5"/>
+              <ClassDef glyph="K" class="7"/>
+              <ClassDef glyph="L" class="9"/>
+              <ClassDef glyph="M" class="1"/>
+              <ClassDef glyph="N" class="1"/>
+              <ClassDef glyph="Ntilde" class="1"/>
+              <ClassDef glyph="O" class="12"/>
+              <ClassDef glyph="Oacute" class="12"/>
+              <ClassDef glyph="Ocircumflex" class="12"/>
+              <ClassDef glyph="Odieresis" class="12"/>
+              <ClassDef glyph="Ograve" class="12"/>
+              <ClassDef glyph="Oslash" class="12"/>
+              <ClassDef glyph="Otilde" class="12"/>
+              <ClassDef glyph="P" class="13"/>
+              <ClassDef glyph="Q" class="12"/>
+              <ClassDef glyph="R" class="15"/>
+              <ClassDef glyph="S" class="21"/>
+              <ClassDef glyph="T" class="24"/>
+              <ClassDef glyph="Thorn" class="22"/>
+              <ClassDef glyph="U" class="26"/>
+              <ClassDef glyph="Uacute" class="26"/>
+              <ClassDef glyph="Ucircumflex" class="26"/>
+              <ClassDef glyph="Udieresis" class="26"/>
+              <ClassDef glyph="Ugrave" class="26"/>
+              <ClassDef glyph="V" class="28"/>
+              <ClassDef glyph="W" class="30"/>
+              <ClassDef glyph="X" class="32"/>
+              <ClassDef glyph="a.sups" class="18"/>
+              <ClassDef glyph="b" class="11"/>
+              <ClassDef glyph="d.sups" class="16"/>
+              <ClassDef glyph="f_f_t" class="23"/>
+              <ClassDef glyph="f_t" class="23"/>
+              <ClassDef glyph="h" class="10"/>
+              <ClassDef glyph="h.sups" class="18"/>
+              <ClassDef glyph="i" class="2"/>
+              <ClassDef glyph="i.sups" class="16"/>
+              <ClassDef glyph="iacute" class="2"/>
+              <ClassDef glyph="icircumflex" class="2"/>
+              <ClassDef glyph="idieresis" class="2"/>
+              <ClassDef glyph="igrave" class="2"/>
+              <ClassDef glyph="j" class="4"/>
+              <ClassDef glyph="j.sups" class="17"/>
+              <ClassDef glyph="k" class="6"/>
+              <ClassDef glyph="l" class="8"/>
+              <ClassDef glyph="l.sups" class="16"/>
+              <ClassDef glyph="m" class="10"/>
+              <ClassDef glyph="m.sups" class="18"/>
+              <ClassDef glyph="n" class="10"/>
+              <ClassDef glyph="n.sups" class="18"/>
+              <ClassDef glyph="ntilde" class="10"/>
+              <ClassDef glyph="o" class="11"/>
+              <ClassDef glyph="oacute" class="11"/>
+              <ClassDef glyph="ocircumflex" class="11"/>
+              <ClassDef glyph="odieresis" class="11"/>
+              <ClassDef glyph="ograve" class="11"/>
+              <ClassDef glyph="oslash" class="11"/>
+              <ClassDef glyph="otilde" class="11"/>
+              <ClassDef glyph="p" class="11"/>
+              <ClassDef glyph="q" class="25"/>
+              <ClassDef glyph="q.sups" class="17"/>
+              <ClassDef glyph="r" class="14"/>
+              <ClassDef glyph="s" class="20"/>
+              <ClassDef glyph="t" class="23"/>
+              <ClassDef glyph="thorn" class="11"/>
+              <ClassDef glyph="u" class="25"/>
+              <ClassDef glyph="u.sups" class="16"/>
+              <ClassDef glyph="uacute" class="25"/>
+              <ClassDef glyph="ucircumflex" class="25"/>
+              <ClassDef glyph="udieresis" class="25"/>
+              <ClassDef glyph="ugrave" class="25"/>
+              <ClassDef glyph="uni004C00B7004C" class="9"/>
+              <ClassDef glyph="uni006C00B7006C" class="8"/>
+              <ClassDef glyph="v" class="27"/>
+              <ClassDef glyph="v.sups" class="19"/>
+              <ClassDef glyph="w" class="29"/>
+              <ClassDef glyph="w.sups" class="19"/>
+              <ClassDef glyph="x" class="31"/>
+              <ClassDef glyph="y" class="33"/>
+              <ClassDef glyph="y.sups" class="19"/>
+              <ClassDef glyph="yacute" class="33"/>
+              <ClassDef glyph="ydieresis" class="33"/>
+            </ClassDef1>
+            <ClassDef2 Format="2">
+              <ClassDef glyph="A" class="1"/>
+              <ClassDef glyph="AE" class="42"/>
+              <ClassDef glyph="Aacute" class="1"/>
+              <ClassDef glyph="Acircumflex" class="1"/>
+              <ClassDef glyph="Adieresis" class="1"/>
+              <ClassDef glyph="Agrave" class="1"/>
+              <ClassDef glyph="Aring" class="1"/>
+              <ClassDef glyph="Atilde" class="1"/>
+              <ClassDef glyph="C" class="12"/>
+              <ClassDef glyph="Ccedilla" class="12"/>
+              <ClassDef glyph="G" class="12"/>
+              <ClassDef glyph="J" class="18"/>
+              <ClassDef glyph="O" class="12"/>
+              <ClassDef glyph="Oacute" class="12"/>
+              <ClassDef glyph="Ocircumflex" class="12"/>
+              <ClassDef glyph="Odieresis" class="12"/>
+              <ClassDef glyph="Ograve" class="12"/>
+              <ClassDef glyph="Oslash" class="12"/>
+              <ClassDef glyph="Otilde" class="12"/>
+              <ClassDef glyph="Q" class="12"/>
+              <ClassDef glyph="S" class="33"/>
+              <ClassDef glyph="T" class="2"/>
+              <ClassDef glyph="U" class="34"/>
+              <ClassDef glyph="Uacute" class="34"/>
+              <ClassDef glyph="Ucircumflex" class="34"/>
+              <ClassDef glyph="Udieresis" class="34"/>
+              <ClassDef glyph="Ugrave" class="34"/>
+              <ClassDef glyph="V" class="3"/>
+              <ClassDef glyph="W" class="4"/>
+              <ClassDef glyph="X" class="39"/>
+              <ClassDef glyph="Y" class="8"/>
+              <ClassDef glyph="Yacute" class="8"/>
+              <ClassDef glyph="Z" class="40"/>
+              <ClassDef glyph="a" class="19"/>
+              <ClassDef glyph="a.sups" class="22"/>
+              <ClassDef glyph="aacute" class="19"/>
+              <ClassDef glyph="acircumflex" class="19"/>
+              <ClassDef glyph="adieresis" class="19"/>
+              <ClassDef glyph="ae" class="19"/>
+              <ClassDef glyph="agrave" class="19"/>
+              <ClassDef glyph="aring" class="19"/>
+              <ClassDef glyph="asterisk" class="5"/>
+              <ClassDef glyph="atilde" class="19"/>
+              <ClassDef glyph="b.sups" class="21"/>
+              <ClassDef glyph="backslash" class="36"/>
+              <ClassDef glyph="braceright" class="37"/>
+              <ClassDef glyph="bracketright" class="37"/>
+              <ClassDef glyph="c" class="11"/>
+              <ClassDef glyph="c.sups" class="22"/>
+              <ClassDef glyph="ccedilla" class="11"/>
+              <ClassDef glyph="colon" class="27"/>
+              <ClassDef glyph="comma" class="17"/>
+              <ClassDef glyph="d" class="11"/>
+              <ClassDef glyph="d.sups" class="22"/>
+              <ClassDef glyph="e" class="11"/>
+              <ClassDef glyph="e.sups" class="22"/>
+              <ClassDef glyph="eacute" class="11"/>
+              <ClassDef glyph="eacute.sups" class="22"/>
+              <ClassDef glyph="ecircumflex" class="11"/>
+              <ClassDef glyph="edieresis" class="11"/>
+              <ClassDef glyph="egrave" class="11"/>
+              <ClassDef glyph="egrave.sups" class="22"/>
+              <ClassDef glyph="exclam" class="45"/>
+              <ClassDef glyph="f" class="9"/>
+              <ClassDef glyph="f_f" class="9"/>
+              <ClassDef glyph="f_f_t" class="9"/>
+              <ClassDef glyph="f_t" class="9"/>
+              <ClassDef glyph="g" class="10"/>
+              <ClassDef glyph="g.sups" class="38"/>
+              <ClassDef glyph="guillemotleft" class="29"/>
+              <ClassDef glyph="guillemotright" class="30"/>
+              <ClassDef glyph="h.sups" class="21"/>
+              <ClassDef glyph="hyphen" class="28"/>
+              <ClassDef glyph="i" class="44"/>
+              <ClassDef glyph="i.sups" class="21"/>
+              <ClassDef glyph="iacute" class="44"/>
+              <ClassDef glyph="icircumflex" class="44"/>
+              <ClassDef glyph="idieresis" class="44"/>
+              <ClassDef glyph="igrave" class="44"/>
+              <ClassDef glyph="j" class="20"/>
+              <ClassDef glyph="j.sups" class="38"/>
+              <ClassDef glyph="k.sups" class="21"/>
+              <ClassDef glyph="l.sups" class="21"/>
+              <ClassDef glyph="m" class="43"/>
+              <ClassDef glyph="m.sups" class="21"/>
+              <ClassDef glyph="n" class="43"/>
+              <ClassDef glyph="n.sups" class="21"/>
+              <ClassDef glyph="ntilde" class="43"/>
+              <ClassDef glyph="o" class="11"/>
+              <ClassDef glyph="o.sups" class="22"/>
+              <ClassDef glyph="oacute" class="11"/>
+              <ClassDef glyph="ocircumflex" class="11"/>
+              <ClassDef glyph="odieresis" class="11"/>
+              <ClassDef glyph="ograve" class="11"/>
+              <ClassDef glyph="oslash" class="11"/>
+              <ClassDef glyph="otilde" class="11"/>
+              <ClassDef glyph="p" class="43"/>
+              <ClassDef glyph="p.sups" class="38"/>
+              <ClassDef glyph="parenright" class="37"/>
+              <ClassDef glyph="period" class="17"/>
+              <ClassDef glyph="periodcentered" class="32"/>
+              <ClassDef glyph="q" class="11"/>
+              <ClassDef glyph="q.sups" class="22"/>
+              <ClassDef glyph="question" class="31"/>
+              <ClassDef glyph="quotedbl" class="35"/>
+              <ClassDef glyph="quotesingle" class="35"/>
+              <ClassDef glyph="r" class="43"/>
+              <ClassDef glyph="r.sups" class="21"/>
+              <ClassDef glyph="registered" class="6"/>
+              <ClassDef glyph="s" class="41"/>
+              <ClassDef glyph="semicolon" class="27"/>
+              <ClassDef glyph="slash" class="7"/>
+              <ClassDef glyph="t" class="13"/>
+              <ClassDef glyph="u" class="24"/>
+              <ClassDef glyph="u.sups" class="21"/>
+              <ClassDef glyph="uacute" class="24"/>
+              <ClassDef glyph="ucircumflex" class="24"/>
+              <ClassDef glyph="udieresis" class="24"/>
+              <ClassDef glyph="ugrave" class="24"/>
+              <ClassDef glyph="v" class="14"/>
+              <ClassDef glyph="v.sups" class="23"/>
+              <ClassDef glyph="w" class="15"/>
+              <ClassDef glyph="w.sups" class="23"/>
+              <ClassDef glyph="x" class="25"/>
+              <ClassDef glyph="y" class="16"/>
+              <ClassDef glyph="y.sups" class="38"/>
+              <ClassDef glyph="yacute" class="16"/>
+              <ClassDef glyph="ydieresis" class="16"/>
+              <ClassDef glyph="z" class="26"/>
+            </ClassDef2>
+            <!-- Class1Count=34 -->
+            <!-- Class2Count=46 -->
+            <Class1Record index="0">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-28"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="8"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="1">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="2">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="3">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="4">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="5">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="6">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-35"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-21"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-11"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-21"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="13"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="13"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-45"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-11"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="7">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-17"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-46"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="-9"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-21"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="8">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="8"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="9">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="3"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-120"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-76"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="-56"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-152"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-92"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-76"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-36"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-36"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-54"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-32"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-92"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="-29"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-90"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-80"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="10">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="11">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-57"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-19"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-25"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-46"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-17"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="-53"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-17"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-6"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="6"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-29"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="27"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="12">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="-6"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="6"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="-17"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="13">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-50"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="30"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-75"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-112"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-146"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-43"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-33"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-78"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="14">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="61"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="25"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="19"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="25"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-57"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-55"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="25"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="13"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="15">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="5"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="6"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="25"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-31"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="16">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="17">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="18">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="19">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-53"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="20">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-49"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-11"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="21">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="3"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="14"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-11"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="22">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-61"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-58"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="23">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="34"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="6"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-21"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="14"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="24">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-89"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-73"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-66"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-33"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-33"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-106"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-126"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-73"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-46"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-39"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-75"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-73"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-47"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-64"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="-39"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-54"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-59"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="-85"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="-46"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="25">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="26">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-31"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-47"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="27">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-11"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-9"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-11"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="45"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-35"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="28">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="53"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-46"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-21"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-15"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-9"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-9"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-9"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-65"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-73"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-15"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-25"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-19"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-21"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-19"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-11"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-19"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="29">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-9"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-11"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="38"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-41"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-17"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="30">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="39"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-29"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-13"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-6"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-65"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="-6"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-6"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="31">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-33"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-15"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-23"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="38"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-17"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="32">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="3"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="8"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-17"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-27"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="33">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="45"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-35"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="5" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="2">
+            <Coverage Format="1">
+              <Glyph value="Y"/>
+              <Glyph value="Z"/>
+              <Glyph value="z"/>
+              <Glyph value="Yacute"/>
+              <Glyph value="period"/>
+              <Glyph value="comma"/>
+              <Glyph value="colon"/>
+              <Glyph value="semicolon"/>
+              <Glyph value="exclam"/>
+              <Glyph value="question"/>
+              <Glyph value="quotesingle"/>
+              <Glyph value="quotedbl"/>
+              <Glyph value="guillemotleft"/>
+              <Glyph value="guillemotright"/>
+              <Glyph value="hyphen"/>
+              <Glyph value="parenleft"/>
+              <Glyph value="bracketleft"/>
+              <Glyph value="braceleft"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <ClassDef1 Format="2">
+              <ClassDef glyph="Z" class="2"/>
+              <ClassDef glyph="braceleft" class="3"/>
+              <ClassDef glyph="bracketleft" class="3"/>
+              <ClassDef glyph="colon" class="4"/>
+              <ClassDef glyph="comma" class="5"/>
+              <ClassDef glyph="exclam" class="7"/>
+              <ClassDef glyph="guillemotleft" class="8"/>
+              <ClassDef glyph="guillemotright" class="9"/>
+              <ClassDef glyph="hyphen" class="6"/>
+              <ClassDef glyph="parenleft" class="3"/>
+              <ClassDef glyph="period" class="5"/>
+              <ClassDef glyph="question" class="10"/>
+              <ClassDef glyph="quotedbl" class="11"/>
+              <ClassDef glyph="quotesingle" class="11"/>
+              <ClassDef glyph="semicolon" class="4"/>
+              <ClassDef glyph="z" class="1"/>
+            </ClassDef1>
+            <ClassDef2 Format="1">
+              <ClassDef glyph="A" class="2"/>
+              <ClassDef glyph="AE" class="37"/>
+              <ClassDef glyph="Aacute" class="2"/>
+              <ClassDef glyph="Acircumflex" class="2"/>
+              <ClassDef glyph="Adieresis" class="2"/>
+              <ClassDef glyph="Agrave" class="2"/>
+              <ClassDef glyph="Aring" class="2"/>
+              <ClassDef glyph="Atilde" class="2"/>
+              <ClassDef glyph="C" class="7"/>
+              <ClassDef glyph="Ccedilla" class="7"/>
+              <ClassDef glyph="G" class="7"/>
+              <ClassDef glyph="J" class="4"/>
+              <ClassDef glyph="O" class="7"/>
+              <ClassDef glyph="Oacute" class="7"/>
+              <ClassDef glyph="Ocircumflex" class="7"/>
+              <ClassDef glyph="Odieresis" class="7"/>
+              <ClassDef glyph="Ograve" class="7"/>
+              <ClassDef glyph="Oslash" class="7"/>
+              <ClassDef glyph="Otilde" class="7"/>
+              <ClassDef glyph="Q" class="7"/>
+              <ClassDef glyph="S" class="9"/>
+              <ClassDef glyph="T" class="11"/>
+              <ClassDef glyph="U" class="13"/>
+              <ClassDef glyph="Uacute" class="13"/>
+              <ClassDef glyph="Ucircumflex" class="13"/>
+              <ClassDef glyph="Udieresis" class="13"/>
+              <ClassDef glyph="Ugrave" class="13"/>
+              <ClassDef glyph="V" class="31"/>
+              <ClassDef glyph="W" class="32"/>
+              <ClassDef glyph="X" class="36"/>
+              <ClassDef glyph="Y" class="29"/>
+              <ClassDef glyph="Yacute" class="29"/>
+              <ClassDef glyph="Z" class="19"/>
+              <ClassDef glyph="a" class="1"/>
+              <ClassDef glyph="aacute" class="1"/>
+              <ClassDef glyph="acircumflex" class="1"/>
+              <ClassDef glyph="adieresis" class="1"/>
+              <ClassDef glyph="ae" class="1"/>
+              <ClassDef glyph="agrave" class="1"/>
+              <ClassDef glyph="aring" class="1"/>
+              <ClassDef glyph="asterisk" class="34"/>
+              <ClassDef glyph="atilde" class="1"/>
+              <ClassDef glyph="c" class="6"/>
+              <ClassDef glyph="ccedilla" class="6"/>
+              <ClassDef glyph="colon" class="20"/>
+              <ClassDef glyph="comma" class="21"/>
+              <ClassDef glyph="d" class="6"/>
+              <ClassDef glyph="e" class="6"/>
+              <ClassDef glyph="eacute" class="6"/>
+              <ClassDef glyph="ecircumflex" class="6"/>
+              <ClassDef glyph="edieresis" class="6"/>
+              <ClassDef glyph="egrave" class="6"/>
+              <ClassDef glyph="exclamdown" class="38"/>
+              <ClassDef glyph="f" class="30"/>
+              <ClassDef glyph="f_f" class="30"/>
+              <ClassDef glyph="f_f_t" class="30"/>
+              <ClassDef glyph="f_t" class="30"/>
+              <ClassDef glyph="g" class="3"/>
+              <ClassDef glyph="guillemotleft" class="23"/>
+              <ClassDef glyph="guillemotright" class="24"/>
+              <ClassDef glyph="hyphen" class="22"/>
+              <ClassDef glyph="j" class="33"/>
+              <ClassDef glyph="m" class="5"/>
+              <ClassDef glyph="n" class="5"/>
+              <ClassDef glyph="ntilde" class="5"/>
+              <ClassDef glyph="o" class="6"/>
+              <ClassDef glyph="oacute" class="6"/>
+              <ClassDef glyph="ocircumflex" class="6"/>
+              <ClassDef glyph="odieresis" class="6"/>
+              <ClassDef glyph="ograve" class="6"/>
+              <ClassDef glyph="oslash" class="6"/>
+              <ClassDef glyph="otilde" class="6"/>
+              <ClassDef glyph="p" class="5"/>
+              <ClassDef glyph="period" class="21"/>
+              <ClassDef glyph="periodcentered" class="26"/>
+              <ClassDef glyph="q" class="6"/>
+              <ClassDef glyph="question" class="25"/>
+              <ClassDef glyph="questiondown" class="39"/>
+              <ClassDef glyph="quotedbl" class="35"/>
+              <ClassDef glyph="quotesingle" class="35"/>
+              <ClassDef glyph="r" class="5"/>
+              <ClassDef glyph="registered" class="27"/>
+              <ClassDef glyph="s" class="8"/>
+              <ClassDef glyph="semicolon" class="20"/>
+              <ClassDef glyph="slash" class="28"/>
+              <ClassDef glyph="t" class="10"/>
+              <ClassDef glyph="u" class="12"/>
+              <ClassDef glyph="uacute" class="12"/>
+              <ClassDef glyph="ucircumflex" class="12"/>
+              <ClassDef glyph="udieresis" class="12"/>
+              <ClassDef glyph="ugrave" class="12"/>
+              <ClassDef glyph="v" class="14"/>
+              <ClassDef glyph="w" class="15"/>
+              <ClassDef glyph="x" class="16"/>
+              <ClassDef glyph="y" class="17"/>
+              <ClassDef glyph="yacute" class="17"/>
+              <ClassDef glyph="ydieresis" class="17"/>
+              <ClassDef glyph="z" class="18"/>
+            </ClassDef2>
+            <!-- Class1Count=12 -->
+            <!-- Class2Count=40 -->
+            <Class1Record index="0">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-67"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-60"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="-100"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-41"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-41"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-29"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-47"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-25"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-91"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="-66"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="-55"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-37"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-46"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="33"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-66"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="1">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-23"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-6"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-11"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="25"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-29"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="2">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-6"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="-33"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-21"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-23"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-60"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-6"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-6"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="3">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="80"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="4">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="4"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="-49"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="5">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-11"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-46"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-99"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-35"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-92"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-65"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="26"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="-139"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-96"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="6">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-17"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-47"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-66"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-19"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-27"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="7">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="8">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-4"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-37"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-17"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-17"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="9">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-33"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-46"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-7"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="-55"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-21"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="10">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="11">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-55"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="-95"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-29"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-115"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+          </PairPos>
+        </ExtensionPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=4 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=6 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="4"/>
+            <FeatureIndex index="2" value="8"/>
+            <FeatureIndex index="3" value="12"/>
+            <FeatureIndex index="4" value="16"/>
+            <FeatureIndex index="5" value="20"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="cyrl"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=6 -->
+            <FeatureIndex index="0" value="1"/>
+            <FeatureIndex index="1" value="5"/>
+            <FeatureIndex index="2" value="9"/>
+            <FeatureIndex index="3" value="13"/>
+            <FeatureIndex index="4" value="17"/>
+            <FeatureIndex index="5" value="21"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="2">
+        <ScriptTag value="grek"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=6 -->
+            <FeatureIndex index="0" value="2"/>
+            <FeatureIndex index="1" value="6"/>
+            <FeatureIndex index="2" value="10"/>
+            <FeatureIndex index="3" value="14"/>
+            <FeatureIndex index="4" value="18"/>
+            <FeatureIndex index="5" value="22"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="3">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=6 -->
+            <FeatureIndex index="0" value="3"/>
+            <FeatureIndex index="1" value="7"/>
+            <FeatureIndex index="2" value="11"/>
+            <FeatureIndex index="3" value="15"/>
+            <FeatureIndex index="4" value="19"/>
+            <FeatureIndex index="5" value="23"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=24 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="ccmp"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="4"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="ccmp"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="4"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="2">
+        <FeatureTag value="ccmp"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="4"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="3">
+        <FeatureTag value="ccmp"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="4"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="4">
+        <FeatureTag value="dnom"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="6"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="5">
+        <FeatureTag value="dnom"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="6"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="6">
+        <FeatureTag value="dnom"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="6"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="7">
+        <FeatureTag value="dnom"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="6"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="8">
+        <FeatureTag value="frac"/>
+        <Feature>
+          <!-- LookupCount=3 -->
+          <LookupListIndex index="0" value="5"/>
+          <LookupListIndex index="1" value="7"/>
+          <LookupListIndex index="2" value="8"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="9">
+        <FeatureTag value="frac"/>
+        <Feature>
+          <!-- LookupCount=3 -->
+          <LookupListIndex index="0" value="5"/>
+          <LookupListIndex index="1" value="7"/>
+          <LookupListIndex index="2" value="8"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="10">
+        <FeatureTag value="frac"/>
+        <Feature>
+          <!-- LookupCount=3 -->
+          <LookupListIndex index="0" value="5"/>
+          <LookupListIndex index="1" value="7"/>
+          <LookupListIndex index="2" value="8"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="11">
+        <FeatureTag value="frac"/>
+        <Feature>
+          <!-- LookupCount=3 -->
+          <LookupListIndex index="0" value="5"/>
+          <LookupListIndex index="1" value="7"/>
+          <LookupListIndex index="2" value="8"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="12">
+        <FeatureTag value="liga"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="9"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="13">
+        <FeatureTag value="liga"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="9"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="14">
+        <FeatureTag value="liga"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="9"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="15">
+        <FeatureTag value="liga"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="9"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="16">
+        <FeatureTag value="numr"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="5"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="17">
+        <FeatureTag value="numr"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="5"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="18">
+        <FeatureTag value="numr"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="5"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="19">
+        <FeatureTag value="numr"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="5"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="20">
+        <FeatureTag value="sups"/>
+        <Feature>
+          <!-- LookupCount=4 -->
+          <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="1" value="1"/>
+          <LookupListIndex index="2" value="2"/>
+          <LookupListIndex index="3" value="3"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="21">
+        <FeatureTag value="sups"/>
+        <Feature>
+          <!-- LookupCount=4 -->
+          <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="1" value="1"/>
+          <LookupListIndex index="2" value="2"/>
+          <LookupListIndex index="3" value="3"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="22">
+        <FeatureTag value="sups"/>
+        <Feature>
+          <!-- LookupCount=4 -->
+          <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="1" value="1"/>
+          <LookupListIndex index="2" value="2"/>
+          <LookupListIndex index="3" value="3"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="23">
+        <FeatureTag value="sups"/>
+        <Feature>
+          <!-- LookupCount=4 -->
+          <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="1" value="1"/>
+          <LookupListIndex index="2" value="2"/>
+          <LookupListIndex index="3" value="3"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=11 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="2">
+          <Substitution in="a" out="a.sups"/>
+          <Substitution in="b" out="b.sups"/>
+          <Substitution in="c" out="c.sups"/>
+          <Substitution in="d" out="d.sups"/>
+          <Substitution in="e" out="e.sups"/>
+          <Substitution in="eacute" out="eacute.sups"/>
+          <Substitution in="egrave" out="egrave.sups"/>
+          <Substitution in="f" out="f.sups"/>
+          <Substitution in="g" out="g.sups"/>
+          <Substitution in="h" out="h.sups"/>
+          <Substitution in="i" out="i.sups"/>
+          <Substitution in="j" out="j.sups"/>
+          <Substitution in="k" out="k.sups"/>
+          <Substitution in="l" out="l.sups"/>
+          <Substitution in="m" out="m.sups"/>
+          <Substitution in="n" out="n.sups"/>
+          <Substitution in="o" out="o.sups"/>
+          <Substitution in="p" out="p.sups"/>
+          <Substitution in="q" out="q.sups"/>
+          <Substitution in="r" out="r.sups"/>
+          <Substitution in="s" out="s.sups"/>
+          <Substitution in="t" out="t.sups"/>
+          <Substitution in="u" out="u.sups"/>
+          <Substitution in="v" out="v.sups"/>
+          <Substitution in="w" out="w.sups"/>
+          <Substitution in="x" out="x.sups"/>
+          <Substitution in="y" out="y.sups"/>
+          <Substitution in="z" out="z.sups"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="1">
+          <Substitution in="A" out="A.sups"/>
+          <Substitution in="B" out="B.sups"/>
+          <Substitution in="C" out="C.sups"/>
+          <Substitution in="D" out="D.sups"/>
+          <Substitution in="E" out="E.sups"/>
+          <Substitution in="F" out="F.sups"/>
+          <Substitution in="G" out="G.sups"/>
+          <Substitution in="H" out="H.sups"/>
+          <Substitution in="I" out="I.sups"/>
+          <Substitution in="J" out="J.sups"/>
+          <Substitution in="K" out="K.sups"/>
+          <Substitution in="L" out="L.sups"/>
+          <Substitution in="M" out="M.sups"/>
+          <Substitution in="N" out="N.sups"/>
+          <Substitution in="O" out="O.sups"/>
+          <Substitution in="P" out="P.sups"/>
+          <Substitution in="Q" out="Q.sups"/>
+          <Substitution in="R" out="R.sups"/>
+          <Substitution in="S" out="S.sups"/>
+          <Substitution in="T" out="T.sups"/>
+          <Substitution in="U" out="U.sups"/>
+          <Substitution in="V" out="V.sups"/>
+          <Substitution in="W" out="W.sups"/>
+          <Substitution in="X" out="X.sups"/>
+          <Substitution in="Y" out="Y.sups"/>
+          <Substitution in="Z" out="Z.sups"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="2">
+          <Substitution in="colon" out="colon.sups"/>
+          <Substitution in="hyphen" out="hyphen.sups"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="3">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="2">
+          <Substitution in="comma" out="comma.sups"/>
+          <Substitution in="eight" out="eight.sups"/>
+          <Substitution in="equal" out="equal.sups"/>
+          <Substitution in="five" out="five.sups"/>
+          <Substitution in="four" out="four.sups"/>
+          <Substitution in="nine" out="nine.sups"/>
+          <Substitution in="one" out="one.sups"/>
+          <Substitution in="parenleft" out="parenleft.sups"/>
+          <Substitution in="parenright" out="parenright.sups"/>
+          <Substitution in="period" out="period.sups"/>
+          <Substitution in="plus" out="plus.sups"/>
+          <Substitution in="seven" out="seven.sups"/>
+          <Substitution in="six" out="six.sups"/>
+          <Substitution in="three" out="three.sups"/>
+          <Substitution in="two" out="two.sups"/>
+          <Substitution in="zero" out="zero.sups"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="4">
+        <LookupType value="4"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0" Format="1">
+          <LigatureSet glyph="L">
+            <Ligature components="periodcentered,L" glyph="uni004C00B7004C"/>
+          </LigatureSet>
+          <LigatureSet glyph="l">
+            <Ligature components="periodcentered,l" glyph="uni006C00B7006C"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="5">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="2">
+          <Substitution in="comma" out="comma.numr"/>
+          <Substitution in="eight" out="eight.numr"/>
+          <Substitution in="five" out="five.numr"/>
+          <Substitution in="four" out="four.numr"/>
+          <Substitution in="nine" out="nine.numr"/>
+          <Substitution in="one" out="one.numr"/>
+          <Substitution in="parenleft" out="parenleft.numr"/>
+          <Substitution in="parenright" out="parenright.numr"/>
+          <Substitution in="period" out="period.numr"/>
+          <Substitution in="seven" out="seven.numr"/>
+          <Substitution in="six" out="six.numr"/>
+          <Substitution in="three" out="three.numr"/>
+          <Substitution in="two" out="two.numr"/>
+          <Substitution in="zero" out="zero.numr"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="6">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="2">
+          <Substitution in="comma" out="comma.dnom"/>
+          <Substitution in="eight" out="eight.dnom"/>
+          <Substitution in="five" out="five.dnom"/>
+          <Substitution in="four" out="four.dnom"/>
+          <Substitution in="nine" out="nine.dnom"/>
+          <Substitution in="one" out="one.dnom"/>
+          <Substitution in="parenleft" out="parenleft.dnom"/>
+          <Substitution in="parenright" out="parenright.dnom"/>
+          <Substitution in="period" out="period.dnom"/>
+          <Substitution in="seven" out="seven.dnom"/>
+          <Substitution in="six" out="six.dnom"/>
+          <Substitution in="three" out="three.dnom"/>
+          <Substitution in="two" out="two.dnom"/>
+          <Substitution in="zero" out="zero.dnom"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="7">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="1">
+          <Substitution in="slash" out="slash.frac"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="8">
+        <LookupType value="6"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=3 -->
+        <ChainContextSubst index="0" Format="3">
+          <!-- BacktrackGlyphCount=1 -->
+          <BacktrackCoverage index="0" Format="2">
+            <Glyph value="zero.numr"/>
+            <Glyph value="one.numr"/>
+            <Glyph value="two.numr"/>
+            <Glyph value="three.numr"/>
+            <Glyph value="four.numr"/>
+            <Glyph value="five.numr"/>
+            <Glyph value="six.numr"/>
+            <Glyph value="seven.numr"/>
+            <Glyph value="eight.numr"/>
+            <Glyph value="nine.numr"/>
+          </BacktrackCoverage>
+          <!-- InputGlyphCount=1 -->
+          <InputCoverage index="0" Format="1">
+            <Glyph value="space"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- SubstCount=1 -->
+          <SubstLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="10"/>
+          </SubstLookupRecord>
+        </ChainContextSubst>
+        <ChainContextSubst index="1" Format="3">
+          <!-- BacktrackGlyphCount=1 -->
+          <BacktrackCoverage index="0" Format="2">
+            <Glyph value="zero.dnom"/>
+            <Glyph value="one.dnom"/>
+            <Glyph value="two.dnom"/>
+            <Glyph value="three.dnom"/>
+            <Glyph value="four.dnom"/>
+            <Glyph value="five.dnom"/>
+            <Glyph value="six.dnom"/>
+            <Glyph value="seven.dnom"/>
+            <Glyph value="eight.dnom"/>
+            <Glyph value="nine.dnom"/>
+            <Glyph value="parenleft.dnom"/>
+            <Glyph value="parenright.dnom"/>
+            <Glyph value="period.dnom"/>
+            <Glyph value="comma.dnom"/>
+            <Glyph value="slash.frac"/>
+          </BacktrackCoverage>
+          <!-- InputGlyphCount=1 -->
+          <InputCoverage index="0" Format="2">
+            <Glyph value="zero.numr"/>
+            <Glyph value="one.numr"/>
+            <Glyph value="two.numr"/>
+            <Glyph value="three.numr"/>
+            <Glyph value="four.numr"/>
+            <Glyph value="five.numr"/>
+            <Glyph value="six.numr"/>
+            <Glyph value="seven.numr"/>
+            <Glyph value="eight.numr"/>
+            <Glyph value="nine.numr"/>
+            <Glyph value="parenleft.numr"/>
+            <Glyph value="parenright.numr"/>
+            <Glyph value="period.numr"/>
+            <Glyph value="comma.numr"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- SubstCount=1 -->
+          <SubstLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="10"/>
+          </SubstLookupRecord>
+        </ChainContextSubst>
+        <ChainContextSubst index="2" Format="3">
+          <!-- BacktrackGlyphCount=2 -->
+          <BacktrackCoverage index="0" Format="1">
+            <Glyph value="space.frac"/>
+          </BacktrackCoverage>
+          <BacktrackCoverage index="1" Format="2">
+            <Glyph value="zero.dnom"/>
+            <Glyph value="one.dnom"/>
+            <Glyph value="two.dnom"/>
+            <Glyph value="three.dnom"/>
+            <Glyph value="four.dnom"/>
+            <Glyph value="five.dnom"/>
+            <Glyph value="six.dnom"/>
+            <Glyph value="seven.dnom"/>
+            <Glyph value="eight.dnom"/>
+            <Glyph value="nine.dnom"/>
+          </BacktrackCoverage>
+          <!-- InputGlyphCount=1 -->
+          <InputCoverage index="0" Format="2">
+            <Glyph value="zero.numr"/>
+            <Glyph value="one.numr"/>
+            <Glyph value="two.numr"/>
+            <Glyph value="three.numr"/>
+            <Glyph value="four.numr"/>
+            <Glyph value="five.numr"/>
+            <Glyph value="six.numr"/>
+            <Glyph value="seven.numr"/>
+            <Glyph value="eight.numr"/>
+            <Glyph value="nine.numr"/>
+            <Glyph value="parenleft.numr"/>
+            <Glyph value="parenright.numr"/>
+            <Glyph value="period.numr"/>
+            <Glyph value="comma.numr"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- SubstCount=1 -->
+          <SubstLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="10"/>
+          </SubstLookupRecord>
+        </ChainContextSubst>
+      </Lookup>
+      <Lookup index="9">
+        <LookupType value="4"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0" Format="1">
+          <LigatureSet glyph="f">
+            <Ligature components="f,t" glyph="f_f_t"/>
+            <Ligature components="f" glyph="f_f"/>
+            <Ligature components="t" glyph="f_t"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="10">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="2">
+          <Substitution in="comma.numr" out="comma.dnom"/>
+          <Substitution in="eight.numr" out="eight.dnom"/>
+          <Substitution in="five.numr" out="five.dnom"/>
+          <Substitution in="four.numr" out="four.dnom"/>
+          <Substitution in="nine.numr" out="nine.dnom"/>
+          <Substitution in="one.numr" out="one.dnom"/>
+          <Substitution in="parenleft.numr" out="parenleft.dnom"/>
+          <Substitution in="parenright.numr" out="parenright.dnom"/>
+          <Substitution in="period.numr" out="period.dnom"/>
+          <Substitution in="seven.numr" out="seven.dnom"/>
+          <Substitution in="six.numr" out="six.dnom"/>
+          <Substitution in="space" out="space.frac"/>
+          <Substitution in="three.numr" out="three.dnom"/>
+          <Substitution in="two.numr" out="two.dnom"/>
+          <Substitution in="zero.numr" out="zero.dnom"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+  <hmtx>
+    <mtx name=".notdef" width="654" lsb="89"/>
+    <mtx name="A" width="544" lsb="3"/>
+    <mtx name="A.sups" width="363" lsb="-1"/>
+    <mtx name="AE" width="823" lsb="8"/>
+    <mtx name="Aacute" width="544" lsb="3"/>
+    <mtx name="Acircumflex" width="544" lsb="3"/>
+    <mtx name="Adieresis" width="544" lsb="3"/>
+    <mtx name="Agrave" width="544" lsb="3"/>
+    <mtx name="Aring" width="544" lsb="3"/>
+    <mtx name="Atilde" width="544" lsb="3"/>
+    <mtx name="B" width="588" lsb="90"/>
+    <mtx name="B.sups" width="392" lsb="57"/>
+    <mtx name="C" width="571" lsb="52"/>
+    <mtx name="C.sups" width="379" lsb="32"/>
+    <mtx name="Ccedilla" width="571" lsb="52"/>
+    <mtx name="D" width="616" lsb="90"/>
+    <mtx name="D.sups" width="411" lsb="57"/>
+    <mtx name="E" width="527" lsb="90"/>
+    <mtx name="E.sups" width="352" lsb="57"/>
+    <mtx name="Eacute" width="527" lsb="90"/>
+    <mtx name="Ecircumflex" width="527" lsb="90"/>
+    <mtx name="Edieresis" width="527" lsb="90"/>
+    <mtx name="Egrave" width="527" lsb="90"/>
+    <mtx name="Eth" width="637" lsb="33"/>
+    <mtx name="F" width="495" lsb="90"/>
+    <mtx name="F.sups" width="330" lsb="57"/>
+    <mtx name="G" width="617" lsb="52"/>
+    <mtx name="G.sups" width="412" lsb="33"/>
+    <mtx name="H" width="652" lsb="90"/>
+    <mtx name="H.sups" width="435" lsb="57"/>
+    <mtx name="I" width="263" lsb="90"/>
+    <mtx name="I.sups" width="177" lsb="57"/>
+    <mtx name="Iacute" width="263" lsb="44"/>
+    <mtx name="Icircumflex" width="263" lsb="-16"/>
+    <mtx name="Idieresis" width="263" lsb="-20"/>
+    <mtx name="Igrave" width="263" lsb="2"/>
+    <mtx name="J" width="480" lsb="33"/>
+    <mtx name="J.sups" width="322" lsb="18"/>
+    <mtx name="K" width="579" lsb="90"/>
+    <mtx name="K.sups" width="387" lsb="57"/>
+    <mtx name="L" width="486" lsb="90"/>
+    <mtx name="L.sups" width="325" lsb="57"/>
+    <mtx name="M" width="727" lsb="89"/>
+    <mtx name="M.sups" width="485" lsb="57"/>
+    <mtx name="N" width="646" lsb="90"/>
+    <mtx name="N.sups" width="430" lsb="57"/>
+    <mtx name="Ntilde" width="647" lsb="90"/>
+    <mtx name="O" width="664" lsb="52"/>
+    <mtx name="O.sups" width="443" lsb="32"/>
+    <mtx name="Oacute" width="664" lsb="52"/>
+    <mtx name="Ocircumflex" width="664" lsb="52"/>
+    <mtx name="Odieresis" width="664" lsb="52"/>
+    <mtx name="Ograve" width="664" lsb="52"/>
+    <mtx name="Oslash" width="664" lsb="48"/>
+    <mtx name="Otilde" width="664" lsb="52"/>
+    <mtx name="P" width="567" lsb="90"/>
+    <mtx name="P.sups" width="385" lsb="57"/>
+    <mtx name="Q" width="664" lsb="52"/>
+    <mtx name="Q.sups" width="443" lsb="31"/>
+    <mtx name="R" width="570" lsb="90"/>
+    <mtx name="R.sups" width="389" lsb="57"/>
+    <mtx name="S" width="534" lsb="42"/>
+    <mtx name="S.sups" width="356" lsb="27"/>
+    <mtx name="T" width="536" lsb="28"/>
+    <mtx name="T.sups" width="357" lsb="17"/>
+    <mtx name="Thorn" width="584" lsb="90"/>
+    <mtx name="U" width="646" lsb="87"/>
+    <mtx name="U.sups" width="431" lsb="56"/>
+    <mtx name="Uacute" width="646" lsb="87"/>
+    <mtx name="Ucircumflex" width="646" lsb="87"/>
+    <mtx name="Udieresis" width="646" lsb="87"/>
+    <mtx name="Ugrave" width="646" lsb="87"/>
+    <mtx name="V" width="516" lsb="0"/>
+    <mtx name="V.sups" width="346" lsb="-2"/>
+    <mtx name="W" width="786" lsb="23"/>
+    <mtx name="W.sups" width="526" lsb="13"/>
+    <mtx name="X" width="514" lsb="15"/>
+    <mtx name="X.sups" width="347" lsb="8"/>
+    <mtx name="Y" width="476" lsb="-1"/>
+    <mtx name="Y.sups" width="321" lsb="-3"/>
+    <mtx name="Yacute" width="476" lsb="-1"/>
+    <mtx name="Z" width="539" lsb="45"/>
+    <mtx name="Z.sups" width="358" lsb="27"/>
+    <mtx name="a" width="504" lsb="52"/>
+    <mtx name="a.sups" width="345" lsb="37"/>
+    <mtx name="aacute" width="505" lsb="52"/>
+    <mtx name="acircumflex" width="505" lsb="52"/>
+    <mtx name="acute" width="542" lsb="186"/>
+    <mtx name="adieresis" width="505" lsb="52"/>
+    <mtx name="ae" width="778" lsb="52"/>
+    <mtx name="agrave" width="505" lsb="52"/>
+    <mtx name="ampersand" width="610" lsb="32"/>
+    <mtx name="aring" width="505" lsb="52"/>
+    <mtx name="asciicircum" width="497" lsb="60"/>
+    <mtx name="asciitilde" width="497" lsb="36"/>
+    <mtx name="asterisk" width="418" lsb="58"/>
+    <mtx name="at" width="846" lsb="48"/>
+    <mtx name="atilde" width="505" lsb="52"/>
+    <mtx name="b" width="554" lsb="82"/>
+    <mtx name="b.sups" width="374" lsb="52"/>
+    <mtx name="backslash" width="350" lsb="14"/>
+    <mtx name="bar" width="242" lsb="92"/>
+    <mtx name="braceleft" width="304" lsb="34"/>
+    <mtx name="braceright" width="304" lsb="31"/>
+    <mtx name="bracketleft" width="304" lsb="94"/>
+    <mtx name="bracketright" width="304" lsb="31"/>
+    <mtx name="brokenbar" width="242" lsb="92"/>
+    <mtx name="c" width="456" lsb="46"/>
+    <mtx name="c.sups" width="306" lsb="30"/>
+    <mtx name="ccedilla" width="456" lsb="46"/>
+    <mtx name="cedilla" width="542" lsb="182"/>
+    <mtx name="cent" width="497" lsb="61"/>
+    <mtx name="colon" width="250" lsb="65"/>
+    <mtx name="colon.sups" width="177" lsb="43"/>
+    <mtx name="comma" width="250" lsb="47"/>
+    <mtx name="comma.dnom" width="177" lsb="33"/>
+    <mtx name="comma.numr" width="177" lsb="33"/>
+    <mtx name="comma.sups" width="177" lsb="33"/>
+    <mtx name="copyright" width="744" lsb="49"/>
+    <mtx name="currency" width="497" lsb="26"/>
+    <mtx name="d" width="555" lsb="47"/>
+    <mtx name="d.sups" width="374" lsb="33"/>
+    <mtx name="degree" width="332" lsb="41"/>
+    <mtx name="dieresis" width="542" lsb="125"/>
+    <mtx name="divide" width="497" lsb="34"/>
+    <mtx name="dollar" width="497" lsb="52"/>
+    <mtx name="e" width="496" lsb="46"/>
+    <mtx name="e.sups" width="336" lsb="28"/>
+    <mtx name="eacute" width="496" lsb="46"/>
+    <mtx name="eacute.sups" width="336" lsb="28"/>
+    <mtx name="ecircumflex" width="496" lsb="46"/>
+    <mtx name="edieresis" width="496" lsb="46"/>
+    <mtx name="egrave" width="496" lsb="46"/>
+    <mtx name="egrave.sups" width="336" lsb="28"/>
+    <mtx name="eight" width="497" lsb="41"/>
+    <mtx name="eight.dnom" width="367" lsb="45"/>
+    <mtx name="eight.numr" width="367" lsb="45"/>
+    <mtx name="eight.sups" width="367" lsb="45"/>
+    <mtx name="equal" width="497" lsb="34"/>
+    <mtx name="equal.sups" width="367" lsb="30"/>
+    <mtx name="eth" width="545" lsb="53"/>
+    <mtx name="exclam" width="290" lsb="85"/>
+    <mtx name="exclamdown" width="290" lsb="85"/>
+    <mtx name="f" width="292" lsb="30"/>
+    <mtx name="f.sups" width="201" lsb="19"/>
+    <mtx name="f_f" width="578" lsb="30"/>
+    <mtx name="f_f_t" width="881" lsb="30"/>
+    <mtx name="f_t" width="595" lsb="30"/>
+    <mtx name="five" width="497" lsb="25"/>
+    <mtx name="five.dnom" width="367" lsb="35"/>
+    <mtx name="five.numr" width="367" lsb="35"/>
+    <mtx name="five.sups" width="367" lsb="35"/>
+    <mtx name="four" width="497" lsb="17"/>
+    <mtx name="four.dnom" width="367" lsb="42"/>
+    <mtx name="four.numr" width="367" lsb="42"/>
+    <mtx name="four.sups" width="367" lsb="42"/>
+    <mtx name="g" width="505" lsb="45"/>
+    <mtx name="g.sups" width="343" lsb="30"/>
+    <mtx name="germandbls" width="576" lsb="82"/>
+    <mtx name="grave" width="542" lsb="135"/>
+    <mtx name="greater" width="497" lsb="34"/>
+    <mtx name="guillemotleft" width="430" lsb="45"/>
+    <mtx name="guillemotright" width="430" lsb="54"/>
+    <mtx name="h" width="544" lsb="82"/>
+    <mtx name="h.sups" width="367" lsb="52"/>
+    <mtx name="hyphen" width="311" lsb="41"/>
+    <mtx name="hyphen.sups" width="236" lsb="41"/>
+    <mtx name="i" width="247" lsb="69"/>
+    <mtx name="i.sups" width="166" lsb="42"/>
+    <mtx name="iacute" width="247" lsb="39"/>
+    <mtx name="icircumflex" width="247" lsb="-31"/>
+    <mtx name="idieresis" width="247" lsb="-22"/>
+    <mtx name="igrave" width="247" lsb="-12"/>
+    <mtx name="j" width="247" lsb="-40"/>
+    <mtx name="j.sups" width="169" lsb="-26"/>
+    <mtx name="k" width="495" lsb="82"/>
+    <mtx name="k.sups" width="338" lsb="52"/>
+    <mtx name="l" width="255" lsb="82"/>
+    <mtx name="l.sups" width="174" lsb="52"/>
+    <mtx name="less" width="497" lsb="34"/>
+    <mtx name="logicalnot" width="497" lsb="34"/>
+    <mtx name="m" width="829" lsb="82"/>
+    <mtx name="m.sups" width="559" lsb="52"/>
+    <mtx name="macron" width="542" lsb="138"/>
+    <mtx name="mu" width="562" lsb="82"/>
+    <mtx name="multiply" width="497" lsb="50"/>
+    <mtx name="n" width="547" lsb="82"/>
+    <mtx name="n.sups" width="369" lsb="52"/>
+    <mtx name="nine" width="497" lsb="40"/>
+    <mtx name="nine.dnom" width="367" lsb="39"/>
+    <mtx name="nine.numr" width="367" lsb="39"/>
+    <mtx name="nine.sups" width="367" lsb="39"/>
+    <mtx name="ntilde" width="547" lsb="82"/>
+    <mtx name="numbersign" width="497" lsb="34"/>
+    <mtx name="o" width="542" lsb="46"/>
+    <mtx name="o.sups" width="365" lsb="30"/>
+    <mtx name="oacute" width="542" lsb="46"/>
+    <mtx name="ocircumflex" width="542" lsb="46"/>
+    <mtx name="odieresis" width="542" lsb="46"/>
+    <mtx name="ograve" width="542" lsb="46"/>
+    <mtx name="one" width="497" lsb="79"/>
+    <mtx name="one.dnom" width="367" lsb="87"/>
+    <mtx name="one.numr" width="367" lsb="87"/>
+    <mtx name="one.sups" width="367" lsb="87"/>
+    <mtx name="onehalf" width="809" lsb="63"/>
+    <mtx name="onequarter" width="781" lsb="63"/>
+    <mtx name="ordfeminine" width="345" lsb="37"/>
+    <mtx name="ordmasculine" width="365" lsb="30"/>
+    <mtx name="oslash" width="543" lsb="40"/>
+    <mtx name="otilde" width="542" lsb="46"/>
+    <mtx name="p" width="555" lsb="82"/>
+    <mtx name="p.sups" width="374" lsb="52"/>
+    <mtx name="paragraph" width="561" lsb="41"/>
+    <mtx name="parenleft" width="304" lsb="82"/>
+    <mtx name="parenleft.dnom" width="237" lsb="65"/>
+    <mtx name="parenleft.numr" width="237" lsb="65"/>
+    <mtx name="parenleft.sups" width="237" lsb="65"/>
+    <mtx name="parenright" width="304" lsb="38"/>
+    <mtx name="parenright.dnom" width="237" lsb="39"/>
+    <mtx name="parenright.numr" width="237" lsb="39"/>
+    <mtx name="parenright.sups" width="237" lsb="39"/>
+    <mtx name="percent" width="825" lsb="35"/>
+    <mtx name="period" width="250" lsb="65"/>
+    <mtx name="period.dnom" width="177" lsb="43"/>
+    <mtx name="period.numr" width="177" lsb="43"/>
+    <mtx name="period.sups" width="177" lsb="43"/>
+    <mtx name="periodcentered" width="250" lsb="65"/>
+    <mtx name="plus" width="497" lsb="34"/>
+    <mtx name="plus.sups" width="367" lsb="30"/>
+    <mtx name="plusminus" width="497" lsb="34"/>
+    <mtx name="q" width="555" lsb="47"/>
+    <mtx name="q.sups" width="374" lsb="33"/>
+    <mtx name="question" width="425" lsb="38"/>
+    <mtx name="questiondown" width="425" lsb="48"/>
+    <mtx name="quotedbl" width="427" lsb="80"/>
+    <mtx name="quotesingle" width="250" lsb="80"/>
+    <mtx name="r" width="348" lsb="82"/>
+    <mtx name="r.sups" width="240" lsb="52"/>
+    <mtx name="registered" width="424" lsb="23"/>
+    <mtx name="s" width="419" lsb="28"/>
+    <mtx name="s.sups" width="283" lsb="19"/>
+    <mtx name="section" width="497" lsb="45"/>
+    <mtx name="semicolon" width="250" lsb="47"/>
+    <mtx name="seven" width="497" lsb="44"/>
+    <mtx name="seven.dnom" width="367" lsb="50"/>
+    <mtx name="seven.numr" width="367" lsb="50"/>
+    <mtx name="seven.sups" width="367" lsb="50"/>
+    <mtx name="six" width="497" lsb="48"/>
+    <mtx name="six.dnom" width="367" lsb="45"/>
+    <mtx name="six.numr" width="367" lsb="45"/>
+    <mtx name="six.sups" width="367" lsb="45"/>
+    <mtx name="slash" width="350" lsb="10"/>
+    <mtx name="slash.frac" width="86" lsb="-167"/>
+    <mtx name="space" width="200" lsb="0"/>
+    <mtx name="space.frac" width="134" lsb="0"/>
+    <mtx name="sterling" width="497" lsb="53"/>
+    <mtx name="t" width="339" lsb="24"/>
+    <mtx name="t.sups" width="232" lsb="16"/>
+    <mtx name="thorn" width="555" lsb="82"/>
+    <mtx name="three" width="497" lsb="26"/>
+    <mtx name="three.dnom" width="367" lsb="35"/>
+    <mtx name="three.numr" width="367" lsb="35"/>
+    <mtx name="three.sups" width="367" lsb="35"/>
+    <mtx name="threequarters" width="796" lsb="34"/>
+    <mtx name="two" width="497" lsb="37"/>
+    <mtx name="two.dnom" width="367" lsb="40"/>
+    <mtx name="two.numr" width="367" lsb="40"/>
+    <mtx name="two.sups" width="367" lsb="40"/>
+    <mtx name="u" width="544" lsb="75"/>
+    <mtx name="u.sups" width="370" lsb="50"/>
+    <mtx name="uacute" width="544" lsb="75"/>
+    <mtx name="ucircumflex" width="544" lsb="75"/>
+    <mtx name="udieresis" width="544" lsb="75"/>
+    <mtx name="ugrave" width="544" lsb="75"/>
+    <mtx name="underscore" width="500" lsb="12"/>
+    <mtx name="uni004C00B7004C" width="972" lsb="90"/>
+    <mtx name="uni006C00B7006C" width="618" lsb="82"/>
+    <mtx name="v" width="468" lsb="12"/>
+    <mtx name="v.sups" width="322" lsb="8"/>
+    <mtx name="w" width="718" lsb="24"/>
+    <mtx name="w.sups" width="488" lsb="16"/>
+    <mtx name="x" width="447" lsb="14"/>
+    <mtx name="x.sups" width="308" lsb="8"/>
+    <mtx name="y" width="468" lsb="12"/>
+    <mtx name="y.sups" width="320" lsb="8"/>
+    <mtx name="yacute" width="468" lsb="12"/>
+    <mtx name="ydieresis" width="468" lsb="12"/>
+    <mtx name="yen" width="497" lsb="24"/>
+    <mtx name="z" width="425" lsb="31"/>
+    <mtx name="z.sups" width="290" lsb="21"/>
+    <mtx name="zero" width="497" lsb="44"/>
+    <mtx name="zero.dnom" width="367" lsb="35"/>
+    <mtx name="zero.numr" width="367" lsb="35"/>
+    <mtx name="zero.sups" width="367" lsb="35"/>
+  </hmtx>
+
+  <DSIG>
+    <!-- note that the Digital Signature will be invalid after recompilation! -->
+    <tableHeader flag="0x0" numSigs="0" version="1"/>
+  </DSIG>
+
+</ttFont>

--- a/tests/data/SourceSansVariable-Roman.subset.ttx
+++ b/tests/data/SourceSansVariable-Roman.subset.ttx
@@ -1,0 +1,26117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.10">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="space"/>
+    <GlyphID id="2" name="A"/>
+    <GlyphID id="3" name="B"/>
+    <GlyphID id="4" name="C"/>
+    <GlyphID id="5" name="D"/>
+    <GlyphID id="6" name="E"/>
+    <GlyphID id="7" name="F"/>
+    <GlyphID id="8" name="G"/>
+    <GlyphID id="9" name="H"/>
+    <GlyphID id="10" name="I"/>
+    <GlyphID id="11" name="J"/>
+    <GlyphID id="12" name="K"/>
+    <GlyphID id="13" name="L"/>
+    <GlyphID id="14" name="M"/>
+    <GlyphID id="15" name="N"/>
+    <GlyphID id="16" name="O"/>
+    <GlyphID id="17" name="P"/>
+    <GlyphID id="18" name="Q"/>
+    <GlyphID id="19" name="R"/>
+    <GlyphID id="20" name="S"/>
+    <GlyphID id="21" name="T"/>
+    <GlyphID id="22" name="U"/>
+    <GlyphID id="23" name="V"/>
+    <GlyphID id="24" name="W"/>
+    <GlyphID id="25" name="X"/>
+    <GlyphID id="26" name="Y"/>
+    <GlyphID id="27" name="Z"/>
+    <GlyphID id="28" name="a"/>
+    <GlyphID id="29" name="b"/>
+    <GlyphID id="30" name="c"/>
+    <GlyphID id="31" name="d"/>
+    <GlyphID id="32" name="e"/>
+    <GlyphID id="33" name="f"/>
+    <GlyphID id="34" name="g"/>
+    <GlyphID id="35" name="h"/>
+    <GlyphID id="36" name="i"/>
+    <GlyphID id="37" name="j"/>
+    <GlyphID id="38" name="k"/>
+    <GlyphID id="39" name="l"/>
+    <GlyphID id="40" name="m"/>
+    <GlyphID id="41" name="n"/>
+    <GlyphID id="42" name="o"/>
+    <GlyphID id="43" name="p"/>
+    <GlyphID id="44" name="q"/>
+    <GlyphID id="45" name="r"/>
+    <GlyphID id="46" name="s"/>
+    <GlyphID id="47" name="t"/>
+    <GlyphID id="48" name="u"/>
+    <GlyphID id="49" name="v"/>
+    <GlyphID id="50" name="w"/>
+    <GlyphID id="51" name="x"/>
+    <GlyphID id="52" name="y"/>
+    <GlyphID id="53" name="z"/>
+    <GlyphID id="54" name="Agrave"/>
+    <GlyphID id="55" name="Aacute"/>
+    <GlyphID id="56" name="Acircumflex"/>
+    <GlyphID id="57" name="Atilde"/>
+    <GlyphID id="58" name="Adieresis"/>
+    <GlyphID id="59" name="Aring"/>
+    <GlyphID id="60" name="AE"/>
+    <GlyphID id="61" name="Ccedilla"/>
+    <GlyphID id="62" name="Egrave"/>
+    <GlyphID id="63" name="Eacute"/>
+    <GlyphID id="64" name="Ecircumflex"/>
+    <GlyphID id="65" name="Edieresis"/>
+    <GlyphID id="66" name="Igrave"/>
+    <GlyphID id="67" name="Iacute"/>
+    <GlyphID id="68" name="Icircumflex"/>
+    <GlyphID id="69" name="Idieresis"/>
+    <GlyphID id="70" name="Ntilde"/>
+    <GlyphID id="71" name="Ograve"/>
+    <GlyphID id="72" name="Oacute"/>
+    <GlyphID id="73" name="Ocircumflex"/>
+    <GlyphID id="74" name="Otilde"/>
+    <GlyphID id="75" name="Odieresis"/>
+    <GlyphID id="76" name="Oslash"/>
+    <GlyphID id="77" name="Ugrave"/>
+    <GlyphID id="78" name="Uacute"/>
+    <GlyphID id="79" name="Ucircumflex"/>
+    <GlyphID id="80" name="Udieresis"/>
+    <GlyphID id="81" name="Yacute"/>
+    <GlyphID id="82" name="Eth"/>
+    <GlyphID id="83" name="Thorn"/>
+    <GlyphID id="84" name="glyph00084"/>
+    <GlyphID id="85" name="agrave"/>
+    <GlyphID id="86" name="aacute"/>
+    <GlyphID id="87" name="acircumflex"/>
+    <GlyphID id="88" name="atilde"/>
+    <GlyphID id="89" name="adieresis"/>
+    <GlyphID id="90" name="aring"/>
+    <GlyphID id="91" name="ae"/>
+    <GlyphID id="92" name="ccedilla"/>
+    <GlyphID id="93" name="egrave"/>
+    <GlyphID id="94" name="eacute"/>
+    <GlyphID id="95" name="ecircumflex"/>
+    <GlyphID id="96" name="edieresis"/>
+    <GlyphID id="97" name="igrave"/>
+    <GlyphID id="98" name="iacute"/>
+    <GlyphID id="99" name="icircumflex"/>
+    <GlyphID id="100" name="idieresis"/>
+    <GlyphID id="101" name="ntilde"/>
+    <GlyphID id="102" name="ograve"/>
+    <GlyphID id="103" name="oacute"/>
+    <GlyphID id="104" name="ocircumflex"/>
+    <GlyphID id="105" name="otilde"/>
+    <GlyphID id="106" name="odieresis"/>
+    <GlyphID id="107" name="oslash"/>
+    <GlyphID id="108" name="germandbls"/>
+    <GlyphID id="109" name="ugrave"/>
+    <GlyphID id="110" name="uacute"/>
+    <GlyphID id="111" name="ucircumflex"/>
+    <GlyphID id="112" name="udieresis"/>
+    <GlyphID id="113" name="yacute"/>
+    <GlyphID id="114" name="ydieresis"/>
+    <GlyphID id="115" name="eth"/>
+    <GlyphID id="116" name="thorn"/>
+    <GlyphID id="117" name="glyph00117"/>
+    <GlyphID id="118" name="glyph00118"/>
+    <GlyphID id="119" name="glyph00119"/>
+    <GlyphID id="120" name="glyph00120"/>
+    <GlyphID id="121" name="mu"/>
+    <GlyphID id="122" name="ampersand"/>
+    <GlyphID id="123" name="zero"/>
+    <GlyphID id="124" name="one"/>
+    <GlyphID id="125" name="two"/>
+    <GlyphID id="126" name="three"/>
+    <GlyphID id="127" name="four"/>
+    <GlyphID id="128" name="five"/>
+    <GlyphID id="129" name="six"/>
+    <GlyphID id="130" name="seven"/>
+    <GlyphID id="131" name="eight"/>
+    <GlyphID id="132" name="nine"/>
+    <GlyphID id="133" name="period"/>
+    <GlyphID id="134" name="comma"/>
+    <GlyphID id="135" name="colon"/>
+    <GlyphID id="136" name="semicolon"/>
+    <GlyphID id="137" name="exclam"/>
+    <GlyphID id="138" name="exclamdown"/>
+    <GlyphID id="139" name="question"/>
+    <GlyphID id="140" name="questiondown"/>
+    <GlyphID id="141" name="quotesingle"/>
+    <GlyphID id="142" name="quotedbl"/>
+    <GlyphID id="143" name="guillemotleft"/>
+    <GlyphID id="144" name="guillemotright"/>
+    <GlyphID id="145" name="hyphen"/>
+    <GlyphID id="146" name="periodcentered"/>
+    <GlyphID id="147" name="underscore"/>
+    <GlyphID id="148" name="parenleft"/>
+    <GlyphID id="149" name="parenright"/>
+    <GlyphID id="150" name="bracketleft"/>
+    <GlyphID id="151" name="bracketright"/>
+    <GlyphID id="152" name="braceleft"/>
+    <GlyphID id="153" name="braceright"/>
+    <GlyphID id="154" name="slash"/>
+    <GlyphID id="155" name="bar"/>
+    <GlyphID id="156" name="backslash"/>
+    <GlyphID id="157" name="brokenbar"/>
+    <GlyphID id="158" name="asterisk"/>
+    <GlyphID id="159" name="section"/>
+    <GlyphID id="160" name="paragraph"/>
+    <GlyphID id="161" name="copyright"/>
+    <GlyphID id="162" name="registered"/>
+    <GlyphID id="163" name="at"/>
+    <GlyphID id="164" name="numbersign"/>
+    <GlyphID id="165" name="glyph00165"/>
+    <GlyphID id="166" name="uni00B9"/>
+    <GlyphID id="167" name="uni00B2"/>
+    <GlyphID id="168" name="uni00B3"/>
+    <GlyphID id="169" name="glyph00169"/>
+    <GlyphID id="170" name="glyph00170"/>
+    <GlyphID id="171" name="glyph00171"/>
+    <GlyphID id="172" name="glyph00172"/>
+    <GlyphID id="173" name="glyph00173"/>
+    <GlyphID id="174" name="glyph00174"/>
+    <GlyphID id="175" name="glyph00175"/>
+    <GlyphID id="176" name="glyph00176"/>
+    <GlyphID id="177" name="glyph00177"/>
+    <GlyphID id="178" name="glyph00178"/>
+    <GlyphID id="179" name="glyph00179"/>
+    <GlyphID id="180" name="glyph00180"/>
+    <GlyphID id="181" name="glyph00181"/>
+    <GlyphID id="182" name="glyph00182"/>
+    <GlyphID id="183" name="glyph00183"/>
+    <GlyphID id="184" name="glyph00184"/>
+    <GlyphID id="185" name="glyph00185"/>
+    <GlyphID id="186" name="glyph00186"/>
+    <GlyphID id="187" name="glyph00187"/>
+    <GlyphID id="188" name="glyph00188"/>
+    <GlyphID id="189" name="glyph00189"/>
+    <GlyphID id="190" name="glyph00190"/>
+    <GlyphID id="191" name="glyph00191"/>
+    <GlyphID id="192" name="glyph00192"/>
+    <GlyphID id="193" name="glyph00193"/>
+    <GlyphID id="194" name="glyph00194"/>
+    <GlyphID id="195" name="glyph00195"/>
+    <GlyphID id="196" name="glyph00196"/>
+    <GlyphID id="197" name="glyph00197"/>
+    <GlyphID id="198" name="glyph00198"/>
+    <GlyphID id="199" name="glyph00199"/>
+    <GlyphID id="200" name="glyph00200"/>
+    <GlyphID id="201" name="glyph00201"/>
+    <GlyphID id="202" name="glyph00202"/>
+    <GlyphID id="203" name="glyph00203"/>
+    <GlyphID id="204" name="glyph00204"/>
+    <GlyphID id="205" name="glyph00205"/>
+    <GlyphID id="206" name="glyph00206"/>
+    <GlyphID id="207" name="glyph00207"/>
+    <GlyphID id="208" name="glyph00208"/>
+    <GlyphID id="209" name="ordfeminine"/>
+    <GlyphID id="210" name="ordmasculine"/>
+    <GlyphID id="211" name="glyph00211"/>
+    <GlyphID id="212" name="glyph00212"/>
+    <GlyphID id="213" name="glyph00213"/>
+    <GlyphID id="214" name="glyph00214"/>
+    <GlyphID id="215" name="glyph00215"/>
+    <GlyphID id="216" name="glyph00216"/>
+    <GlyphID id="217" name="glyph00217"/>
+    <GlyphID id="218" name="glyph00218"/>
+    <GlyphID id="219" name="glyph00219"/>
+    <GlyphID id="220" name="glyph00220"/>
+    <GlyphID id="221" name="glyph00221"/>
+    <GlyphID id="222" name="glyph00222"/>
+    <GlyphID id="223" name="glyph00223"/>
+    <GlyphID id="224" name="glyph00224"/>
+    <GlyphID id="225" name="glyph00225"/>
+    <GlyphID id="226" name="glyph00226"/>
+    <GlyphID id="227" name="glyph00227"/>
+    <GlyphID id="228" name="glyph00228"/>
+    <GlyphID id="229" name="glyph00229"/>
+    <GlyphID id="230" name="glyph00230"/>
+    <GlyphID id="231" name="glyph00231"/>
+    <GlyphID id="232" name="glyph00232"/>
+    <GlyphID id="233" name="glyph00233"/>
+    <GlyphID id="234" name="glyph00234"/>
+    <GlyphID id="235" name="glyph00235"/>
+    <GlyphID id="236" name="glyph00236"/>
+    <GlyphID id="237" name="glyph00237"/>
+    <GlyphID id="238" name="glyph00238"/>
+    <GlyphID id="239" name="glyph00239"/>
+    <GlyphID id="240" name="glyph00240"/>
+    <GlyphID id="241" name="glyph00241"/>
+    <GlyphID id="242" name="glyph00242"/>
+    <GlyphID id="243" name="glyph00243"/>
+    <GlyphID id="244" name="glyph00244"/>
+    <GlyphID id="245" name="glyph00245"/>
+    <GlyphID id="246" name="glyph00246"/>
+    <GlyphID id="247" name="glyph00247"/>
+    <GlyphID id="248" name="glyph00248"/>
+    <GlyphID id="249" name="glyph00249"/>
+    <GlyphID id="250" name="glyph00250"/>
+    <GlyphID id="251" name="glyph00251"/>
+    <GlyphID id="252" name="glyph00252"/>
+    <GlyphID id="253" name="glyph00253"/>
+    <GlyphID id="254" name="glyph00254"/>
+    <GlyphID id="255" name="glyph00255"/>
+    <GlyphID id="256" name="glyph00256"/>
+    <GlyphID id="257" name="glyph00257"/>
+    <GlyphID id="258" name="glyph00258"/>
+    <GlyphID id="259" name="glyph00259"/>
+    <GlyphID id="260" name="glyph00260"/>
+    <GlyphID id="261" name="glyph00261"/>
+    <GlyphID id="262" name="glyph00262"/>
+    <GlyphID id="263" name="glyph00263"/>
+    <GlyphID id="264" name="glyph00264"/>
+    <GlyphID id="265" name="glyph00265"/>
+    <GlyphID id="266" name="glyph00266"/>
+    <GlyphID id="267" name="currency"/>
+    <GlyphID id="268" name="dollar"/>
+    <GlyphID id="269" name="sterling"/>
+    <GlyphID id="270" name="yen"/>
+    <GlyphID id="271" name="cent"/>
+    <GlyphID id="272" name="glyph00272"/>
+    <GlyphID id="273" name="percent"/>
+    <GlyphID id="274" name="onequarter"/>
+    <GlyphID id="275" name="onehalf"/>
+    <GlyphID id="276" name="threequarters"/>
+    <GlyphID id="277" name="plus"/>
+    <GlyphID id="278" name="multiply"/>
+    <GlyphID id="279" name="divide"/>
+    <GlyphID id="280" name="equal"/>
+    <GlyphID id="281" name="less"/>
+    <GlyphID id="282" name="greater"/>
+    <GlyphID id="283" name="plusminus"/>
+    <GlyphID id="284" name="asciicircum"/>
+    <GlyphID id="285" name="asciitilde"/>
+    <GlyphID id="286" name="logicalnot"/>
+    <GlyphID id="287" name="degree"/>
+    <GlyphID id="288" name="grave"/>
+    <GlyphID id="289" name="acute"/>
+    <GlyphID id="290" name="dieresis"/>
+    <GlyphID id="291" name="macron"/>
+    <GlyphID id="292" name="cedilla"/>
+    <GlyphID id="293" name="glyph00293"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="3.006"/>
+    <checkSumAdjustment value="0x6fea4c3"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Aug  9 14:26:15 2019"/>
+    <modified value="Thu May 28 16:17:56 2020"/>
+    <xMin value="-164"/>
+    <yMin value="-250"/>
+    <xMax value="902"/>
+    <yMax value="906"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="3"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1024"/>
+    <descent value="-400"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="2200"/>
+    <minLeftSideBearing value="-452"/>
+    <minRightSideBearing value="-452"/>
+    <xMaxExtent value="2160"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="294"/>
+  </hhea>
+
+  <maxp>
+    <tableVersion value="0x5000"/>
+    <numGlyphs value="294"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="3"/>
+    <xAvgCharWidth value="496"/>
+    <usWeightClass value="200"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="286"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="11"/>
+      <bWeight value="3"/>
+      <bProportion value="3"/>
+      <bContrast value="3"/>
+      <bStrokeVariation value="4"/>
+      <bArmStyle value="3"/>
+      <bLetterForm value="2"/>
+      <bMidline value="2"/>
+      <bXHeight value="4"/>
+    </panose>
+    <ulUnicodeRange1 value="01100000 00000000 00000010 11110111"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000011"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="ADBO"/>
+    <fsSelection value="00000000 00000000"/>
+    <usFirstCharIndex value="32"/>
+    <usLastCharIndex value="65535"/>
+    <sTypoAscender value="1024"/>
+    <sTypoDescender value="-400"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1024"/>
+    <usWinDescent value="400"/>
+    <ulCodePageRange1 value="00100000 00000000 00000001 10011111"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="478"/>
+    <sCapHeight value="660"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="3"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="624" lsb="96"/>
+    <mtx name="A" width="520" lsb="10"/>
+    <mtx name="AE" width="804" lsb="26"/>
+    <mtx name="Aacute" width="520" lsb="10"/>
+    <mtx name="Acircumflex" width="520" lsb="10"/>
+    <mtx name="Adieresis" width="520" lsb="10"/>
+    <mtx name="Agrave" width="520" lsb="10"/>
+    <mtx name="Aring" width="520" lsb="10"/>
+    <mtx name="Atilde" width="520" lsb="10"/>
+    <mtx name="B" width="574" lsb="100"/>
+    <mtx name="C" width="562" lsb="56"/>
+    <mtx name="Ccedilla" width="562" lsb="56"/>
+    <mtx name="D" width="600" lsb="100"/>
+    <mtx name="E" width="510" lsb="100"/>
+    <mtx name="Eacute" width="510" lsb="100"/>
+    <mtx name="Ecircumflex" width="510" lsb="100"/>
+    <mtx name="Edieresis" width="510" lsb="100"/>
+    <mtx name="Egrave" width="510" lsb="100"/>
+    <mtx name="Eth" width="620" lsb="38"/>
+    <mtx name="F" width="470" lsb="100"/>
+    <mtx name="G" width="600" lsb="56"/>
+    <mtx name="H" width="634" lsb="100"/>
+    <mtx name="I" width="232" lsb="100"/>
+    <mtx name="Iacute" width="232" lsb="48"/>
+    <mtx name="Icircumflex" width="232" lsb="-14"/>
+    <mtx name="Idieresis" width="232" lsb="-12"/>
+    <mtx name="Igrave" width="232" lsb="12"/>
+    <mtx name="J" width="456" lsb="44"/>
+    <mtx name="K" width="550" lsb="100"/>
+    <mtx name="L" width="460" lsb="100"/>
+    <mtx name="M" width="698" lsb="100"/>
+    <mtx name="N" width="632" lsb="100"/>
+    <mtx name="Ntilde" width="632" lsb="100"/>
+    <mtx name="O" width="648" lsb="56"/>
+    <mtx name="Oacute" width="648" lsb="56"/>
+    <mtx name="Ocircumflex" width="648" lsb="56"/>
+    <mtx name="Odieresis" width="648" lsb="56"/>
+    <mtx name="Ograve" width="648" lsb="56"/>
+    <mtx name="Oslash" width="648" lsb="58"/>
+    <mtx name="Otilde" width="648" lsb="56"/>
+    <mtx name="P" width="542" lsb="100"/>
+    <mtx name="Q" width="648" lsb="56"/>
+    <mtx name="R" width="534" lsb="100"/>
+    <mtx name="S" width="516" lsb="48"/>
+    <mtx name="T" width="520" lsb="30"/>
+    <mtx name="Thorn" width="556" lsb="100"/>
+    <mtx name="U" width="630" lsb="98"/>
+    <mtx name="Uacute" width="630" lsb="98"/>
+    <mtx name="Ucircumflex" width="630" lsb="98"/>
+    <mtx name="Udieresis" width="630" lsb="98"/>
+    <mtx name="Ugrave" width="630" lsb="98"/>
+    <mtx name="V" width="482" lsb="6"/>
+    <mtx name="W" width="764" lsb="30"/>
+    <mtx name="X" width="470" lsb="18"/>
+    <mtx name="Y" width="436" lsb="4"/>
+    <mtx name="Yacute" width="436" lsb="4"/>
+    <mtx name="Z" width="538" lsb="52"/>
+    <mtx name="a" width="486" lsb="60"/>
+    <mtx name="aacute" width="486" lsb="60"/>
+    <mtx name="acircumflex" width="486" lsb="60"/>
+    <mtx name="acute" width="532" lsb="204"/>
+    <mtx name="adieresis" width="486" lsb="60"/>
+    <mtx name="ae" width="776" lsb="60"/>
+    <mtx name="agrave" width="486" lsb="60"/>
+    <mtx name="ampersand" width="562" lsb="38"/>
+    <mtx name="aring" width="486" lsb="60"/>
+    <mtx name="asciicircum" width="472" lsb="68"/>
+    <mtx name="asciitilde" width="472" lsb="42"/>
+    <mtx name="asterisk" width="386" lsb="74"/>
+    <mtx name="at" width="802" lsb="52"/>
+    <mtx name="atilde" width="486" lsb="60"/>
+    <mtx name="b" width="538" lsb="96"/>
+    <mtx name="backslash" width="360" lsb="2"/>
+    <mtx name="bar" width="220" lsb="96"/>
+    <mtx name="braceleft" width="270" lsb="36"/>
+    <mtx name="braceright" width="270" lsb="18"/>
+    <mtx name="bracketleft" width="270" lsb="100"/>
+    <mtx name="bracketright" width="270" lsb="18"/>
+    <mtx name="brokenbar" width="220" lsb="96"/>
+    <mtx name="c" width="446" lsb="54"/>
+    <mtx name="ccedilla" width="446" lsb="54"/>
+    <mtx name="cedilla" width="532" lsb="196"/>
+    <mtx name="cent" width="472" lsb="62"/>
+    <mtx name="colon" width="208" lsb="68"/>
+    <mtx name="comma" width="208" lsb="48"/>
+    <mtx name="copyright" width="740" lsb="52"/>
+    <mtx name="currency" width="472" lsb="32"/>
+    <mtx name="d" width="540" lsb="54"/>
+    <mtx name="degree" width="304" lsb="42"/>
+    <mtx name="dieresis" width="532" lsb="148"/>
+    <mtx name="divide" width="472" lsb="34"/>
+    <mtx name="dollar" width="472" lsb="62"/>
+    <mtx name="e" width="478" lsb="54"/>
+    <mtx name="eacute" width="478" lsb="54"/>
+    <mtx name="ecircumflex" width="478" lsb="54"/>
+    <mtx name="edieresis" width="478" lsb="54"/>
+    <mtx name="egrave" width="478" lsb="54"/>
+    <mtx name="eight" width="472" lsb="40"/>
+    <mtx name="equal" width="472" lsb="34"/>
+    <mtx name="eth" width="532" lsb="62"/>
+    <mtx name="exclam" width="248" lsb="88"/>
+    <mtx name="exclamdown" width="248" lsb="88"/>
+    <mtx name="f" width="252" lsb="34"/>
+    <mtx name="five" width="472" lsb="26"/>
+    <mtx name="four" width="472" lsb="16"/>
+    <mtx name="g" width="480" lsb="54"/>
+    <mtx name="germandbls" width="530" lsb="96"/>
+    <mtx name="glyph00084" width="920" lsb="100"/>
+    <mtx name="glyph00117" width="518" lsb="96"/>
+    <mtx name="glyph00118" width="512" lsb="34"/>
+    <mtx name="glyph00119" width="518" lsb="34"/>
+    <mtx name="glyph00120" width="778" lsb="34"/>
+    <mtx name="glyph00165" width="360" lsb="42"/>
+    <mtx name="glyph00169" width="360" lsb="48"/>
+    <mtx name="glyph00170" width="360" lsb="42"/>
+    <mtx name="glyph00171" width="360" lsb="52"/>
+    <mtx name="glyph00172" width="360" lsb="50"/>
+    <mtx name="glyph00173" width="360" lsb="50"/>
+    <mtx name="glyph00174" width="360" lsb="42"/>
+    <mtx name="glyph00175" width="360" lsb="34"/>
+    <mtx name="glyph00176" width="360" lsb="34"/>
+    <mtx name="glyph00177" width="212" lsb="66"/>
+    <mtx name="glyph00178" width="212" lsb="42"/>
+    <mtx name="glyph00179" width="152" lsb="44"/>
+    <mtx name="glyph00180" width="152" lsb="34"/>
+    <mtx name="glyph00181" width="360" lsb="42"/>
+    <mtx name="glyph00182" width="360" lsb="96"/>
+    <mtx name="glyph00183" width="360" lsb="50"/>
+    <mtx name="glyph00184" width="360" lsb="42"/>
+    <mtx name="glyph00185" width="360" lsb="48"/>
+    <mtx name="glyph00186" width="360" lsb="42"/>
+    <mtx name="glyph00187" width="360" lsb="52"/>
+    <mtx name="glyph00188" width="360" lsb="50"/>
+    <mtx name="glyph00189" width="360" lsb="50"/>
+    <mtx name="glyph00190" width="360" lsb="42"/>
+    <mtx name="glyph00191" width="212" lsb="66"/>
+    <mtx name="glyph00192" width="212" lsb="42"/>
+    <mtx name="glyph00193" width="152" lsb="44"/>
+    <mtx name="glyph00194" width="152" lsb="34"/>
+    <mtx name="glyph00195" width="360" lsb="42"/>
+    <mtx name="glyph00196" width="360" lsb="96"/>
+    <mtx name="glyph00197" width="360" lsb="50"/>
+    <mtx name="glyph00198" width="360" lsb="42"/>
+    <mtx name="glyph00199" width="360" lsb="48"/>
+    <mtx name="glyph00200" width="360" lsb="42"/>
+    <mtx name="glyph00201" width="360" lsb="52"/>
+    <mtx name="glyph00202" width="360" lsb="50"/>
+    <mtx name="glyph00203" width="360" lsb="50"/>
+    <mtx name="glyph00204" width="360" lsb="42"/>
+    <mtx name="glyph00205" width="212" lsb="66"/>
+    <mtx name="glyph00206" width="212" lsb="42"/>
+    <mtx name="glyph00207" width="152" lsb="44"/>
+    <mtx name="glyph00208" width="152" lsb="34"/>
+    <mtx name="glyph00211" width="343" lsb="3"/>
+    <mtx name="glyph00212" width="379" lsb="63"/>
+    <mtx name="glyph00213" width="369" lsb="34"/>
+    <mtx name="glyph00214" width="398" lsb="63"/>
+    <mtx name="glyph00215" width="337" lsb="63"/>
+    <mtx name="glyph00216" width="311" lsb="63"/>
+    <mtx name="glyph00217" width="396" lsb="34"/>
+    <mtx name="glyph00218" width="420" lsb="63"/>
+    <mtx name="glyph00219" width="155" lsb="63"/>
+    <mtx name="glyph00220" width="303" lsb="25"/>
+    <mtx name="glyph00221" width="365" lsb="63"/>
+    <mtx name="glyph00222" width="305" lsb="63"/>
+    <mtx name="glyph00223" width="463" lsb="63"/>
+    <mtx name="glyph00224" width="418" lsb="63"/>
+    <mtx name="glyph00225" width="428" lsb="34"/>
+    <mtx name="glyph00226" width="366" lsb="63"/>
+    <mtx name="glyph00227" width="428" lsb="34"/>
+    <mtx name="glyph00228" width="367" lsb="63"/>
+    <mtx name="glyph00229" width="341" lsb="29"/>
+    <mtx name="glyph00230" width="341" lsb="17"/>
+    <mtx name="glyph00231" width="418" lsb="62"/>
+    <mtx name="glyph00232" width="320" lsb="1"/>
+    <mtx name="glyph00233" width="507" lsb="17"/>
+    <mtx name="glyph00234" width="314" lsb="9"/>
+    <mtx name="glyph00235" width="291" lsb="-1"/>
+    <mtx name="glyph00236" width="353" lsb="31"/>
+    <mtx name="glyph00237" width="334" lsb="44"/>
+    <mtx name="glyph00238" width="364" lsb="60"/>
+    <mtx name="glyph00239" width="300" lsb="34"/>
+    <mtx name="glyph00240" width="364" lsb="38"/>
+    <mtx name="glyph00241" width="328" lsb="32"/>
+    <mtx name="glyph00242" width="176" lsb="22"/>
+    <mtx name="glyph00243" width="328" lsb="36"/>
+    <mtx name="glyph00244" width="352" lsb="60"/>
+    <mtx name="glyph00245" width="148" lsb="48"/>
+    <mtx name="glyph00246" width="152" lsb="-20"/>
+    <mtx name="glyph00247" width="310" lsb="60"/>
+    <mtx name="glyph00248" width="158" lsb="60"/>
+    <mtx name="glyph00249" width="544" lsb="60"/>
+    <mtx name="glyph00250" width="356" lsb="60"/>
+    <mtx name="glyph00251" width="358" lsb="34"/>
+    <mtx name="glyph00252" width="364" lsb="60"/>
+    <mtx name="glyph00253" width="364" lsb="38"/>
+    <mtx name="glyph00254" width="214" lsb="60"/>
+    <mtx name="glyph00255" width="272" lsb="22"/>
+    <mtx name="glyph00256" width="210" lsb="19"/>
+    <mtx name="glyph00257" width="360" lsb="60"/>
+    <mtx name="glyph00258" width="294" lsb="8"/>
+    <mtx name="glyph00259" width="458" lsb="16"/>
+    <mtx name="glyph00260" width="274" lsb="8"/>
+    <mtx name="glyph00261" width="292" lsb="8"/>
+    <mtx name="glyph00262" width="272" lsb="18"/>
+    <mtx name="glyph00263" width="328" lsb="32"/>
+    <mtx name="glyph00264" width="328" lsb="32"/>
+    <mtx name="glyph00265" width="152" lsb="44"/>
+    <mtx name="glyph00266" width="224" lsb="40"/>
+    <mtx name="glyph00272" width="78" lsb="-164"/>
+    <mtx name="glyph00293" width="130" lsb="0"/>
+    <mtx name="grave" width="532" lsb="162"/>
+    <mtx name="greater" width="472" lsb="34"/>
+    <mtx name="guillemotleft" width="388" lsb="42"/>
+    <mtx name="guillemotright" width="388" lsb="54"/>
+    <mtx name="h" width="522" lsb="96"/>
+    <mtx name="hyphen" width="294" lsb="40"/>
+    <mtx name="i" width="222" lsb="80"/>
+    <mtx name="iacute" width="222" lsb="50"/>
+    <mtx name="icircumflex" width="222" lsb="-20"/>
+    <mtx name="idieresis" width="222" lsb="-6"/>
+    <mtx name="igrave" width="222" lsb="8"/>
+    <mtx name="j" width="222" lsb="-30"/>
+    <mtx name="k" width="452" lsb="96"/>
+    <mtx name="l" width="230" lsb="96"/>
+    <mtx name="less" width="472" lsb="34"/>
+    <mtx name="logicalnot" width="472" lsb="34"/>
+    <mtx name="m" width="806" lsb="96"/>
+    <mtx name="macron" width="532" lsb="146"/>
+    <mtx name="mu" width="536" lsb="96"/>
+    <mtx name="multiply" width="472" lsb="52"/>
+    <mtx name="n" width="526" lsb="96"/>
+    <mtx name="nine" width="472" lsb="44"/>
+    <mtx name="ntilde" width="526" lsb="96"/>
+    <mtx name="numbersign" width="472" lsb="36"/>
+    <mtx name="o" width="532" lsb="54"/>
+    <mtx name="oacute" width="532" lsb="54"/>
+    <mtx name="ocircumflex" width="532" lsb="54"/>
+    <mtx name="odieresis" width="532" lsb="54"/>
+    <mtx name="ograve" width="532" lsb="54"/>
+    <mtx name="one" width="472" lsb="86"/>
+    <mtx name="onehalf" width="778" lsb="76"/>
+    <mtx name="onequarter" width="758" lsb="76"/>
+    <mtx name="ordfeminine" width="334" lsb="44"/>
+    <mtx name="ordmasculine" width="358" lsb="34"/>
+    <mtx name="oslash" width="532" lsb="46"/>
+    <mtx name="otilde" width="532" lsb="54"/>
+    <mtx name="p" width="540" lsb="96"/>
+    <mtx name="paragraph" width="498" lsb="42"/>
+    <mtx name="parenleft" width="270" lsb="90"/>
+    <mtx name="parenright" width="270" lsb="30"/>
+    <mtx name="percent" width="798" lsb="42"/>
+    <mtx name="period" width="208" lsb="68"/>
+    <mtx name="periodcentered" width="208" lsb="68"/>
+    <mtx name="plus" width="472" lsb="34"/>
+    <mtx name="plusminus" width="472" lsb="34"/>
+    <mtx name="q" width="540" lsb="54"/>
+    <mtx name="question" width="394" lsb="36"/>
+    <mtx name="questiondown" width="394" lsb="52"/>
+    <mtx name="quotedbl" width="336" lsb="84"/>
+    <mtx name="quotesingle" width="208" lsb="84"/>
+    <mtx name="r" width="306" lsb="96"/>
+    <mtx name="registered" width="392" lsb="16"/>
+    <mtx name="s" width="400" lsb="34"/>
+    <mtx name="section" width="472" lsb="52"/>
+    <mtx name="semicolon" width="208" lsb="48"/>
+    <mtx name="seven" width="472" lsb="44"/>
+    <mtx name="six" width="472" lsb="54"/>
+    <mtx name="slash" width="360" lsb="8"/>
+    <mtx name="space" width="200" lsb="0"/>
+    <mtx name="sterling" width="472" lsb="54"/>
+    <mtx name="t" width="302" lsb="30"/>
+    <mtx name="thorn" width="540" lsb="96"/>
+    <mtx name="three" width="472" lsb="30"/>
+    <mtx name="threequarters" width="778" lsb="42"/>
+    <mtx name="two" width="472" lsb="40"/>
+    <mtx name="u" width="524" lsb="88"/>
+    <mtx name="uacute" width="524" lsb="88"/>
+    <mtx name="ucircumflex" width="524" lsb="88"/>
+    <mtx name="udieresis" width="524" lsb="88"/>
+    <mtx name="ugrave" width="524" lsb="88"/>
+    <mtx name="underscore" width="500" lsb="12"/>
+    <mtx name="uni00B2" width="360" lsb="50"/>
+    <mtx name="uni00B3" width="360" lsb="42"/>
+    <mtx name="uni00B9" width="360" lsb="96"/>
+    <mtx name="v" width="422" lsb="12"/>
+    <mtx name="w" width="672" lsb="24"/>
+    <mtx name="x" width="392" lsb="14"/>
+    <mtx name="y" width="424" lsb="12"/>
+    <mtx name="yacute" width="424" lsb="12"/>
+    <mtx name="ydieresis" width="424" lsb="12"/>
+    <mtx name="yen" width="472" lsb="32"/>
+    <mtx name="z" width="396" lsb="26"/>
+    <mtx name="zero" width="472" lsb="50"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x21" name="exclam"/><!-- EXCLAMATION MARK -->
+      <map code="0x22" name="quotedbl"/><!-- QUOTATION MARK -->
+      <map code="0x23" name="numbersign"/><!-- NUMBER SIGN -->
+      <map code="0x24" name="dollar"/><!-- DOLLAR SIGN -->
+      <map code="0x25" name="percent"/><!-- PERCENT SIGN -->
+      <map code="0x26" name="ampersand"/><!-- AMPERSAND -->
+      <map code="0x27" name="quotesingle"/><!-- APOSTROPHE -->
+      <map code="0x28" name="parenleft"/><!-- LEFT PARENTHESIS -->
+      <map code="0x29" name="parenright"/><!-- RIGHT PARENTHESIS -->
+      <map code="0x2a" name="asterisk"/><!-- ASTERISK -->
+      <map code="0x2b" name="plus"/><!-- PLUS SIGN -->
+      <map code="0x2c" name="comma"/><!-- COMMA -->
+      <map code="0x2d" name="hyphen"/><!-- HYPHEN-MINUS -->
+      <map code="0x2e" name="period"/><!-- FULL STOP -->
+      <map code="0x2f" name="slash"/><!-- SOLIDUS -->
+      <map code="0x30" name="zero"/><!-- DIGIT ZERO -->
+      <map code="0x31" name="one"/><!-- DIGIT ONE -->
+      <map code="0x32" name="two"/><!-- DIGIT TWO -->
+      <map code="0x33" name="three"/><!-- DIGIT THREE -->
+      <map code="0x34" name="four"/><!-- DIGIT FOUR -->
+      <map code="0x35" name="five"/><!-- DIGIT FIVE -->
+      <map code="0x36" name="six"/><!-- DIGIT SIX -->
+      <map code="0x37" name="seven"/><!-- DIGIT SEVEN -->
+      <map code="0x38" name="eight"/><!-- DIGIT EIGHT -->
+      <map code="0x39" name="nine"/><!-- DIGIT NINE -->
+      <map code="0x3a" name="colon"/><!-- COLON -->
+      <map code="0x3b" name="semicolon"/><!-- SEMICOLON -->
+      <map code="0x3c" name="less"/><!-- LESS-THAN SIGN -->
+      <map code="0x3d" name="equal"/><!-- EQUALS SIGN -->
+      <map code="0x3e" name="greater"/><!-- GREATER-THAN SIGN -->
+      <map code="0x3f" name="question"/><!-- QUESTION MARK -->
+      <map code="0x40" name="at"/><!-- COMMERCIAL AT -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x44" name="D"/><!-- LATIN CAPITAL LETTER D -->
+      <map code="0x45" name="E"/><!-- LATIN CAPITAL LETTER E -->
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x47" name="G"/><!-- LATIN CAPITAL LETTER G -->
+      <map code="0x48" name="H"/><!-- LATIN CAPITAL LETTER H -->
+      <map code="0x49" name="I"/><!-- LATIN CAPITAL LETTER I -->
+      <map code="0x4a" name="J"/><!-- LATIN CAPITAL LETTER J -->
+      <map code="0x4b" name="K"/><!-- LATIN CAPITAL LETTER K -->
+      <map code="0x4c" name="L"/><!-- LATIN CAPITAL LETTER L -->
+      <map code="0x4d" name="M"/><!-- LATIN CAPITAL LETTER M -->
+      <map code="0x4e" name="N"/><!-- LATIN CAPITAL LETTER N -->
+      <map code="0x4f" name="O"/><!-- LATIN CAPITAL LETTER O -->
+      <map code="0x50" name="P"/><!-- LATIN CAPITAL LETTER P -->
+      <map code="0x51" name="Q"/><!-- LATIN CAPITAL LETTER Q -->
+      <map code="0x52" name="R"/><!-- LATIN CAPITAL LETTER R -->
+      <map code="0x53" name="S"/><!-- LATIN CAPITAL LETTER S -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x55" name="U"/><!-- LATIN CAPITAL LETTER U -->
+      <map code="0x56" name="V"/><!-- LATIN CAPITAL LETTER V -->
+      <map code="0x57" name="W"/><!-- LATIN CAPITAL LETTER W -->
+      <map code="0x58" name="X"/><!-- LATIN CAPITAL LETTER X -->
+      <map code="0x59" name="Y"/><!-- LATIN CAPITAL LETTER Y -->
+      <map code="0x5a" name="Z"/><!-- LATIN CAPITAL LETTER Z -->
+      <map code="0x5b" name="bracketleft"/><!-- LEFT SQUARE BRACKET -->
+      <map code="0x5c" name="backslash"/><!-- REVERSE SOLIDUS -->
+      <map code="0x5d" name="bracketright"/><!-- RIGHT SQUARE BRACKET -->
+      <map code="0x5e" name="asciicircum"/><!-- CIRCUMFLEX ACCENT -->
+      <map code="0x5f" name="underscore"/><!-- LOW LINE -->
+      <map code="0x60" name="grave"/><!-- GRAVE ACCENT -->
+      <map code="0x61" name="a"/><!-- LATIN SMALL LETTER A -->
+      <map code="0x62" name="b"/><!-- LATIN SMALL LETTER B -->
+      <map code="0x63" name="c"/><!-- LATIN SMALL LETTER C -->
+      <map code="0x64" name="d"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="e"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="f"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="g"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="h"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="i"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="j"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="k"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6d" name="m"/><!-- LATIN SMALL LETTER M -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x70" name="p"/><!-- LATIN SMALL LETTER P -->
+      <map code="0x71" name="q"/><!-- LATIN SMALL LETTER Q -->
+      <map code="0x72" name="r"/><!-- LATIN SMALL LETTER R -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+      <map code="0x75" name="u"/><!-- LATIN SMALL LETTER U -->
+      <map code="0x76" name="v"/><!-- LATIN SMALL LETTER V -->
+      <map code="0x77" name="w"/><!-- LATIN SMALL LETTER W -->
+      <map code="0x78" name="x"/><!-- LATIN SMALL LETTER X -->
+      <map code="0x79" name="y"/><!-- LATIN SMALL LETTER Y -->
+      <map code="0x7a" name="z"/><!-- LATIN SMALL LETTER Z -->
+      <map code="0x7b" name="braceleft"/><!-- LEFT CURLY BRACKET -->
+      <map code="0x7c" name="bar"/><!-- VERTICAL LINE -->
+      <map code="0x7d" name="braceright"/><!-- RIGHT CURLY BRACKET -->
+      <map code="0x7e" name="asciitilde"/><!-- TILDE -->
+      <map code="0xa0" name="space"/><!-- NO-BREAK SPACE -->
+      <map code="0xa1" name="exclamdown"/><!-- INVERTED EXCLAMATION MARK -->
+      <map code="0xa2" name="cent"/><!-- CENT SIGN -->
+      <map code="0xa3" name="sterling"/><!-- POUND SIGN -->
+      <map code="0xa4" name="currency"/><!-- CURRENCY SIGN -->
+      <map code="0xa5" name="yen"/><!-- YEN SIGN -->
+      <map code="0xa6" name="brokenbar"/><!-- BROKEN BAR -->
+      <map code="0xa7" name="section"/><!-- SECTION SIGN -->
+      <map code="0xa8" name="dieresis"/><!-- DIAERESIS -->
+      <map code="0xa9" name="copyright"/><!-- COPYRIGHT SIGN -->
+      <map code="0xaa" name="ordfeminine"/><!-- FEMININE ORDINAL INDICATOR -->
+      <map code="0xab" name="guillemotleft"/><!-- LEFT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+      <map code="0xac" name="logicalnot"/><!-- NOT SIGN -->
+      <map code="0xad" name="hyphen"/><!-- SOFT HYPHEN -->
+      <map code="0xae" name="registered"/><!-- REGISTERED SIGN -->
+      <map code="0xaf" name="macron"/><!-- MACRON -->
+      <map code="0xb0" name="degree"/><!-- DEGREE SIGN -->
+      <map code="0xb1" name="plusminus"/><!-- PLUS-MINUS SIGN -->
+      <map code="0xb2" name="uni00B2"/><!-- SUPERSCRIPT TWO -->
+      <map code="0xb3" name="uni00B3"/><!-- SUPERSCRIPT THREE -->
+      <map code="0xb4" name="acute"/><!-- ACUTE ACCENT -->
+      <map code="0xb5" name="mu"/><!-- MICRO SIGN -->
+      <map code="0xb6" name="paragraph"/><!-- PILCROW SIGN -->
+      <map code="0xb7" name="periodcentered"/><!-- MIDDLE DOT -->
+      <map code="0xb8" name="cedilla"/><!-- CEDILLA -->
+      <map code="0xb9" name="uni00B9"/><!-- SUPERSCRIPT ONE -->
+      <map code="0xba" name="ordmasculine"/><!-- MASCULINE ORDINAL INDICATOR -->
+      <map code="0xbb" name="guillemotright"/><!-- RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+      <map code="0xbc" name="onequarter"/><!-- VULGAR FRACTION ONE QUARTER -->
+      <map code="0xbd" name="onehalf"/><!-- VULGAR FRACTION ONE HALF -->
+      <map code="0xbe" name="threequarters"/><!-- VULGAR FRACTION THREE QUARTERS -->
+      <map code="0xbf" name="questiondown"/><!-- INVERTED QUESTION MARK -->
+      <map code="0xc0" name="Agrave"/><!-- LATIN CAPITAL LETTER A WITH GRAVE -->
+      <map code="0xc1" name="Aacute"/><!-- LATIN CAPITAL LETTER A WITH ACUTE -->
+      <map code="0xc2" name="Acircumflex"/><!-- LATIN CAPITAL LETTER A WITH CIRCUMFLEX -->
+      <map code="0xc3" name="Atilde"/><!-- LATIN CAPITAL LETTER A WITH TILDE -->
+      <map code="0xc4" name="Adieresis"/><!-- LATIN CAPITAL LETTER A WITH DIAERESIS -->
+      <map code="0xc5" name="Aring"/><!-- LATIN CAPITAL LETTER A WITH RING ABOVE -->
+      <map code="0xc6" name="AE"/><!-- LATIN CAPITAL LETTER AE -->
+      <map code="0xc7" name="Ccedilla"/><!-- LATIN CAPITAL LETTER C WITH CEDILLA -->
+      <map code="0xc8" name="Egrave"/><!-- LATIN CAPITAL LETTER E WITH GRAVE -->
+      <map code="0xc9" name="Eacute"/><!-- LATIN CAPITAL LETTER E WITH ACUTE -->
+      <map code="0xca" name="Ecircumflex"/><!-- LATIN CAPITAL LETTER E WITH CIRCUMFLEX -->
+      <map code="0xcb" name="Edieresis"/><!-- LATIN CAPITAL LETTER E WITH DIAERESIS -->
+      <map code="0xcc" name="Igrave"/><!-- LATIN CAPITAL LETTER I WITH GRAVE -->
+      <map code="0xcd" name="Iacute"/><!-- LATIN CAPITAL LETTER I WITH ACUTE -->
+      <map code="0xce" name="Icircumflex"/><!-- LATIN CAPITAL LETTER I WITH CIRCUMFLEX -->
+      <map code="0xcf" name="Idieresis"/><!-- LATIN CAPITAL LETTER I WITH DIAERESIS -->
+      <map code="0xd0" name="Eth"/><!-- LATIN CAPITAL LETTER ETH -->
+      <map code="0xd1" name="Ntilde"/><!-- LATIN CAPITAL LETTER N WITH TILDE -->
+      <map code="0xd2" name="Ograve"/><!-- LATIN CAPITAL LETTER O WITH GRAVE -->
+      <map code="0xd3" name="Oacute"/><!-- LATIN CAPITAL LETTER O WITH ACUTE -->
+      <map code="0xd4" name="Ocircumflex"/><!-- LATIN CAPITAL LETTER O WITH CIRCUMFLEX -->
+      <map code="0xd5" name="Otilde"/><!-- LATIN CAPITAL LETTER O WITH TILDE -->
+      <map code="0xd6" name="Odieresis"/><!-- LATIN CAPITAL LETTER O WITH DIAERESIS -->
+      <map code="0xd7" name="multiply"/><!-- MULTIPLICATION SIGN -->
+      <map code="0xd8" name="Oslash"/><!-- LATIN CAPITAL LETTER O WITH STROKE -->
+      <map code="0xd9" name="Ugrave"/><!-- LATIN CAPITAL LETTER U WITH GRAVE -->
+      <map code="0xda" name="Uacute"/><!-- LATIN CAPITAL LETTER U WITH ACUTE -->
+      <map code="0xdb" name="Ucircumflex"/><!-- LATIN CAPITAL LETTER U WITH CIRCUMFLEX -->
+      <map code="0xdc" name="Udieresis"/><!-- LATIN CAPITAL LETTER U WITH DIAERESIS -->
+      <map code="0xdd" name="Yacute"/><!-- LATIN CAPITAL LETTER Y WITH ACUTE -->
+      <map code="0xde" name="Thorn"/><!-- LATIN CAPITAL LETTER THORN -->
+      <map code="0xdf" name="germandbls"/><!-- LATIN SMALL LETTER SHARP S -->
+      <map code="0xe0" name="agrave"/><!-- LATIN SMALL LETTER A WITH GRAVE -->
+      <map code="0xe1" name="aacute"/><!-- LATIN SMALL LETTER A WITH ACUTE -->
+      <map code="0xe2" name="acircumflex"/><!-- LATIN SMALL LETTER A WITH CIRCUMFLEX -->
+      <map code="0xe3" name="atilde"/><!-- LATIN SMALL LETTER A WITH TILDE -->
+      <map code="0xe4" name="adieresis"/><!-- LATIN SMALL LETTER A WITH DIAERESIS -->
+      <map code="0xe5" name="aring"/><!-- LATIN SMALL LETTER A WITH RING ABOVE -->
+      <map code="0xe6" name="ae"/><!-- LATIN SMALL LETTER AE -->
+      <map code="0xe7" name="ccedilla"/><!-- LATIN SMALL LETTER C WITH CEDILLA -->
+      <map code="0xe8" name="egrave"/><!-- LATIN SMALL LETTER E WITH GRAVE -->
+      <map code="0xe9" name="eacute"/><!-- LATIN SMALL LETTER E WITH ACUTE -->
+      <map code="0xea" name="ecircumflex"/><!-- LATIN SMALL LETTER E WITH CIRCUMFLEX -->
+      <map code="0xeb" name="edieresis"/><!-- LATIN SMALL LETTER E WITH DIAERESIS -->
+      <map code="0xec" name="igrave"/><!-- LATIN SMALL LETTER I WITH GRAVE -->
+      <map code="0xed" name="iacute"/><!-- LATIN SMALL LETTER I WITH ACUTE -->
+      <map code="0xee" name="icircumflex"/><!-- LATIN SMALL LETTER I WITH CIRCUMFLEX -->
+      <map code="0xef" name="idieresis"/><!-- LATIN SMALL LETTER I WITH DIAERESIS -->
+      <map code="0xf0" name="eth"/><!-- LATIN SMALL LETTER ETH -->
+      <map code="0xf1" name="ntilde"/><!-- LATIN SMALL LETTER N WITH TILDE -->
+      <map code="0xf2" name="ograve"/><!-- LATIN SMALL LETTER O WITH GRAVE -->
+      <map code="0xf3" name="oacute"/><!-- LATIN SMALL LETTER O WITH ACUTE -->
+      <map code="0xf4" name="ocircumflex"/><!-- LATIN SMALL LETTER O WITH CIRCUMFLEX -->
+      <map code="0xf5" name="otilde"/><!-- LATIN SMALL LETTER O WITH TILDE -->
+      <map code="0xf6" name="odieresis"/><!-- LATIN SMALL LETTER O WITH DIAERESIS -->
+      <map code="0xf7" name="divide"/><!-- DIVISION SIGN -->
+      <map code="0xf8" name="oslash"/><!-- LATIN SMALL LETTER O WITH STROKE -->
+      <map code="0xf9" name="ugrave"/><!-- LATIN SMALL LETTER U WITH GRAVE -->
+      <map code="0xfa" name="uacute"/><!-- LATIN SMALL LETTER U WITH ACUTE -->
+      <map code="0xfb" name="ucircumflex"/><!-- LATIN SMALL LETTER U WITH CIRCUMFLEX -->
+      <map code="0xfc" name="udieresis"/><!-- LATIN SMALL LETTER U WITH DIAERESIS -->
+      <map code="0xfd" name="yacute"/><!-- LATIN SMALL LETTER Y WITH ACUTE -->
+      <map code="0xfe" name="thorn"/><!-- LATIN SMALL LETTER THORN -->
+      <map code="0xff" name="ydieresis"/><!-- LATIN SMALL LETTER Y WITH DIAERESIS -->
+    </cmap_format_4>
+    <cmap_format_12 platformID="0" platEncID="4" format="12" reserved="0" length="952" language="0" nGroups="78">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x21" name="exclam"/><!-- EXCLAMATION MARK -->
+      <map code="0x22" name="quotedbl"/><!-- QUOTATION MARK -->
+      <map code="0x23" name="numbersign"/><!-- NUMBER SIGN -->
+      <map code="0x24" name="dollar"/><!-- DOLLAR SIGN -->
+      <map code="0x25" name="percent"/><!-- PERCENT SIGN -->
+      <map code="0x26" name="ampersand"/><!-- AMPERSAND -->
+      <map code="0x27" name="quotesingle"/><!-- APOSTROPHE -->
+      <map code="0x28" name="parenleft"/><!-- LEFT PARENTHESIS -->
+      <map code="0x29" name="parenright"/><!-- RIGHT PARENTHESIS -->
+      <map code="0x2a" name="asterisk"/><!-- ASTERISK -->
+      <map code="0x2b" name="plus"/><!-- PLUS SIGN -->
+      <map code="0x2c" name="comma"/><!-- COMMA -->
+      <map code="0x2d" name="hyphen"/><!-- HYPHEN-MINUS -->
+      <map code="0x2e" name="period"/><!-- FULL STOP -->
+      <map code="0x2f" name="slash"/><!-- SOLIDUS -->
+      <map code="0x30" name="zero"/><!-- DIGIT ZERO -->
+      <map code="0x31" name="one"/><!-- DIGIT ONE -->
+      <map code="0x32" name="two"/><!-- DIGIT TWO -->
+      <map code="0x33" name="three"/><!-- DIGIT THREE -->
+      <map code="0x34" name="four"/><!-- DIGIT FOUR -->
+      <map code="0x35" name="five"/><!-- DIGIT FIVE -->
+      <map code="0x36" name="six"/><!-- DIGIT SIX -->
+      <map code="0x37" name="seven"/><!-- DIGIT SEVEN -->
+      <map code="0x38" name="eight"/><!-- DIGIT EIGHT -->
+      <map code="0x39" name="nine"/><!-- DIGIT NINE -->
+      <map code="0x3a" name="colon"/><!-- COLON -->
+      <map code="0x3b" name="semicolon"/><!-- SEMICOLON -->
+      <map code="0x3c" name="less"/><!-- LESS-THAN SIGN -->
+      <map code="0x3d" name="equal"/><!-- EQUALS SIGN -->
+      <map code="0x3e" name="greater"/><!-- GREATER-THAN SIGN -->
+      <map code="0x3f" name="question"/><!-- QUESTION MARK -->
+      <map code="0x40" name="at"/><!-- COMMERCIAL AT -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x44" name="D"/><!-- LATIN CAPITAL LETTER D -->
+      <map code="0x45" name="E"/><!-- LATIN CAPITAL LETTER E -->
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x47" name="G"/><!-- LATIN CAPITAL LETTER G -->
+      <map code="0x48" name="H"/><!-- LATIN CAPITAL LETTER H -->
+      <map code="0x49" name="I"/><!-- LATIN CAPITAL LETTER I -->
+      <map code="0x4a" name="J"/><!-- LATIN CAPITAL LETTER J -->
+      <map code="0x4b" name="K"/><!-- LATIN CAPITAL LETTER K -->
+      <map code="0x4c" name="L"/><!-- LATIN CAPITAL LETTER L -->
+      <map code="0x4d" name="M"/><!-- LATIN CAPITAL LETTER M -->
+      <map code="0x4e" name="N"/><!-- LATIN CAPITAL LETTER N -->
+      <map code="0x4f" name="O"/><!-- LATIN CAPITAL LETTER O -->
+      <map code="0x50" name="P"/><!-- LATIN CAPITAL LETTER P -->
+      <map code="0x51" name="Q"/><!-- LATIN CAPITAL LETTER Q -->
+      <map code="0x52" name="R"/><!-- LATIN CAPITAL LETTER R -->
+      <map code="0x53" name="S"/><!-- LATIN CAPITAL LETTER S -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x55" name="U"/><!-- LATIN CAPITAL LETTER U -->
+      <map code="0x56" name="V"/><!-- LATIN CAPITAL LETTER V -->
+      <map code="0x57" name="W"/><!-- LATIN CAPITAL LETTER W -->
+      <map code="0x58" name="X"/><!-- LATIN CAPITAL LETTER X -->
+      <map code="0x59" name="Y"/><!-- LATIN CAPITAL LETTER Y -->
+      <map code="0x5a" name="Z"/><!-- LATIN CAPITAL LETTER Z -->
+      <map code="0x5b" name="bracketleft"/><!-- LEFT SQUARE BRACKET -->
+      <map code="0x5c" name="backslash"/><!-- REVERSE SOLIDUS -->
+      <map code="0x5d" name="bracketright"/><!-- RIGHT SQUARE BRACKET -->
+      <map code="0x5e" name="asciicircum"/><!-- CIRCUMFLEX ACCENT -->
+      <map code="0x5f" name="underscore"/><!-- LOW LINE -->
+      <map code="0x60" name="grave"/><!-- GRAVE ACCENT -->
+      <map code="0x61" name="a"/><!-- LATIN SMALL LETTER A -->
+      <map code="0x62" name="b"/><!-- LATIN SMALL LETTER B -->
+      <map code="0x63" name="c"/><!-- LATIN SMALL LETTER C -->
+      <map code="0x64" name="d"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="e"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="f"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="g"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="h"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="i"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="j"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="k"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6d" name="m"/><!-- LATIN SMALL LETTER M -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x70" name="p"/><!-- LATIN SMALL LETTER P -->
+      <map code="0x71" name="q"/><!-- LATIN SMALL LETTER Q -->
+      <map code="0x72" name="r"/><!-- LATIN SMALL LETTER R -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+      <map code="0x75" name="u"/><!-- LATIN SMALL LETTER U -->
+      <map code="0x76" name="v"/><!-- LATIN SMALL LETTER V -->
+      <map code="0x77" name="w"/><!-- LATIN SMALL LETTER W -->
+      <map code="0x78" name="x"/><!-- LATIN SMALL LETTER X -->
+      <map code="0x79" name="y"/><!-- LATIN SMALL LETTER Y -->
+      <map code="0x7a" name="z"/><!-- LATIN SMALL LETTER Z -->
+      <map code="0x7b" name="braceleft"/><!-- LEFT CURLY BRACKET -->
+      <map code="0x7c" name="bar"/><!-- VERTICAL LINE -->
+      <map code="0x7d" name="braceright"/><!-- RIGHT CURLY BRACKET -->
+      <map code="0x7e" name="asciitilde"/><!-- TILDE -->
+      <map code="0xa0" name="space"/><!-- NO-BREAK SPACE -->
+      <map code="0xa1" name="exclamdown"/><!-- INVERTED EXCLAMATION MARK -->
+      <map code="0xa2" name="cent"/><!-- CENT SIGN -->
+      <map code="0xa3" name="sterling"/><!-- POUND SIGN -->
+      <map code="0xa4" name="currency"/><!-- CURRENCY SIGN -->
+      <map code="0xa5" name="yen"/><!-- YEN SIGN -->
+      <map code="0xa6" name="brokenbar"/><!-- BROKEN BAR -->
+      <map code="0xa7" name="section"/><!-- SECTION SIGN -->
+      <map code="0xa8" name="dieresis"/><!-- DIAERESIS -->
+      <map code="0xa9" name="copyright"/><!-- COPYRIGHT SIGN -->
+      <map code="0xaa" name="ordfeminine"/><!-- FEMININE ORDINAL INDICATOR -->
+      <map code="0xab" name="guillemotleft"/><!-- LEFT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+      <map code="0xac" name="logicalnot"/><!-- NOT SIGN -->
+      <map code="0xad" name="hyphen"/><!-- SOFT HYPHEN -->
+      <map code="0xae" name="registered"/><!-- REGISTERED SIGN -->
+      <map code="0xaf" name="macron"/><!-- MACRON -->
+      <map code="0xb0" name="degree"/><!-- DEGREE SIGN -->
+      <map code="0xb1" name="plusminus"/><!-- PLUS-MINUS SIGN -->
+      <map code="0xb2" name="uni00B2"/><!-- SUPERSCRIPT TWO -->
+      <map code="0xb3" name="uni00B3"/><!-- SUPERSCRIPT THREE -->
+      <map code="0xb4" name="acute"/><!-- ACUTE ACCENT -->
+      <map code="0xb5" name="mu"/><!-- MICRO SIGN -->
+      <map code="0xb6" name="paragraph"/><!-- PILCROW SIGN -->
+      <map code="0xb7" name="periodcentered"/><!-- MIDDLE DOT -->
+      <map code="0xb8" name="cedilla"/><!-- CEDILLA -->
+      <map code="0xb9" name="uni00B9"/><!-- SUPERSCRIPT ONE -->
+      <map code="0xba" name="ordmasculine"/><!-- MASCULINE ORDINAL INDICATOR -->
+      <map code="0xbb" name="guillemotright"/><!-- RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+      <map code="0xbc" name="onequarter"/><!-- VULGAR FRACTION ONE QUARTER -->
+      <map code="0xbd" name="onehalf"/><!-- VULGAR FRACTION ONE HALF -->
+      <map code="0xbe" name="threequarters"/><!-- VULGAR FRACTION THREE QUARTERS -->
+      <map code="0xbf" name="questiondown"/><!-- INVERTED QUESTION MARK -->
+      <map code="0xc0" name="Agrave"/><!-- LATIN CAPITAL LETTER A WITH GRAVE -->
+      <map code="0xc1" name="Aacute"/><!-- LATIN CAPITAL LETTER A WITH ACUTE -->
+      <map code="0xc2" name="Acircumflex"/><!-- LATIN CAPITAL LETTER A WITH CIRCUMFLEX -->
+      <map code="0xc3" name="Atilde"/><!-- LATIN CAPITAL LETTER A WITH TILDE -->
+      <map code="0xc4" name="Adieresis"/><!-- LATIN CAPITAL LETTER A WITH DIAERESIS -->
+      <map code="0xc5" name="Aring"/><!-- LATIN CAPITAL LETTER A WITH RING ABOVE -->
+      <map code="0xc6" name="AE"/><!-- LATIN CAPITAL LETTER AE -->
+      <map code="0xc7" name="Ccedilla"/><!-- LATIN CAPITAL LETTER C WITH CEDILLA -->
+      <map code="0xc8" name="Egrave"/><!-- LATIN CAPITAL LETTER E WITH GRAVE -->
+      <map code="0xc9" name="Eacute"/><!-- LATIN CAPITAL LETTER E WITH ACUTE -->
+      <map code="0xca" name="Ecircumflex"/><!-- LATIN CAPITAL LETTER E WITH CIRCUMFLEX -->
+      <map code="0xcb" name="Edieresis"/><!-- LATIN CAPITAL LETTER E WITH DIAERESIS -->
+      <map code="0xcc" name="Igrave"/><!-- LATIN CAPITAL LETTER I WITH GRAVE -->
+      <map code="0xcd" name="Iacute"/><!-- LATIN CAPITAL LETTER I WITH ACUTE -->
+      <map code="0xce" name="Icircumflex"/><!-- LATIN CAPITAL LETTER I WITH CIRCUMFLEX -->
+      <map code="0xcf" name="Idieresis"/><!-- LATIN CAPITAL LETTER I WITH DIAERESIS -->
+      <map code="0xd0" name="Eth"/><!-- LATIN CAPITAL LETTER ETH -->
+      <map code="0xd1" name="Ntilde"/><!-- LATIN CAPITAL LETTER N WITH TILDE -->
+      <map code="0xd2" name="Ograve"/><!-- LATIN CAPITAL LETTER O WITH GRAVE -->
+      <map code="0xd3" name="Oacute"/><!-- LATIN CAPITAL LETTER O WITH ACUTE -->
+      <map code="0xd4" name="Ocircumflex"/><!-- LATIN CAPITAL LETTER O WITH CIRCUMFLEX -->
+      <map code="0xd5" name="Otilde"/><!-- LATIN CAPITAL LETTER O WITH TILDE -->
+      <map code="0xd6" name="Odieresis"/><!-- LATIN CAPITAL LETTER O WITH DIAERESIS -->
+      <map code="0xd7" name="multiply"/><!-- MULTIPLICATION SIGN -->
+      <map code="0xd8" name="Oslash"/><!-- LATIN CAPITAL LETTER O WITH STROKE -->
+      <map code="0xd9" name="Ugrave"/><!-- LATIN CAPITAL LETTER U WITH GRAVE -->
+      <map code="0xda" name="Uacute"/><!-- LATIN CAPITAL LETTER U WITH ACUTE -->
+      <map code="0xdb" name="Ucircumflex"/><!-- LATIN CAPITAL LETTER U WITH CIRCUMFLEX -->
+      <map code="0xdc" name="Udieresis"/><!-- LATIN CAPITAL LETTER U WITH DIAERESIS -->
+      <map code="0xdd" name="Yacute"/><!-- LATIN CAPITAL LETTER Y WITH ACUTE -->
+      <map code="0xde" name="Thorn"/><!-- LATIN CAPITAL LETTER THORN -->
+      <map code="0xdf" name="germandbls"/><!-- LATIN SMALL LETTER SHARP S -->
+      <map code="0xe0" name="agrave"/><!-- LATIN SMALL LETTER A WITH GRAVE -->
+      <map code="0xe1" name="aacute"/><!-- LATIN SMALL LETTER A WITH ACUTE -->
+      <map code="0xe2" name="acircumflex"/><!-- LATIN SMALL LETTER A WITH CIRCUMFLEX -->
+      <map code="0xe3" name="atilde"/><!-- LATIN SMALL LETTER A WITH TILDE -->
+      <map code="0xe4" name="adieresis"/><!-- LATIN SMALL LETTER A WITH DIAERESIS -->
+      <map code="0xe5" name="aring"/><!-- LATIN SMALL LETTER A WITH RING ABOVE -->
+      <map code="0xe6" name="ae"/><!-- LATIN SMALL LETTER AE -->
+      <map code="0xe7" name="ccedilla"/><!-- LATIN SMALL LETTER C WITH CEDILLA -->
+      <map code="0xe8" name="egrave"/><!-- LATIN SMALL LETTER E WITH GRAVE -->
+      <map code="0xe9" name="eacute"/><!-- LATIN SMALL LETTER E WITH ACUTE -->
+      <map code="0xea" name="ecircumflex"/><!-- LATIN SMALL LETTER E WITH CIRCUMFLEX -->
+      <map code="0xeb" name="edieresis"/><!-- LATIN SMALL LETTER E WITH DIAERESIS -->
+      <map code="0xec" name="igrave"/><!-- LATIN SMALL LETTER I WITH GRAVE -->
+      <map code="0xed" name="iacute"/><!-- LATIN SMALL LETTER I WITH ACUTE -->
+      <map code="0xee" name="icircumflex"/><!-- LATIN SMALL LETTER I WITH CIRCUMFLEX -->
+      <map code="0xef" name="idieresis"/><!-- LATIN SMALL LETTER I WITH DIAERESIS -->
+      <map code="0xf0" name="eth"/><!-- LATIN SMALL LETTER ETH -->
+      <map code="0xf1" name="ntilde"/><!-- LATIN SMALL LETTER N WITH TILDE -->
+      <map code="0xf2" name="ograve"/><!-- LATIN SMALL LETTER O WITH GRAVE -->
+      <map code="0xf3" name="oacute"/><!-- LATIN SMALL LETTER O WITH ACUTE -->
+      <map code="0xf4" name="ocircumflex"/><!-- LATIN SMALL LETTER O WITH CIRCUMFLEX -->
+      <map code="0xf5" name="otilde"/><!-- LATIN SMALL LETTER O WITH TILDE -->
+      <map code="0xf6" name="odieresis"/><!-- LATIN SMALL LETTER O WITH DIAERESIS -->
+      <map code="0xf7" name="divide"/><!-- DIVISION SIGN -->
+      <map code="0xf8" name="oslash"/><!-- LATIN SMALL LETTER O WITH STROKE -->
+      <map code="0xf9" name="ugrave"/><!-- LATIN SMALL LETTER U WITH GRAVE -->
+      <map code="0xfa" name="uacute"/><!-- LATIN SMALL LETTER U WITH ACUTE -->
+      <map code="0xfb" name="ucircumflex"/><!-- LATIN SMALL LETTER U WITH CIRCUMFLEX -->
+      <map code="0xfc" name="udieresis"/><!-- LATIN SMALL LETTER U WITH DIAERESIS -->
+      <map code="0xfd" name="yacute"/><!-- LATIN SMALL LETTER Y WITH ACUTE -->
+      <map code="0xfe" name="thorn"/><!-- LATIN SMALL LETTER THORN -->
+      <map code="0xff" name="ydieresis"/><!-- LATIN SMALL LETTER Y WITH DIAERESIS -->
+    </cmap_format_12>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x21" name="exclam"/><!-- EXCLAMATION MARK -->
+      <map code="0x22" name="quotedbl"/><!-- QUOTATION MARK -->
+      <map code="0x23" name="numbersign"/><!-- NUMBER SIGN -->
+      <map code="0x24" name="dollar"/><!-- DOLLAR SIGN -->
+      <map code="0x25" name="percent"/><!-- PERCENT SIGN -->
+      <map code="0x26" name="ampersand"/><!-- AMPERSAND -->
+      <map code="0x27" name="quotesingle"/><!-- APOSTROPHE -->
+      <map code="0x28" name="parenleft"/><!-- LEFT PARENTHESIS -->
+      <map code="0x29" name="parenright"/><!-- RIGHT PARENTHESIS -->
+      <map code="0x2a" name="asterisk"/><!-- ASTERISK -->
+      <map code="0x2b" name="plus"/><!-- PLUS SIGN -->
+      <map code="0x2c" name="comma"/><!-- COMMA -->
+      <map code="0x2d" name="hyphen"/><!-- HYPHEN-MINUS -->
+      <map code="0x2e" name="period"/><!-- FULL STOP -->
+      <map code="0x2f" name="slash"/><!-- SOLIDUS -->
+      <map code="0x30" name="zero"/><!-- DIGIT ZERO -->
+      <map code="0x31" name="one"/><!-- DIGIT ONE -->
+      <map code="0x32" name="two"/><!-- DIGIT TWO -->
+      <map code="0x33" name="three"/><!-- DIGIT THREE -->
+      <map code="0x34" name="four"/><!-- DIGIT FOUR -->
+      <map code="0x35" name="five"/><!-- DIGIT FIVE -->
+      <map code="0x36" name="six"/><!-- DIGIT SIX -->
+      <map code="0x37" name="seven"/><!-- DIGIT SEVEN -->
+      <map code="0x38" name="eight"/><!-- DIGIT EIGHT -->
+      <map code="0x39" name="nine"/><!-- DIGIT NINE -->
+      <map code="0x3a" name="colon"/><!-- COLON -->
+      <map code="0x3b" name="semicolon"/><!-- SEMICOLON -->
+      <map code="0x3c" name="less"/><!-- LESS-THAN SIGN -->
+      <map code="0x3d" name="equal"/><!-- EQUALS SIGN -->
+      <map code="0x3e" name="greater"/><!-- GREATER-THAN SIGN -->
+      <map code="0x3f" name="question"/><!-- QUESTION MARK -->
+      <map code="0x40" name="at"/><!-- COMMERCIAL AT -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x44" name="D"/><!-- LATIN CAPITAL LETTER D -->
+      <map code="0x45" name="E"/><!-- LATIN CAPITAL LETTER E -->
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x47" name="G"/><!-- LATIN CAPITAL LETTER G -->
+      <map code="0x48" name="H"/><!-- LATIN CAPITAL LETTER H -->
+      <map code="0x49" name="I"/><!-- LATIN CAPITAL LETTER I -->
+      <map code="0x4a" name="J"/><!-- LATIN CAPITAL LETTER J -->
+      <map code="0x4b" name="K"/><!-- LATIN CAPITAL LETTER K -->
+      <map code="0x4c" name="L"/><!-- LATIN CAPITAL LETTER L -->
+      <map code="0x4d" name="M"/><!-- LATIN CAPITAL LETTER M -->
+      <map code="0x4e" name="N"/><!-- LATIN CAPITAL LETTER N -->
+      <map code="0x4f" name="O"/><!-- LATIN CAPITAL LETTER O -->
+      <map code="0x50" name="P"/><!-- LATIN CAPITAL LETTER P -->
+      <map code="0x51" name="Q"/><!-- LATIN CAPITAL LETTER Q -->
+      <map code="0x52" name="R"/><!-- LATIN CAPITAL LETTER R -->
+      <map code="0x53" name="S"/><!-- LATIN CAPITAL LETTER S -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x55" name="U"/><!-- LATIN CAPITAL LETTER U -->
+      <map code="0x56" name="V"/><!-- LATIN CAPITAL LETTER V -->
+      <map code="0x57" name="W"/><!-- LATIN CAPITAL LETTER W -->
+      <map code="0x58" name="X"/><!-- LATIN CAPITAL LETTER X -->
+      <map code="0x59" name="Y"/><!-- LATIN CAPITAL LETTER Y -->
+      <map code="0x5a" name="Z"/><!-- LATIN CAPITAL LETTER Z -->
+      <map code="0x5b" name="bracketleft"/><!-- LEFT SQUARE BRACKET -->
+      <map code="0x5c" name="backslash"/><!-- REVERSE SOLIDUS -->
+      <map code="0x5d" name="bracketright"/><!-- RIGHT SQUARE BRACKET -->
+      <map code="0x5e" name="asciicircum"/><!-- CIRCUMFLEX ACCENT -->
+      <map code="0x5f" name="underscore"/><!-- LOW LINE -->
+      <map code="0x60" name="grave"/><!-- GRAVE ACCENT -->
+      <map code="0x61" name="a"/><!-- LATIN SMALL LETTER A -->
+      <map code="0x62" name="b"/><!-- LATIN SMALL LETTER B -->
+      <map code="0x63" name="c"/><!-- LATIN SMALL LETTER C -->
+      <map code="0x64" name="d"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="e"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="f"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="g"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="h"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="i"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="j"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="k"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6d" name="m"/><!-- LATIN SMALL LETTER M -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x70" name="p"/><!-- LATIN SMALL LETTER P -->
+      <map code="0x71" name="q"/><!-- LATIN SMALL LETTER Q -->
+      <map code="0x72" name="r"/><!-- LATIN SMALL LETTER R -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+      <map code="0x75" name="u"/><!-- LATIN SMALL LETTER U -->
+      <map code="0x76" name="v"/><!-- LATIN SMALL LETTER V -->
+      <map code="0x77" name="w"/><!-- LATIN SMALL LETTER W -->
+      <map code="0x78" name="x"/><!-- LATIN SMALL LETTER X -->
+      <map code="0x79" name="y"/><!-- LATIN SMALL LETTER Y -->
+      <map code="0x7a" name="z"/><!-- LATIN SMALL LETTER Z -->
+      <map code="0x7b" name="braceleft"/><!-- LEFT CURLY BRACKET -->
+      <map code="0x7c" name="bar"/><!-- VERTICAL LINE -->
+      <map code="0x7d" name="braceright"/><!-- RIGHT CURLY BRACKET -->
+      <map code="0x7e" name="asciitilde"/><!-- TILDE -->
+      <map code="0xa0" name="space"/><!-- NO-BREAK SPACE -->
+      <map code="0xa1" name="exclamdown"/><!-- INVERTED EXCLAMATION MARK -->
+      <map code="0xa2" name="cent"/><!-- CENT SIGN -->
+      <map code="0xa3" name="sterling"/><!-- POUND SIGN -->
+      <map code="0xa4" name="currency"/><!-- CURRENCY SIGN -->
+      <map code="0xa5" name="yen"/><!-- YEN SIGN -->
+      <map code="0xa6" name="brokenbar"/><!-- BROKEN BAR -->
+      <map code="0xa7" name="section"/><!-- SECTION SIGN -->
+      <map code="0xa8" name="dieresis"/><!-- DIAERESIS -->
+      <map code="0xa9" name="copyright"/><!-- COPYRIGHT SIGN -->
+      <map code="0xaa" name="ordfeminine"/><!-- FEMININE ORDINAL INDICATOR -->
+      <map code="0xab" name="guillemotleft"/><!-- LEFT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+      <map code="0xac" name="logicalnot"/><!-- NOT SIGN -->
+      <map code="0xad" name="hyphen"/><!-- SOFT HYPHEN -->
+      <map code="0xae" name="registered"/><!-- REGISTERED SIGN -->
+      <map code="0xaf" name="macron"/><!-- MACRON -->
+      <map code="0xb0" name="degree"/><!-- DEGREE SIGN -->
+      <map code="0xb1" name="plusminus"/><!-- PLUS-MINUS SIGN -->
+      <map code="0xb2" name="uni00B2"/><!-- SUPERSCRIPT TWO -->
+      <map code="0xb3" name="uni00B3"/><!-- SUPERSCRIPT THREE -->
+      <map code="0xb4" name="acute"/><!-- ACUTE ACCENT -->
+      <map code="0xb5" name="mu"/><!-- MICRO SIGN -->
+      <map code="0xb6" name="paragraph"/><!-- PILCROW SIGN -->
+      <map code="0xb7" name="periodcentered"/><!-- MIDDLE DOT -->
+      <map code="0xb8" name="cedilla"/><!-- CEDILLA -->
+      <map code="0xb9" name="uni00B9"/><!-- SUPERSCRIPT ONE -->
+      <map code="0xba" name="ordmasculine"/><!-- MASCULINE ORDINAL INDICATOR -->
+      <map code="0xbb" name="guillemotright"/><!-- RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+      <map code="0xbc" name="onequarter"/><!-- VULGAR FRACTION ONE QUARTER -->
+      <map code="0xbd" name="onehalf"/><!-- VULGAR FRACTION ONE HALF -->
+      <map code="0xbe" name="threequarters"/><!-- VULGAR FRACTION THREE QUARTERS -->
+      <map code="0xbf" name="questiondown"/><!-- INVERTED QUESTION MARK -->
+      <map code="0xc0" name="Agrave"/><!-- LATIN CAPITAL LETTER A WITH GRAVE -->
+      <map code="0xc1" name="Aacute"/><!-- LATIN CAPITAL LETTER A WITH ACUTE -->
+      <map code="0xc2" name="Acircumflex"/><!-- LATIN CAPITAL LETTER A WITH CIRCUMFLEX -->
+      <map code="0xc3" name="Atilde"/><!-- LATIN CAPITAL LETTER A WITH TILDE -->
+      <map code="0xc4" name="Adieresis"/><!-- LATIN CAPITAL LETTER A WITH DIAERESIS -->
+      <map code="0xc5" name="Aring"/><!-- LATIN CAPITAL LETTER A WITH RING ABOVE -->
+      <map code="0xc6" name="AE"/><!-- LATIN CAPITAL LETTER AE -->
+      <map code="0xc7" name="Ccedilla"/><!-- LATIN CAPITAL LETTER C WITH CEDILLA -->
+      <map code="0xc8" name="Egrave"/><!-- LATIN CAPITAL LETTER E WITH GRAVE -->
+      <map code="0xc9" name="Eacute"/><!-- LATIN CAPITAL LETTER E WITH ACUTE -->
+      <map code="0xca" name="Ecircumflex"/><!-- LATIN CAPITAL LETTER E WITH CIRCUMFLEX -->
+      <map code="0xcb" name="Edieresis"/><!-- LATIN CAPITAL LETTER E WITH DIAERESIS -->
+      <map code="0xcc" name="Igrave"/><!-- LATIN CAPITAL LETTER I WITH GRAVE -->
+      <map code="0xcd" name="Iacute"/><!-- LATIN CAPITAL LETTER I WITH ACUTE -->
+      <map code="0xce" name="Icircumflex"/><!-- LATIN CAPITAL LETTER I WITH CIRCUMFLEX -->
+      <map code="0xcf" name="Idieresis"/><!-- LATIN CAPITAL LETTER I WITH DIAERESIS -->
+      <map code="0xd0" name="Eth"/><!-- LATIN CAPITAL LETTER ETH -->
+      <map code="0xd1" name="Ntilde"/><!-- LATIN CAPITAL LETTER N WITH TILDE -->
+      <map code="0xd2" name="Ograve"/><!-- LATIN CAPITAL LETTER O WITH GRAVE -->
+      <map code="0xd3" name="Oacute"/><!-- LATIN CAPITAL LETTER O WITH ACUTE -->
+      <map code="0xd4" name="Ocircumflex"/><!-- LATIN CAPITAL LETTER O WITH CIRCUMFLEX -->
+      <map code="0xd5" name="Otilde"/><!-- LATIN CAPITAL LETTER O WITH TILDE -->
+      <map code="0xd6" name="Odieresis"/><!-- LATIN CAPITAL LETTER O WITH DIAERESIS -->
+      <map code="0xd7" name="multiply"/><!-- MULTIPLICATION SIGN -->
+      <map code="0xd8" name="Oslash"/><!-- LATIN CAPITAL LETTER O WITH STROKE -->
+      <map code="0xd9" name="Ugrave"/><!-- LATIN CAPITAL LETTER U WITH GRAVE -->
+      <map code="0xda" name="Uacute"/><!-- LATIN CAPITAL LETTER U WITH ACUTE -->
+      <map code="0xdb" name="Ucircumflex"/><!-- LATIN CAPITAL LETTER U WITH CIRCUMFLEX -->
+      <map code="0xdc" name="Udieresis"/><!-- LATIN CAPITAL LETTER U WITH DIAERESIS -->
+      <map code="0xdd" name="Yacute"/><!-- LATIN CAPITAL LETTER Y WITH ACUTE -->
+      <map code="0xde" name="Thorn"/><!-- LATIN CAPITAL LETTER THORN -->
+      <map code="0xdf" name="germandbls"/><!-- LATIN SMALL LETTER SHARP S -->
+      <map code="0xe0" name="agrave"/><!-- LATIN SMALL LETTER A WITH GRAVE -->
+      <map code="0xe1" name="aacute"/><!-- LATIN SMALL LETTER A WITH ACUTE -->
+      <map code="0xe2" name="acircumflex"/><!-- LATIN SMALL LETTER A WITH CIRCUMFLEX -->
+      <map code="0xe3" name="atilde"/><!-- LATIN SMALL LETTER A WITH TILDE -->
+      <map code="0xe4" name="adieresis"/><!-- LATIN SMALL LETTER A WITH DIAERESIS -->
+      <map code="0xe5" name="aring"/><!-- LATIN SMALL LETTER A WITH RING ABOVE -->
+      <map code="0xe6" name="ae"/><!-- LATIN SMALL LETTER AE -->
+      <map code="0xe7" name="ccedilla"/><!-- LATIN SMALL LETTER C WITH CEDILLA -->
+      <map code="0xe8" name="egrave"/><!-- LATIN SMALL LETTER E WITH GRAVE -->
+      <map code="0xe9" name="eacute"/><!-- LATIN SMALL LETTER E WITH ACUTE -->
+      <map code="0xea" name="ecircumflex"/><!-- LATIN SMALL LETTER E WITH CIRCUMFLEX -->
+      <map code="0xeb" name="edieresis"/><!-- LATIN SMALL LETTER E WITH DIAERESIS -->
+      <map code="0xec" name="igrave"/><!-- LATIN SMALL LETTER I WITH GRAVE -->
+      <map code="0xed" name="iacute"/><!-- LATIN SMALL LETTER I WITH ACUTE -->
+      <map code="0xee" name="icircumflex"/><!-- LATIN SMALL LETTER I WITH CIRCUMFLEX -->
+      <map code="0xef" name="idieresis"/><!-- LATIN SMALL LETTER I WITH DIAERESIS -->
+      <map code="0xf0" name="eth"/><!-- LATIN SMALL LETTER ETH -->
+      <map code="0xf1" name="ntilde"/><!-- LATIN SMALL LETTER N WITH TILDE -->
+      <map code="0xf2" name="ograve"/><!-- LATIN SMALL LETTER O WITH GRAVE -->
+      <map code="0xf3" name="oacute"/><!-- LATIN SMALL LETTER O WITH ACUTE -->
+      <map code="0xf4" name="ocircumflex"/><!-- LATIN SMALL LETTER O WITH CIRCUMFLEX -->
+      <map code="0xf5" name="otilde"/><!-- LATIN SMALL LETTER O WITH TILDE -->
+      <map code="0xf6" name="odieresis"/><!-- LATIN SMALL LETTER O WITH DIAERESIS -->
+      <map code="0xf7" name="divide"/><!-- DIVISION SIGN -->
+      <map code="0xf8" name="oslash"/><!-- LATIN SMALL LETTER O WITH STROKE -->
+      <map code="0xf9" name="ugrave"/><!-- LATIN SMALL LETTER U WITH GRAVE -->
+      <map code="0xfa" name="uacute"/><!-- LATIN SMALL LETTER U WITH ACUTE -->
+      <map code="0xfb" name="ucircumflex"/><!-- LATIN SMALL LETTER U WITH CIRCUMFLEX -->
+      <map code="0xfc" name="udieresis"/><!-- LATIN SMALL LETTER U WITH DIAERESIS -->
+      <map code="0xfd" name="yacute"/><!-- LATIN SMALL LETTER Y WITH ACUTE -->
+      <map code="0xfe" name="thorn"/><!-- LATIN SMALL LETTER THORN -->
+      <map code="0xff" name="ydieresis"/><!-- LATIN SMALL LETTER Y WITH DIAERESIS -->
+    </cmap_format_4>
+    <cmap_format_12 platformID="3" platEncID="10" format="12" reserved="0" length="952" language="0" nGroups="78">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x21" name="exclam"/><!-- EXCLAMATION MARK -->
+      <map code="0x22" name="quotedbl"/><!-- QUOTATION MARK -->
+      <map code="0x23" name="numbersign"/><!-- NUMBER SIGN -->
+      <map code="0x24" name="dollar"/><!-- DOLLAR SIGN -->
+      <map code="0x25" name="percent"/><!-- PERCENT SIGN -->
+      <map code="0x26" name="ampersand"/><!-- AMPERSAND -->
+      <map code="0x27" name="quotesingle"/><!-- APOSTROPHE -->
+      <map code="0x28" name="parenleft"/><!-- LEFT PARENTHESIS -->
+      <map code="0x29" name="parenright"/><!-- RIGHT PARENTHESIS -->
+      <map code="0x2a" name="asterisk"/><!-- ASTERISK -->
+      <map code="0x2b" name="plus"/><!-- PLUS SIGN -->
+      <map code="0x2c" name="comma"/><!-- COMMA -->
+      <map code="0x2d" name="hyphen"/><!-- HYPHEN-MINUS -->
+      <map code="0x2e" name="period"/><!-- FULL STOP -->
+      <map code="0x2f" name="slash"/><!-- SOLIDUS -->
+      <map code="0x30" name="zero"/><!-- DIGIT ZERO -->
+      <map code="0x31" name="one"/><!-- DIGIT ONE -->
+      <map code="0x32" name="two"/><!-- DIGIT TWO -->
+      <map code="0x33" name="three"/><!-- DIGIT THREE -->
+      <map code="0x34" name="four"/><!-- DIGIT FOUR -->
+      <map code="0x35" name="five"/><!-- DIGIT FIVE -->
+      <map code="0x36" name="six"/><!-- DIGIT SIX -->
+      <map code="0x37" name="seven"/><!-- DIGIT SEVEN -->
+      <map code="0x38" name="eight"/><!-- DIGIT EIGHT -->
+      <map code="0x39" name="nine"/><!-- DIGIT NINE -->
+      <map code="0x3a" name="colon"/><!-- COLON -->
+      <map code="0x3b" name="semicolon"/><!-- SEMICOLON -->
+      <map code="0x3c" name="less"/><!-- LESS-THAN SIGN -->
+      <map code="0x3d" name="equal"/><!-- EQUALS SIGN -->
+      <map code="0x3e" name="greater"/><!-- GREATER-THAN SIGN -->
+      <map code="0x3f" name="question"/><!-- QUESTION MARK -->
+      <map code="0x40" name="at"/><!-- COMMERCIAL AT -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x44" name="D"/><!-- LATIN CAPITAL LETTER D -->
+      <map code="0x45" name="E"/><!-- LATIN CAPITAL LETTER E -->
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x47" name="G"/><!-- LATIN CAPITAL LETTER G -->
+      <map code="0x48" name="H"/><!-- LATIN CAPITAL LETTER H -->
+      <map code="0x49" name="I"/><!-- LATIN CAPITAL LETTER I -->
+      <map code="0x4a" name="J"/><!-- LATIN CAPITAL LETTER J -->
+      <map code="0x4b" name="K"/><!-- LATIN CAPITAL LETTER K -->
+      <map code="0x4c" name="L"/><!-- LATIN CAPITAL LETTER L -->
+      <map code="0x4d" name="M"/><!-- LATIN CAPITAL LETTER M -->
+      <map code="0x4e" name="N"/><!-- LATIN CAPITAL LETTER N -->
+      <map code="0x4f" name="O"/><!-- LATIN CAPITAL LETTER O -->
+      <map code="0x50" name="P"/><!-- LATIN CAPITAL LETTER P -->
+      <map code="0x51" name="Q"/><!-- LATIN CAPITAL LETTER Q -->
+      <map code="0x52" name="R"/><!-- LATIN CAPITAL LETTER R -->
+      <map code="0x53" name="S"/><!-- LATIN CAPITAL LETTER S -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x55" name="U"/><!-- LATIN CAPITAL LETTER U -->
+      <map code="0x56" name="V"/><!-- LATIN CAPITAL LETTER V -->
+      <map code="0x57" name="W"/><!-- LATIN CAPITAL LETTER W -->
+      <map code="0x58" name="X"/><!-- LATIN CAPITAL LETTER X -->
+      <map code="0x59" name="Y"/><!-- LATIN CAPITAL LETTER Y -->
+      <map code="0x5a" name="Z"/><!-- LATIN CAPITAL LETTER Z -->
+      <map code="0x5b" name="bracketleft"/><!-- LEFT SQUARE BRACKET -->
+      <map code="0x5c" name="backslash"/><!-- REVERSE SOLIDUS -->
+      <map code="0x5d" name="bracketright"/><!-- RIGHT SQUARE BRACKET -->
+      <map code="0x5e" name="asciicircum"/><!-- CIRCUMFLEX ACCENT -->
+      <map code="0x5f" name="underscore"/><!-- LOW LINE -->
+      <map code="0x60" name="grave"/><!-- GRAVE ACCENT -->
+      <map code="0x61" name="a"/><!-- LATIN SMALL LETTER A -->
+      <map code="0x62" name="b"/><!-- LATIN SMALL LETTER B -->
+      <map code="0x63" name="c"/><!-- LATIN SMALL LETTER C -->
+      <map code="0x64" name="d"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="e"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="f"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="g"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="h"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="i"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="j"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="k"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6d" name="m"/><!-- LATIN SMALL LETTER M -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x70" name="p"/><!-- LATIN SMALL LETTER P -->
+      <map code="0x71" name="q"/><!-- LATIN SMALL LETTER Q -->
+      <map code="0x72" name="r"/><!-- LATIN SMALL LETTER R -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+      <map code="0x75" name="u"/><!-- LATIN SMALL LETTER U -->
+      <map code="0x76" name="v"/><!-- LATIN SMALL LETTER V -->
+      <map code="0x77" name="w"/><!-- LATIN SMALL LETTER W -->
+      <map code="0x78" name="x"/><!-- LATIN SMALL LETTER X -->
+      <map code="0x79" name="y"/><!-- LATIN SMALL LETTER Y -->
+      <map code="0x7a" name="z"/><!-- LATIN SMALL LETTER Z -->
+      <map code="0x7b" name="braceleft"/><!-- LEFT CURLY BRACKET -->
+      <map code="0x7c" name="bar"/><!-- VERTICAL LINE -->
+      <map code="0x7d" name="braceright"/><!-- RIGHT CURLY BRACKET -->
+      <map code="0x7e" name="asciitilde"/><!-- TILDE -->
+      <map code="0xa0" name="space"/><!-- NO-BREAK SPACE -->
+      <map code="0xa1" name="exclamdown"/><!-- INVERTED EXCLAMATION MARK -->
+      <map code="0xa2" name="cent"/><!-- CENT SIGN -->
+      <map code="0xa3" name="sterling"/><!-- POUND SIGN -->
+      <map code="0xa4" name="currency"/><!-- CURRENCY SIGN -->
+      <map code="0xa5" name="yen"/><!-- YEN SIGN -->
+      <map code="0xa6" name="brokenbar"/><!-- BROKEN BAR -->
+      <map code="0xa7" name="section"/><!-- SECTION SIGN -->
+      <map code="0xa8" name="dieresis"/><!-- DIAERESIS -->
+      <map code="0xa9" name="copyright"/><!-- COPYRIGHT SIGN -->
+      <map code="0xaa" name="ordfeminine"/><!-- FEMININE ORDINAL INDICATOR -->
+      <map code="0xab" name="guillemotleft"/><!-- LEFT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+      <map code="0xac" name="logicalnot"/><!-- NOT SIGN -->
+      <map code="0xad" name="hyphen"/><!-- SOFT HYPHEN -->
+      <map code="0xae" name="registered"/><!-- REGISTERED SIGN -->
+      <map code="0xaf" name="macron"/><!-- MACRON -->
+      <map code="0xb0" name="degree"/><!-- DEGREE SIGN -->
+      <map code="0xb1" name="plusminus"/><!-- PLUS-MINUS SIGN -->
+      <map code="0xb2" name="uni00B2"/><!-- SUPERSCRIPT TWO -->
+      <map code="0xb3" name="uni00B3"/><!-- SUPERSCRIPT THREE -->
+      <map code="0xb4" name="acute"/><!-- ACUTE ACCENT -->
+      <map code="0xb5" name="mu"/><!-- MICRO SIGN -->
+      <map code="0xb6" name="paragraph"/><!-- PILCROW SIGN -->
+      <map code="0xb7" name="periodcentered"/><!-- MIDDLE DOT -->
+      <map code="0xb8" name="cedilla"/><!-- CEDILLA -->
+      <map code="0xb9" name="uni00B9"/><!-- SUPERSCRIPT ONE -->
+      <map code="0xba" name="ordmasculine"/><!-- MASCULINE ORDINAL INDICATOR -->
+      <map code="0xbb" name="guillemotright"/><!-- RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+      <map code="0xbc" name="onequarter"/><!-- VULGAR FRACTION ONE QUARTER -->
+      <map code="0xbd" name="onehalf"/><!-- VULGAR FRACTION ONE HALF -->
+      <map code="0xbe" name="threequarters"/><!-- VULGAR FRACTION THREE QUARTERS -->
+      <map code="0xbf" name="questiondown"/><!-- INVERTED QUESTION MARK -->
+      <map code="0xc0" name="Agrave"/><!-- LATIN CAPITAL LETTER A WITH GRAVE -->
+      <map code="0xc1" name="Aacute"/><!-- LATIN CAPITAL LETTER A WITH ACUTE -->
+      <map code="0xc2" name="Acircumflex"/><!-- LATIN CAPITAL LETTER A WITH CIRCUMFLEX -->
+      <map code="0xc3" name="Atilde"/><!-- LATIN CAPITAL LETTER A WITH TILDE -->
+      <map code="0xc4" name="Adieresis"/><!-- LATIN CAPITAL LETTER A WITH DIAERESIS -->
+      <map code="0xc5" name="Aring"/><!-- LATIN CAPITAL LETTER A WITH RING ABOVE -->
+      <map code="0xc6" name="AE"/><!-- LATIN CAPITAL LETTER AE -->
+      <map code="0xc7" name="Ccedilla"/><!-- LATIN CAPITAL LETTER C WITH CEDILLA -->
+      <map code="0xc8" name="Egrave"/><!-- LATIN CAPITAL LETTER E WITH GRAVE -->
+      <map code="0xc9" name="Eacute"/><!-- LATIN CAPITAL LETTER E WITH ACUTE -->
+      <map code="0xca" name="Ecircumflex"/><!-- LATIN CAPITAL LETTER E WITH CIRCUMFLEX -->
+      <map code="0xcb" name="Edieresis"/><!-- LATIN CAPITAL LETTER E WITH DIAERESIS -->
+      <map code="0xcc" name="Igrave"/><!-- LATIN CAPITAL LETTER I WITH GRAVE -->
+      <map code="0xcd" name="Iacute"/><!-- LATIN CAPITAL LETTER I WITH ACUTE -->
+      <map code="0xce" name="Icircumflex"/><!-- LATIN CAPITAL LETTER I WITH CIRCUMFLEX -->
+      <map code="0xcf" name="Idieresis"/><!-- LATIN CAPITAL LETTER I WITH DIAERESIS -->
+      <map code="0xd0" name="Eth"/><!-- LATIN CAPITAL LETTER ETH -->
+      <map code="0xd1" name="Ntilde"/><!-- LATIN CAPITAL LETTER N WITH TILDE -->
+      <map code="0xd2" name="Ograve"/><!-- LATIN CAPITAL LETTER O WITH GRAVE -->
+      <map code="0xd3" name="Oacute"/><!-- LATIN CAPITAL LETTER O WITH ACUTE -->
+      <map code="0xd4" name="Ocircumflex"/><!-- LATIN CAPITAL LETTER O WITH CIRCUMFLEX -->
+      <map code="0xd5" name="Otilde"/><!-- LATIN CAPITAL LETTER O WITH TILDE -->
+      <map code="0xd6" name="Odieresis"/><!-- LATIN CAPITAL LETTER O WITH DIAERESIS -->
+      <map code="0xd7" name="multiply"/><!-- MULTIPLICATION SIGN -->
+      <map code="0xd8" name="Oslash"/><!-- LATIN CAPITAL LETTER O WITH STROKE -->
+      <map code="0xd9" name="Ugrave"/><!-- LATIN CAPITAL LETTER U WITH GRAVE -->
+      <map code="0xda" name="Uacute"/><!-- LATIN CAPITAL LETTER U WITH ACUTE -->
+      <map code="0xdb" name="Ucircumflex"/><!-- LATIN CAPITAL LETTER U WITH CIRCUMFLEX -->
+      <map code="0xdc" name="Udieresis"/><!-- LATIN CAPITAL LETTER U WITH DIAERESIS -->
+      <map code="0xdd" name="Yacute"/><!-- LATIN CAPITAL LETTER Y WITH ACUTE -->
+      <map code="0xde" name="Thorn"/><!-- LATIN CAPITAL LETTER THORN -->
+      <map code="0xdf" name="germandbls"/><!-- LATIN SMALL LETTER SHARP S -->
+      <map code="0xe0" name="agrave"/><!-- LATIN SMALL LETTER A WITH GRAVE -->
+      <map code="0xe1" name="aacute"/><!-- LATIN SMALL LETTER A WITH ACUTE -->
+      <map code="0xe2" name="acircumflex"/><!-- LATIN SMALL LETTER A WITH CIRCUMFLEX -->
+      <map code="0xe3" name="atilde"/><!-- LATIN SMALL LETTER A WITH TILDE -->
+      <map code="0xe4" name="adieresis"/><!-- LATIN SMALL LETTER A WITH DIAERESIS -->
+      <map code="0xe5" name="aring"/><!-- LATIN SMALL LETTER A WITH RING ABOVE -->
+      <map code="0xe6" name="ae"/><!-- LATIN SMALL LETTER AE -->
+      <map code="0xe7" name="ccedilla"/><!-- LATIN SMALL LETTER C WITH CEDILLA -->
+      <map code="0xe8" name="egrave"/><!-- LATIN SMALL LETTER E WITH GRAVE -->
+      <map code="0xe9" name="eacute"/><!-- LATIN SMALL LETTER E WITH ACUTE -->
+      <map code="0xea" name="ecircumflex"/><!-- LATIN SMALL LETTER E WITH CIRCUMFLEX -->
+      <map code="0xeb" name="edieresis"/><!-- LATIN SMALL LETTER E WITH DIAERESIS -->
+      <map code="0xec" name="igrave"/><!-- LATIN SMALL LETTER I WITH GRAVE -->
+      <map code="0xed" name="iacute"/><!-- LATIN SMALL LETTER I WITH ACUTE -->
+      <map code="0xee" name="icircumflex"/><!-- LATIN SMALL LETTER I WITH CIRCUMFLEX -->
+      <map code="0xef" name="idieresis"/><!-- LATIN SMALL LETTER I WITH DIAERESIS -->
+      <map code="0xf0" name="eth"/><!-- LATIN SMALL LETTER ETH -->
+      <map code="0xf1" name="ntilde"/><!-- LATIN SMALL LETTER N WITH TILDE -->
+      <map code="0xf2" name="ograve"/><!-- LATIN SMALL LETTER O WITH GRAVE -->
+      <map code="0xf3" name="oacute"/><!-- LATIN SMALL LETTER O WITH ACUTE -->
+      <map code="0xf4" name="ocircumflex"/><!-- LATIN SMALL LETTER O WITH CIRCUMFLEX -->
+      <map code="0xf5" name="otilde"/><!-- LATIN SMALL LETTER O WITH TILDE -->
+      <map code="0xf6" name="odieresis"/><!-- LATIN SMALL LETTER O WITH DIAERESIS -->
+      <map code="0xf7" name="divide"/><!-- DIVISION SIGN -->
+      <map code="0xf8" name="oslash"/><!-- LATIN SMALL LETTER O WITH STROKE -->
+      <map code="0xf9" name="ugrave"/><!-- LATIN SMALL LETTER U WITH GRAVE -->
+      <map code="0xfa" name="uacute"/><!-- LATIN SMALL LETTER U WITH ACUTE -->
+      <map code="0xfb" name="ucircumflex"/><!-- LATIN SMALL LETTER U WITH CIRCUMFLEX -->
+      <map code="0xfc" name="udieresis"/><!-- LATIN SMALL LETTER U WITH DIAERESIS -->
+      <map code="0xfd" name="yacute"/><!-- LATIN SMALL LETTER Y WITH ACUTE -->
+      <map code="0xfe" name="thorn"/><!-- LATIN SMALL LETTER THORN -->
+      <map code="0xff" name="ydieresis"/><!-- LATIN SMALL LETTER Y WITH DIAERESIS -->
+    </cmap_format_12>
+  </cmap>
+
+  <name>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      © 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/), with Reserved Font Name ‘Source’.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Source Sans Variable
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      3.006;ADBO;SourceSansVariable-Roman;ADOBE
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Source Sans Variable
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      SourceSansVariable-Roman
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Source is a trademark of Adobe Systems Incorporated in the United States and/or other countries.
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Adobe Systems Incorporated
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Paul D. Hunt
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://www.adobe.com/type
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: http://scripts.sil.org/OFL. This Font Software is distributed on an ‘AS IS’ BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://scripts.sil.org/OFL
+    </namerecord>
+    <namerecord nameID="285" platformID="3" platEncID="1" langID="0x409">
+      Roman
+    </namerecord>
+    <namerecord nameID="286" platformID="3" platEncID="1" langID="0x409">
+      Italic
+    </namerecord>
+    <namerecord nameID="287" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+    <namerecord nameID="288" platformID="3" platEncID="1" langID="0x409">
+      ExtraLight
+    </namerecord>
+    <namerecord nameID="289" platformID="3" platEncID="1" langID="0x409">
+      SourceSansRoman-ExtraLight
+    </namerecord>
+    <namerecord nameID="290" platformID="3" platEncID="1" langID="0x409">
+      Light
+    </namerecord>
+    <namerecord nameID="291" platformID="3" platEncID="1" langID="0x409">
+      SourceSansRoman-Light
+    </namerecord>
+    <namerecord nameID="292" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="293" platformID="3" platEncID="1" langID="0x409">
+      SourceSansRoman-Regular
+    </namerecord>
+    <namerecord nameID="294" platformID="3" platEncID="1" langID="0x409">
+      Semibold
+    </namerecord>
+    <namerecord nameID="295" platformID="3" platEncID="1" langID="0x409">
+      SourceSansRoman-Semibold
+    </namerecord>
+    <namerecord nameID="296" platformID="3" platEncID="1" langID="0x409">
+      Bold
+    </namerecord>
+    <namerecord nameID="297" platformID="3" platEncID="1" langID="0x409">
+      SourceSansRoman-Bold
+    </namerecord>
+    <namerecord nameID="298" platformID="3" platEncID="1" langID="0x409">
+      Black
+    </namerecord>
+    <namerecord nameID="299" platformID="3" platEncID="1" langID="0x409">
+      SourceSansRoman-Black
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="3.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-50"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+  </post>
+
+  <BASE>
+    <Version value="0x00010000"/>
+    <HorizAxis>
+      <BaseTagList>
+        <!-- BaseTagCount=2 -->
+        <BaselineTag index="0" value="ideo"/>
+        <BaselineTag index="1" value="romn"/>
+      </BaseTagList>
+      <BaseScriptList>
+        <!-- BaseScriptCount=4 -->
+        <BaseScriptRecord index="0">
+          <BaseScriptTag value="DFLT"/>
+          <BaseScript>
+            <BaseValues>
+              <DefaultIndex value="1"/>
+              <!-- BaseCoordCount=2 -->
+              <BaseCoord index="0" Format="1">
+                <Coordinate value="-170"/>
+              </BaseCoord>
+              <BaseCoord index="1" Format="1">
+                <Coordinate value="0"/>
+              </BaseCoord>
+            </BaseValues>
+            <!-- BaseLangSysCount=0 -->
+          </BaseScript>
+        </BaseScriptRecord>
+        <BaseScriptRecord index="1">
+          <BaseScriptTag value="cyrl"/>
+          <BaseScript>
+            <BaseValues>
+              <DefaultIndex value="1"/>
+              <!-- BaseCoordCount=2 -->
+              <BaseCoord index="0" Format="1">
+                <Coordinate value="-170"/>
+              </BaseCoord>
+              <BaseCoord index="1" Format="1">
+                <Coordinate value="0"/>
+              </BaseCoord>
+            </BaseValues>
+            <!-- BaseLangSysCount=0 -->
+          </BaseScript>
+        </BaseScriptRecord>
+        <BaseScriptRecord index="2">
+          <BaseScriptTag value="grek"/>
+          <BaseScript>
+            <BaseValues>
+              <DefaultIndex value="1"/>
+              <!-- BaseCoordCount=2 -->
+              <BaseCoord index="0" Format="1">
+                <Coordinate value="-170"/>
+              </BaseCoord>
+              <BaseCoord index="1" Format="1">
+                <Coordinate value="0"/>
+              </BaseCoord>
+            </BaseValues>
+            <!-- BaseLangSysCount=0 -->
+          </BaseScript>
+        </BaseScriptRecord>
+        <BaseScriptRecord index="3">
+          <BaseScriptTag value="latn"/>
+          <BaseScript>
+            <BaseValues>
+              <DefaultIndex value="1"/>
+              <!-- BaseCoordCount=2 -->
+              <BaseCoord index="0" Format="1">
+                <Coordinate value="-170"/>
+              </BaseCoord>
+              <BaseCoord index="1" Format="1">
+                <Coordinate value="0"/>
+              </BaseCoord>
+            </BaseValues>
+            <!-- BaseLangSysCount=0 -->
+          </BaseScript>
+        </BaseScriptRecord>
+      </BaseScriptList>
+    </HorizAxis>
+  </BASE>
+
+  <CFF2>
+    <major value="2"/>
+    <minor value="0"/>
+    <CFFFont name="CFF2Font">
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FDArray>
+        <FontDict index="0">
+          <Private>
+            <BlueScale value="0.039625"/>
+            <BlueShift value="7"/>
+            <BlueFuzz value="1"/>
+          </Private>
+        </FontDict>
+      </FDArray>
+      <CharStrings>
+        <CharString name=".notdef">
+          96 -12 -20 1 blend
+          0 rmoveto
+          432 74 120 1 blend
+          0 rlineto
+          0 660 rlineto
+          -432 -74 -120 1 blend
+          0 rlineto
+          0 -660 rlineto
+          48 32 101 164 45 72 2 blend
+          rmoveto
+          102 176 -47 -76 -75 -120 2 blend
+          rlineto
+          64 106 -17 -28 -6 -10 2 blend
+          rlineto
+          4 0 rlineto
+          62 -106 -16 -26 6 10 2 blend
+          rlineto
+          100 -176 -46 -74 75 120 2 blend
+          rlineto
+          -332 126 204 1 blend
+          0 rlineto
+          166 334 -64 -104 -9 -14 2 blend
+          rmoveto
+          -56 92 10 16 3 4 2 blend
+          rlineto
+          -94 168 47 76 -82 -132 2 blend
+          rlineto
+          302 -113 -182 1 blend
+          0 rlineto
+          -94 -168 47 76 82 132 2 blend
+          rlineto
+          -54 -92 9 14 -3 -4 2 blend
+          rlineto
+          -4 0 rlineto
+          -176 -292 9 14 25 40 2 blend
+          rmoveto
+          0 536 -124 -200 1 blend
+          rlineto
+          154 -270 -45 -72 63 102 2 blend
+          rlineto
+          -154 -266 45 72 61 98 2 blend
+          rlineto
+          354 -17 -26 1 blend
+          0 rmoveto
+          -152 266 44 70 -61 -98 2 blend
+          rlineto
+          152 270 -44 -70 -63 -102 2 blend
+          rlineto
+          0 -536 124 200 1 blend
+          rlineto
+        </CharString>
+        <CharString name="A">
+          1 vsindex
+          10 -20 1 blend
+          0 rmoveto
+          32 144 1 blend
+          0 rlineto
+          140 396 -66 -80 2 blend
+          rlineto
+          28 80 24 68 24 82 -12 -18 -8 10 -10 -16 6 blend
+          rrcurveto
+          4 0 rlineto
+          24 -82 24 -68 28 -80 -8 17 -8 -11 -12 18 6 blend
+          rrcurveto
+          138 -396 -64 80 2 blend
+          rlineto
+          34 148 1 blend
+          0 rlineto
+          -236 660 38 -10 2 blend
+          rlineto
+          -28 -180 1 blend
+          0 rlineto
+          -236 -660 38 10 2 blend
+          rlineto
+          102 236 40 -98 2 blend
+          rmoveto
+          293 25 1 blend
+          0 rlineto
+          0 28 105 1 blend
+          rlineto
+          -293 -25 1 blend
+          0 rlineto
+          0 -28 -105 1 blend
+          rlineto
+        </CharString>
+        <CharString name="AE">
+          1 vsindex
+          26 -48 1 blend
+          0 rmoveto
+          34 146 1 blend
+          0 rlineto
+          220 392 -70 -44 2 blend
+          rlineto
+          44 82 44 80 42 76 -22 -30 -22 -20 -18 -14 6 blend
+          rrcurveto
+          4 0 rlineto
+          0 -630 108 1 blend
+          rlineto
+          344 76 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -312 64 1 blend
+          0 rlineto
+          0 310 -194 1 blend
+          rlineto
+          250 -48 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -250 48 1 blend
+          0 rlineto
+          0 266 -164 1 blend
+          rlineto
+          302 -64 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -350 -166 1 blend
+          0 rlineto
+          -372 -660 76 10 2 blend
+          rlineto
+          148 226 4 -94 2 blend
+          rmoveto
+          268 70 1 blend
+          0 rlineto
+          0 28 105 1 blend
+          rlineto
+          -268 -70 1 blend
+          0 rlineto
+          0 -28 -105 1 blend
+          rlineto
+        </CharString>
+        <CharString name="Aacute">
+          1 vsindex
+          10 -20 1 blend
+          0 rmoveto
+          32 144 1 blend
+          0 rlineto
+          140 396 -66 -80 2 blend
+          rlineto
+          28 80 24 68 24 82 -12 -18 -8 10 -10 -16 6 blend
+          rrcurveto
+          4 0 rlineto
+          24 -82 24 -68 28 -80 -8 17 -8 -11 -12 18 6 blend
+          rrcurveto
+          138 -396 -64 80 2 blend
+          rlineto
+          34 148 1 blend
+          0 rlineto
+          -236 660 38 -10 2 blend
+          rlineto
+          -28 -180 1 blend
+          0 rlineto
+          -236 -660 38 10 2 blend
+          rlineto
+          102 236 40 -98 2 blend
+          rmoveto
+          293 25 1 blend
+          0 rlineto
+          0 28 105 1 blend
+          rlineto
+          -293 -25 1 blend
+          0 rlineto
+          0 -28 -105 1 blend
+          rlineto
+          96 474 62 1 blend
+          rmoveto
+          156 112 80 8 2 blend
+          rlineto
+          -20 24 -50 86 2 blend
+          rlineto
+          -152 -120 -74 -26 2 blend
+          rlineto
+          16 -16 44 -68 2 blend
+          rlineto
+        </CharString>
+        <CharString name="Acircumflex">
+          1 vsindex
+          10 -20 1 blend
+          0 rmoveto
+          32 144 1 blend
+          0 rlineto
+          140 396 -66 -80 2 blend
+          rlineto
+          28 80 24 68 24 82 -12 -18 -8 10 -10 -16 6 blend
+          rrcurveto
+          4 0 rlineto
+          24 -82 24 -68 28 -80 -8 17 -8 -11 -12 18 6 blend
+          rrcurveto
+          138 -396 -64 80 2 blend
+          rlineto
+          34 148 1 blend
+          0 rlineto
+          -236 660 38 -10 2 blend
+          rlineto
+          -28 -180 1 blend
+          0 rlineto
+          -236 -660 38 10 2 blend
+          rlineto
+          102 236 40 -98 2 blend
+          rmoveto
+          293 25 1 blend
+          0 rlineto
+          0 28 105 1 blend
+          rlineto
+          -293 -25 1 blend
+          0 rlineto
+          0 -28 -105 1 blend
+          rlineto
+          32 474 22 68 2 blend
+          rmoveto
+          114 100 -12 -20 2 blend
+          rlineto
+          4 0 rlineto
+          114 -100 -12 20 2 blend
+          rlineto
+          14 16 60 28 2 blend
+          rlineto
+          -116 114 32 -4 2 blend
+          rlineto
+          -28 -160 1 blend
+          0 rlineto
+          -116 -114 32 4 2 blend
+          rlineto
+          14 -16 60 -28 2 blend
+          rlineto
+        </CharString>
+        <CharString name="Adieresis">
+          1 vsindex
+          10 -20 1 blend
+          0 rmoveto
+          32 144 1 blend
+          0 rlineto
+          140 396 -66 -80 2 blend
+          rlineto
+          28 80 24 68 24 82 -12 -18 -8 10 -10 -16 6 blend
+          rrcurveto
+          4 0 rlineto
+          24 -82 24 -68 28 -80 -8 17 -8 -11 -12 18 6 blend
+          rrcurveto
+          138 -396 -64 80 2 blend
+          rlineto
+          34 148 1 blend
+          0 rlineto
+          -236 660 38 -10 2 blend
+          rlineto
+          -28 -180 1 blend
+          0 rlineto
+          -236 -660 38 10 2 blend
+          rlineto
+          102 236 40 -98 2 blend
+          rmoveto
+          293 25 1 blend
+          0 rlineto
+          0 28 105 1 blend
+          rlineto
+          -293 -25 1 blend
+          0 rlineto
+          0 -28 -105 1 blend
+          rlineto
+          52 492 -8 64 2 blend
+          rmoveto
+          18 28 1 blend
+          0 14 12 18 22 2 blend
+          0 20 24 1 blend
+          rrcurveto
+          0 20 -14 12 -18 24 -18 22 -28 4 blend
+          0 rrcurveto
+          -18 -28 1 blend
+          0 -14 -12 -18 -22 2 blend
+          0 -20 -24 1 blend
+          rrcurveto
+          0 -20 14 -12 18 -24 18 -22 28 4 blend
+          0 rrcurveto
+          192 36 1 blend
+          0 rmoveto
+          18 28 1 blend
+          0 14 12 18 22 2 blend
+          0 20 24 1 blend
+          rrcurveto
+          0 20 -14 12 -18 24 -18 22 -28 4 blend
+          0 rrcurveto
+          -18 -28 1 blend
+          0 -14 -12 -18 -22 2 blend
+          0 -20 -24 1 blend
+          rrcurveto
+          0 -20 14 -12 18 -24 18 -22 28 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="Agrave">
+          1 vsindex
+          10 -20 1 blend
+          0 rmoveto
+          32 144 1 blend
+          0 rlineto
+          140 396 -66 -80 2 blend
+          rlineto
+          28 80 24 68 24 82 -12 -18 -8 10 -10 -16 6 blend
+          rrcurveto
+          4 0 rlineto
+          24 -82 24 -68 28 -80 -8 17 -8 -11 -12 18 6 blend
+          rrcurveto
+          138 -396 -64 80 2 blend
+          rlineto
+          34 148 1 blend
+          0 rlineto
+          -236 660 38 -10 2 blend
+          rlineto
+          -28 -180 1 blend
+          0 rlineto
+          -236 -660 38 10 2 blend
+          rlineto
+          102 236 40 -98 2 blend
+          rmoveto
+          293 25 1 blend
+          0 rlineto
+          0 28 105 1 blend
+          rlineto
+          -293 -25 1 blend
+          0 rlineto
+          0 -28 -105 1 blend
+          rlineto
+          200 474 20 62 2 blend
+          rmoveto
+          16 16 44 68 2 blend
+          rlineto
+          -152 120 -74 26 2 blend
+          rlineto
+          -20 -24 -50 -86 2 blend
+          rlineto
+          156 -112 80 -8 2 blend
+          rlineto
+        </CharString>
+        <CharString name="Aring">
+          1 vsindex
+          10 -20 1 blend
+          0 rmoveto
+          32 144 1 blend
+          0 rlineto
+          140 396 -66 -80 2 blend
+          rlineto
+          28 80 24 68 24 82 -12 -18 -8 10 -10 -16 6 blend
+          rrcurveto
+          4 0 rlineto
+          24 -82 24 -68 28 -80 -8 17 -8 -11 -12 18 6 blend
+          rrcurveto
+          138 -396 -64 80 2 blend
+          rlineto
+          34 148 1 blend
+          0 rlineto
+          -236 660 38 -10 2 blend
+          rlineto
+          -28 -180 1 blend
+          0 rlineto
+          -236 -660 38 10 2 blend
+          rlineto
+          102 236 40 -98 2 blend
+          rmoveto
+          293 25 1 blend
+          0 rlineto
+          0 28 105 1 blend
+          rlineto
+          -293 -25 1 blend
+          0 rlineto
+          0 -28 -105 1 blend
+          rlineto
+          148 464 10 94 2 blend
+          rmoveto
+          54 36 1 blend
+          0 40 32 10 8 2 blend
+          0 52 10 1 blend
+          rrcurveto
+          0 52 -40 32 -54 10 -10 8 -36 4 blend
+          0 rrcurveto
+          -54 -36 1 blend
+          0 -40 -32 -10 -8 2 blend
+          0 -52 -10 1 blend
+          rrcurveto
+          0 -52 40 -32 54 -10 10 -8 36 4 blend
+          0 rrcurveto
+          0 22 38 1 blend
+          rmoveto
+          -38 14 1 blend
+          0 -30 20 16 -2 2 blend
+          0 42 -18 1 blend
+          rrcurveto
+          0 42 30 20 38 -18 -16 -2 -14 4 blend
+          0 rrcurveto
+          38 -14 1 blend
+          0 30 -20 -16 2 2 blend
+          0 -42 18 1 blend
+          rrcurveto
+          0 -42 -30 -20 -38 18 16 2 14 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="Atilde">
+          1 vsindex
+          10 -20 1 blend
+          0 rmoveto
+          32 144 1 blend
+          0 rlineto
+          140 396 -66 -80 2 blend
+          rlineto
+          28 80 24 68 24 82 -12 -18 -8 10 -10 -16 6 blend
+          rrcurveto
+          4 0 rlineto
+          24 -82 24 -68 28 -80 -8 17 -8 -11 -12 18 6 blend
+          rrcurveto
+          138 -396 -64 80 2 blend
+          rlineto
+          34 148 1 blend
+          0 rlineto
+          -236 660 38 -10 2 blend
+          rlineto
+          -28 -180 1 blend
+          0 rlineto
+          -236 -660 38 10 2 blend
+          rlineto
+          102 236 40 -98 2 blend
+          rmoveto
+          293 25 1 blend
+          0 rlineto
+          0 28 105 1 blend
+          rlineto
+          -293 -25 1 blend
+          0 rlineto
+          0 -28 -105 1 blend
+          rlineto
+          226 486 2 62 2 blend
+          rmoveto
+          52 21 1 blend
+          0 28 49 2 57 29 -7 4 53 4 blend
+          rrcurveto
+          -24 2 -86 6 2 blend
+          rlineto
+          -6 -48 -21 -32 -31 2 14 9 24 15 5 blend
+          0 rrcurveto
+          -58 30 1 blend
+          0 -20 82 -78 -16 -30 8 3 blend
+          0 rrcurveto
+          -52 -21 1 blend
+          0 -28 -49 -2 -57 -29 7 -4 -53 4 blend
+          rrcurveto
+          24 -2 86 -6 2 blend
+          rlineto
+          4 48 23 32 31 -14 -11 -24 -15 4 blend
+          0 rrcurveto
+          58 -30 1 blend
+          0 20 -82 78 16 30 -8 3 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="B">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          184 70 1 blend
+          0 rlineto
+          150 -10 1 blend
+          0 94 66 22 -8 2 blend
+          0 126 8 1 blend
+          rrcurveto
+          0 92 -58 54 -88 14 -6 8 -6 26 4 5 blend
+          rrcurveto
+          0 4 rlineto
+          68 -18 1 blend
+          20 36 54 -4 10 2 blend
+          0 70 -14 1 blend
+          rrcurveto
+          0 108 -82 52 -132 20 -28 -18 -4 4 blend
+          0 rrcurveto
+          -172 -62 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+          32 366 140 30 2 blend
+          rmoveto
+          0 266 -144 1 blend
+          rlineto
+          126 -68 1 blend
+          0 rlineto
+          128 -72 1 blend
+          0 68 -36 -42 20 2 blend
+          0 -98 58 1 blend
+          rrcurveto
+          0 -82 -58 -50 -144 42 32 24 88 4 blend
+          0 rrcurveto
+          -120 62 1 blend
+          0 rlineto
+          0 -338 74 1 blend
+          rmoveto
+          0 310 -172 1 blend
+          rlineto
+          140 -70 1 blend
+          0 rlineto
+          142 -74 1 blend
+          0 82 -48 -50 30 2 blend
+          0 -100 52 1 blend
+          rrcurveto
+          0 -112 -86 -50 -138 64 54 26 70 4 blend
+          0 rrcurveto
+          -140 70 1 blend
+          0 rlineto
+        </CharString>
+        <CharString name="C">
+          1 vsindex
+          328 26 1 blend
+          -12 rmoveto
+          86 -4 1 blend
+          0 58 36 50 58 16 -6 8 8 4 blend
+          rrcurveto
+          -20 20 -70 82 2 blend
+          rlineto
+          -50 -56 -52 -28 -70 22 26 12 8 20 5 blend
+          0 rrcurveto
+          -148 64 1 blend
+          0 -92 124 36 -56 2 blend
+          0 190 -68 1 blend
+          rrcurveto
+          0 190 92 120 152 -72 -26 -50 -76 4 blend
+          0 rrcurveto
+          62 -18 1 blend
+          0 50 -28 36 -42 -18 14 -4 14 4 blend
+          rrcurveto
+          20 22 70 82 2 blend
+          rlineto
+          -34 40 -58 -12 8 -12 3 blend
+          38 -76 -10 1 blend
+          0 rrcurveto
+          -168 4 1 blend
+          0 -110 -132 -40 8 2 blend
+          0 -208 -10 1 blend
+          rrcurveto
+          0 -208 110 -136 162 -14 34 26 4 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="Ccedilla">
+          1 vsindex
+          328 26 1 blend
+          -12 rmoveto
+          86 -4 1 blend
+          0 58 36 50 58 16 -6 8 8 4 blend
+          rrcurveto
+          -20 20 -70 82 2 blend
+          rlineto
+          -50 -56 -52 -28 -70 22 26 12 8 20 5 blend
+          0 rrcurveto
+          -148 64 1 blend
+          0 -92 124 36 -56 2 blend
+          0 190 -68 1 blend
+          rrcurveto
+          0 190 92 120 152 -72 -26 -50 -76 4 blend
+          0 rrcurveto
+          62 -18 1 blend
+          0 50 -28 36 -42 -18 14 -4 14 4 blend
+          rrcurveto
+          20 22 70 82 2 blend
+          rlineto
+          -34 40 -58 -12 8 -12 3 blend
+          38 -76 -10 1 blend
+          0 rrcurveto
+          -168 4 1 blend
+          0 -110 -132 -40 8 2 blend
+          0 -208 -10 1 blend
+          rrcurveto
+          0 -208 110 -136 162 -14 34 26 4 4 blend
+          0 rrcurveto
+          -64 -204 -48 -28 2 blend
+          rmoveto
+          90 6 48 26 42 -2 30 6 4 blend
+          0 50 22 1 blend
+          rrcurveto
+          0 40 -28 18 -42 10 2 2 4 -10 2 5 blend
+          rrcurveto
+          30 68 -2 -4 2 blend
+          rlineto
+          -28 -70 1 blend
+          0 rlineto
+          -40 -86 -10 -14 2 blend
+          rlineto
+          54 8 1 blend
+          -8 24 -10 1 blend
+          -14 0 -30 12 1 blend
+          rrcurveto
+          0 -30 -26 -18 -88 -6 2 2 8 12 2 5 blend
+          rrcurveto
+          6 -26 6 -40 2 blend
+          rlineto
+        </CharString>
+        <CharString name="D">
+          100 -17 -28 1 blend
+          0 rmoveto
+          148 33 54 1 blend
+          0 rlineto
+          204 -10 -16 1 blend
+          0 92 136 26 44 -23 -38 2 blend
+          0 196 21 34 1 blend
+          rrcurveto
+          0 196 -92 132 -204 20 34 -26 -44 -24 -40 4 6 4 blend
+          0 rrcurveto
+          -148 -27 -44 1 blend
+          0 rlineto
+          0 -660 6 10 1 blend
+          rlineto
+          32 28 84 140 66 110 2 blend
+          rmoveto
+          0 604 -138 -230 1 blend
+          rlineto
+          112 -61 -102 1 blend
+          0 rlineto
+          188 -56 -94 1 blend
+          0 78 -126 -3 -4 56 94 2 blend
+          0 -174 14 22 1 blend
+          rrcurveto
+          0 -174 -78 -130 -188 13 22 3 4 55 92 56 94 4 blend
+          0 rrcurveto
+          -112 61 102 1 blend
+          0 rlineto
+        </CharString>
+        <CharString name="E">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          364 66 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -332 74 1 blend
+          0 rlineto
+          0 310 -194 1 blend
+          rlineto
+          270 -58 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -270 58 1 blend
+          0 rlineto
+          0 266 -164 1 blend
+          rlineto
+          322 -74 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -354 -66 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+        </CharString>
+        <CharString name="Eacute">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          364 66 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -332 74 1 blend
+          0 rlineto
+          0 310 -194 1 blend
+          rlineto
+          270 -58 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -270 58 1 blend
+          0 rlineto
+          0 266 -164 1 blend
+          rlineto
+          322 -74 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -354 -66 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+          138 710 18 -36 2 blend
+          rmoveto
+          156 112 80 8 2 blend
+          rlineto
+          -20 24 -50 86 2 blend
+          rlineto
+          -152 -120 -74 -26 2 blend
+          rlineto
+          16 -16 44 -68 2 blend
+          rlineto
+        </CharString>
+        <CharString name="Ecircumflex">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          364 66 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -332 74 1 blend
+          0 rlineto
+          0 310 -194 1 blend
+          rlineto
+          270 -58 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -270 58 1 blend
+          0 rlineto
+          0 266 -164 1 blend
+          rlineto
+          322 -74 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -354 -66 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+          74 710 40 -30 2 blend
+          rmoveto
+          114 100 -12 -20 2 blend
+          rlineto
+          4 0 rlineto
+          114 -100 -12 20 2 blend
+          rlineto
+          14 16 60 28 2 blend
+          rlineto
+          -116 114 32 -4 2 blend
+          rlineto
+          -28 -160 1 blend
+          0 rlineto
+          -116 -114 32 4 2 blend
+          rlineto
+          14 -16 60 -28 2 blend
+          rlineto
+        </CharString>
+        <CharString name="Edieresis">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          364 66 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -332 74 1 blend
+          0 rlineto
+          0 310 -194 1 blend
+          rlineto
+          270 -58 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -270 58 1 blend
+          0 rlineto
+          0 266 -164 1 blend
+          rlineto
+          322 -74 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -354 -66 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+          94 728 10 -34 2 blend
+          rmoveto
+          18 28 1 blend
+          0 14 12 18 22 2 blend
+          0 20 24 1 blend
+          rrcurveto
+          0 20 -14 12 -18 24 -18 22 -28 4 blend
+          0 rrcurveto
+          -18 -28 1 blend
+          0 -14 -12 -18 -22 2 blend
+          0 -20 -24 1 blend
+          rrcurveto
+          0 -20 14 -12 18 -24 18 -22 28 4 blend
+          0 rrcurveto
+          192 36 1 blend
+          0 rmoveto
+          18 28 1 blend
+          0 14 12 18 22 2 blend
+          0 20 24 1 blend
+          rrcurveto
+          0 20 -14 12 -18 24 -18 22 -28 4 blend
+          0 rrcurveto
+          -18 -28 1 blend
+          0 -14 -12 -18 -22 2 blend
+          0 -20 -24 1 blend
+          rrcurveto
+          0 -20 14 -12 18 -24 18 -22 28 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="Egrave">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          364 66 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -332 74 1 blend
+          0 rlineto
+          0 310 -194 1 blend
+          rlineto
+          270 -58 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -270 58 1 blend
+          0 rlineto
+          0 266 -164 1 blend
+          rlineto
+          322 -74 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -354 -66 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+          242 710 38 -36 2 blend
+          rmoveto
+          16 16 44 68 2 blend
+          rlineto
+          -152 120 -74 26 2 blend
+          rlineto
+          -20 -24 -50 -86 2 blend
+          rlineto
+          156 -112 80 -8 2 blend
+          rlineto
+        </CharString>
+        <CharString name="Eth">
+          38 336 -8 -14 -38 -58 2 blend
+          rmoveto
+          282 48 80 1 blend
+          0 rlineto
+          0 28 58 84 1 blend
+          rlineto
+          -198 -53 -88 1 blend
+          0 rlineto
+          -84 -2 5 8 -2 -4 2 blend
+          rlineto
+          0 -26 -56 -80 1 blend
+          rlineto
+          82 -336 -5 -8 38 58 2 blend
+          rmoveto
+          148 33 54 1 blend
+          0 rlineto
+          204 -10 -16 1 blend
+          0 92 136 26 44 -23 -38 2 blend
+          0 196 21 34 1 blend
+          rrcurveto
+          0 196 -92 132 -204 20 34 -26 -44 -24 -40 4 6 4 blend
+          0 rrcurveto
+          -148 -27 -44 1 blend
+          0 rlineto
+          0 -660 6 10 1 blend
+          rlineto
+          32 28 84 140 66 110 2 blend
+          rmoveto
+          0 604 -138 -230 1 blend
+          rlineto
+          112 -61 -102 1 blend
+          0 rlineto
+          188 -56 -94 1 blend
+          0 78 -126 -3 -4 56 94 2 blend
+          0 -174 14 22 1 blend
+          rrcurveto
+          0 -174 -78 -130 -188 13 22 3 4 55 92 56 94 4 blend
+          0 rrcurveto
+          -112 61 102 1 blend
+          0 rlineto
+        </CharString>
+        <CharString name="F">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          32 140 1 blend
+          0 rlineto
+          0 326 -88 1 blend
+          rlineto
+          270 -54 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -270 54 1 blend
+          0 rlineto
+          0 278 -154 1 blend
+          rlineto
+          320 -68 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -352 -72 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+        </CharString>
+        <CharString name="G">
+          1 vsindex
+          334 38 1 blend
+          -12 rmoveto
+          86 6 1 blend
+          0 66 30 40 16 6 6 3 blend
+          44 rrcurveto
+          0 256 54 1 blend
+          rlineto
+          -196 -52 1 blend
+          0 rlineto
+          0 -28 -112 1 blend
+          rlineto
+          164 -68 1 blend
+          0 rlineto
+          0 -218 128 1 blend
+          rlineto
+          -34 -34 -60 -20 -64 22 26 40 16 46 5 blend
+          0 rrcurveto
+          -154 38 1 blend
+          0 -92 124 38 -56 2 blend
+          0 190 -68 1 blend
+          rrcurveto
+          0 190 96 120 158 -72 -30 -50 -70 4 blend
+          0 rrcurveto
+          74 -22 1 blend
+          0 48 -32 34 -38 -16 18 -2 10 4 blend
+          rrcurveto
+          20 22 70 82 2 blend
+          rlineto
+          -34 36 -54 42 -88 -12 12 -16 -4 -8 5 blend
+          0 rrcurveto
+          -174 0 -114 -132 -36 8 2 blend
+          0 -208 -10 1 blend
+          rrcurveto
+          0 -208 110 -136 168 -14 36 26 14 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="H">
+          100 -17 -28 1 blend
+          0 rmoveto
+          32 84 140 1 blend
+          0 rlineto
+          0 338 -48 -80 1 blend
+          rlineto
+          370 -105 -176 1 blend
+          0 rlineto
+          0 -338 48 80 1 blend
+          rlineto
+          32 84 140 1 blend
+          0 rlineto
+          0 660 -6 -10 1 blend
+          rlineto
+          -32 -84 -140 1 blend
+          0 rlineto
+          0 -294 31 52 1 blend
+          rlineto
+          -370 105 176 1 blend
+          0 rlineto
+          0 294 -31 -52 1 blend
+          rlineto
+          -32 -84 -140 1 blend
+          0 rlineto
+          0 -660 6 10 1 blend
+          rlineto
+        </CharString>
+        <CharString name="I">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          32 140 1 blend
+          0 rlineto
+          0 660 -10 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+        </CharString>
+        <CharString name="Iacute">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          32 140 1 blend
+          0 rlineto
+          0 660 -10 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+          -36 710 62 -36 2 blend
+          rmoveto
+          156 112 80 8 2 blend
+          rlineto
+          -20 24 -50 86 2 blend
+          rlineto
+          -152 -120 -74 -26 2 blend
+          rlineto
+          16 -16 44 -68 2 blend
+          rlineto
+        </CharString>
+        <CharString name="Icircumflex">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          32 140 1 blend
+          0 rlineto
+          0 660 -10 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+          -100 710 84 -30 2 blend
+          rmoveto
+          114 100 -12 -20 2 blend
+          rlineto
+          4 0 rlineto
+          114 -100 -12 20 2 blend
+          rlineto
+          14 16 60 28 2 blend
+          rlineto
+          -116 114 32 -4 2 blend
+          rlineto
+          -28 -160 1 blend
+          0 rlineto
+          -116 -114 32 4 2 blend
+          rlineto
+          14 -16 60 -28 2 blend
+          rlineto
+        </CharString>
+        <CharString name="Idieresis">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          32 140 1 blend
+          0 rlineto
+          0 660 -10 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+          -80 728 54 -34 2 blend
+          rmoveto
+          18 28 1 blend
+          0 14 12 18 22 2 blend
+          0 20 24 1 blend
+          rrcurveto
+          0 20 -14 12 -18 24 -18 22 -28 4 blend
+          0 rrcurveto
+          -18 -28 1 blend
+          0 -14 -12 -18 -22 2 blend
+          0 -20 -24 1 blend
+          rrcurveto
+          0 -20 14 -12 18 -24 18 -22 28 4 blend
+          0 rrcurveto
+          192 36 1 blend
+          0 rmoveto
+          18 28 1 blend
+          0 14 12 18 22 2 blend
+          0 20 24 1 blend
+          rrcurveto
+          0 20 -14 12 -18 24 -18 22 -28 4 blend
+          0 rrcurveto
+          -18 -28 1 blend
+          0 -14 -12 -18 -22 2 blend
+          0 -20 -24 1 blend
+          rrcurveto
+          0 -20 14 -12 18 -24 18 -22 28 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="Igrave">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          32 140 1 blend
+          0 rlineto
+          0 660 -10 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+          68 710 82 -36 2 blend
+          rmoveto
+          16 16 44 68 2 blend
+          rlineto
+          -152 120 -74 26 2 blend
+          rlineto
+          -20 -24 -50 -86 2 blend
+          rlineto
+          156 -112 80 -8 2 blend
+          rlineto
+        </CharString>
+        <CharString name="J">
+          1 vsindex
+          200 20 1 blend
+          -12 rmoveto
+          116 42 1 blend
+          0 42 82 32 28 2 blend
+          0 104 30 1 blend
+          rrcurveto
+          0 486 -68 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -482 78 1 blend
+          rlineto
+          0 -110 -40 -50 -84 24 14 26 32 4 blend
+          0 rrcurveto
+          -58 26 1 blend
+          0 -40 22 -34 58 8 -2 18 -26 4 blend
+          rrcurveto
+          -26 -16 -82 -58 2 blend
+          rlineto
+          32 -60 54 -34 70 12 -28 12 -4 26 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="K">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          32 140 1 blend
+          0 rlineto
+          0 234 -72 1 blend
+          rlineto
+          142 160 -80 -72 2 blend
+          rlineto
+          226 -394 -82 144 2 blend
+          rlineto
+          38 150 1 blend
+          0 rlineto
+          -240 418 8 -32 2 blend
+          rlineto
+          212 242 -18 22 2 blend
+          rlineto
+          -40 -148 1 blend
+          0 rlineto
+          -336 -380 172 138 2 blend
+          rlineto
+          -2 -2 1 blend
+          0 rlineto
+          0 380 -138 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+        </CharString>
+        <CharString name="L">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          342 76 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -310 64 1 blend
+          0 rlineto
+          0 632 -126 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+        </CharString>
+        <CharString name="M">
+          100 -18 -28 1 blend
+          0 rmoveto
+          30 78 124 1 blend
+          0 rlineto
+          0 460 -162 -268 1 blend
+          rlineto
+          0 52 -2 66 -2 54 10 14 -8 -12 24 54 -6 -6 6 12 5 blend
+          rrcurveto
+          4 0 rlineto
+          52 -146 -12 -30 1 blend
+          rlineto
+          150 -412 -46 -70 120 197 2 blend
+          rlineto
+          34 44 58 1 blend
+          0 rlineto
+          149 412 -43 -69 -120 -197 2 blend
+          rlineto
+          51 146 1 3 12 30 2 blend
+          rlineto
+          4 0 rlineto
+          -2 -54 -2 -66 -6 -6 -6 -12 -8 -12 -24 -54 4 blend
+          0 -52 -10 -14 1 blend
+          rrcurveto
+          0 -460 162 268 1 blend
+          rlineto
+          32 78 124 1 blend
+          0 rlineto
+          0 660 -6 -10 1 blend
+          rlineto
+          -52 -88 -132 1 blend
+          0 rlineto
+          -142 -400 30 48 80 134 2 blend
+          rlineto
+          -18 -50 -16 -50 -18 -50 4 6 8 14 6 6 12 10 6 6 2 12 6 blend
+          rrcurveto
+          -4 0 rlineto
+          -18 50 -18 50 -18 50 6 6 -2 -12 6 8 -12 -10 4 6 -8 -14 6 blend
+          rrcurveto
+          -142 400 30 44 -80 -134 2 blend
+          rlineto
+          -52 -88 -132 1 blend
+          0 rlineto
+          0 -660 6 10 1 blend
+          rlineto
+        </CharString>
+        <CharString name="N">
+          100 -17 -28 1 blend
+          0 rmoveto
+          30 81 134 1 blend
+          0 rlineto
+          0 434 -148 -246 1 blend
+          rlineto
+          0 62 -2 56 -2 62 11 18 -6 -12 25 38 -5 -6 6 12 5 blend
+          rrcurveto
+          4 0 rlineto
+          24 -42 26 -44 26 -3 -4 -10 -8 -4 -6 -8 -8 -2 -4 5 blend
+          -44 rrcurveto
+          292 -484 -96 -148 124 194 2 blend
+          rlineto
+          34 93 142 1 blend
+          0 rlineto
+          0 660 -6 -10 1 blend
+          rlineto
+          -30 -81 -134 1 blend
+          0 rlineto
+          0 -428 142 240 1 blend
+          rlineto
+          0 -62 2 -60 2 -64 -10 -18 6 12 -20 -38 5 6 -6 -6 5 blend
+          rrcurveto
+          -4 0 rlineto
+          -24 42 -26 44 -26 3 4 10 8 4 6 8 8 2 4 5 blend
+          44 rrcurveto
+          -292 484 96 148 -124 -194 2 blend
+          rlineto
+          -34 -93 -142 1 blend
+          0 rlineto
+          0 -660 6 10 1 blend
+          rlineto
+        </CharString>
+        <CharString name="Ntilde">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          30 134 1 blend
+          0 rlineto
+          0 434 -246 1 blend
+          rlineto
+          0 62 -2 56 -2 62 18 -12 38 -6 12 5 blend
+          rrcurveto
+          4 0 rlineto
+          24 -42 26 -44 26 -4 -8 -6 -8 -4 5 blend
+          -44 rrcurveto
+          292 -484 -148 194 2 blend
+          rlineto
+          34 142 1 blend
+          0 rlineto
+          0 660 -10 1 blend
+          rlineto
+          -30 -134 1 blend
+          0 rlineto
+          0 -428 240 1 blend
+          rlineto
+          0 -62 2 -60 2 -64 -18 12 -38 6 -6 5 blend
+          rrcurveto
+          -4 0 rlineto
+          -24 42 -26 44 -26 4 8 6 8 4 5 blend
+          44 rrcurveto
+          -292 484 148 -194 2 blend
+          rlineto
+          -34 -142 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+          308 722 30 -36 2 blend
+          rmoveto
+          52 21 1 blend
+          0 28 49 2 57 29 -7 4 53 4 blend
+          rrcurveto
+          -24 2 -86 6 2 blend
+          rlineto
+          -6 -48 -21 -32 -31 2 14 9 24 15 5 blend
+          0 rrcurveto
+          -58 30 1 blend
+          0 -20 82 -78 -16 -30 8 3 blend
+          0 rrcurveto
+          -52 -21 1 blend
+          0 -28 -49 -2 -57 -29 7 -4 -53 4 blend
+          rrcurveto
+          24 -2 86 -6 2 blend
+          rlineto
+          4 48 23 32 31 -14 -11 -24 -15 4 blend
+          0 rrcurveto
+          58 -30 1 blend
+          0 20 -82 78 16 30 -8 3 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="O">
+          324 13 22 1 blend
+          -12 rmoveto
+          156 15 24 1 blend
+          0 112 136 6 10 -6 -10 2 blend
+          0 208 4 6 1 blend
+          rrcurveto
+          0 208 -112 132 -156 3 5 -6 -10 -7 -11 -15 -24 4 blend
+          0 rrcurveto
+          -156 -14 -24 1 blend
+          0 -112 -132 -6 -10 7 12 2 blend
+          0 -208 -3 -6 1 blend
+          rrcurveto
+          0 -208 112 -136 156 -4 -6 6 10 6 10 14 24 4 blend
+          0 rrcurveto
+          0 30 71 118 1 blend
+          rmoveto
+          -140 37 62 1 blend
+          0 -94 124 28 46 -30 -50 2 blend
+          0 190 -43 -72 1 blend
+          rrcurveto
+          0 190 94 120 140 -44 -72 -28 -46 -31 -52 -37 -62 4 blend
+          0 rrcurveto
+          140 -37 -62 1 blend
+          0 94 -120 -28 -46 31 52 2 blend
+          0 -190 44 72 1 blend
+          rrcurveto
+          0 -190 -94 -124 -140 43 72 28 46 30 50 37 62 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="Oacute">
+          1 vsindex
+          324 22 1 blend
+          -12 rmoveto
+          156 24 1 blend
+          0 112 136 10 -10 2 blend
+          0 208 6 1 blend
+          rrcurveto
+          0 208 -112 132 -156 5 -10 -11 -24 4 blend
+          0 rrcurveto
+          -156 -24 1 blend
+          0 -112 -132 -10 12 2 blend
+          0 -208 -6 1 blend
+          rrcurveto
+          0 -208 112 -136 156 -6 10 10 24 4 blend
+          0 rrcurveto
+          0 30 118 1 blend
+          rmoveto
+          -140 62 1 blend
+          0 -94 124 46 -50 2 blend
+          0 190 -72 1 blend
+          rrcurveto
+          0 190 94 120 140 -72 -46 -52 -62 4 blend
+          0 rrcurveto
+          140 -62 1 blend
+          0 94 -120 -46 52 2 blend
+          0 -190 72 1 blend
+          rrcurveto
+          0 -190 -94 -124 -140 72 46 50 62 4 blend
+          0 rrcurveto
+          -52 692 -10 -154 2 blend
+          rmoveto
+          156 112 80 8 2 blend
+          rlineto
+          -20 24 -50 86 2 blend
+          rlineto
+          -152 -120 -74 -26 2 blend
+          rlineto
+          16 -16 44 -68 2 blend
+          rlineto
+        </CharString>
+        <CharString name="Ocircumflex">
+          1 vsindex
+          324 22 1 blend
+          -12 rmoveto
+          156 24 1 blend
+          0 112 136 10 -10 2 blend
+          0 208 6 1 blend
+          rrcurveto
+          0 208 -112 132 -156 5 -10 -11 -24 4 blend
+          0 rrcurveto
+          -156 -24 1 blend
+          0 -112 -132 -10 12 2 blend
+          0 -208 -6 1 blend
+          rrcurveto
+          0 -208 112 -136 156 -6 10 10 24 4 blend
+          0 rrcurveto
+          0 30 118 1 blend
+          rmoveto
+          -140 62 1 blend
+          0 -94 124 46 -50 2 blend
+          0 190 -72 1 blend
+          rrcurveto
+          0 190 94 120 140 -72 -46 -52 -62 4 blend
+          0 rrcurveto
+          140 -62 1 blend
+          0 94 -120 -46 52 2 blend
+          0 -190 72 1 blend
+          rrcurveto
+          0 -190 -94 -124 -140 72 46 50 62 4 blend
+          0 rrcurveto
+          -116 692 12 -148 2 blend
+          rmoveto
+          114 100 -12 -20 2 blend
+          rlineto
+          4 0 rlineto
+          114 -100 -12 20 2 blend
+          rlineto
+          14 16 60 28 2 blend
+          rlineto
+          -116 114 32 -4 2 blend
+          rlineto
+          -28 -160 1 blend
+          0 rlineto
+          -116 -114 32 4 2 blend
+          rlineto
+          14 -16 60 -28 2 blend
+          rlineto
+        </CharString>
+        <CharString name="Odieresis">
+          1 vsindex
+          324 22 1 blend
+          -12 rmoveto
+          156 24 1 blend
+          0 112 136 10 -10 2 blend
+          0 208 6 1 blend
+          rrcurveto
+          0 208 -112 132 -156 5 -10 -11 -24 4 blend
+          0 rrcurveto
+          -156 -24 1 blend
+          0 -112 -132 -10 12 2 blend
+          0 -208 -6 1 blend
+          rrcurveto
+          0 -208 112 -136 156 -6 10 10 24 4 blend
+          0 rrcurveto
+          0 30 118 1 blend
+          rmoveto
+          -140 62 1 blend
+          0 -94 124 46 -50 2 blend
+          0 190 -72 1 blend
+          rrcurveto
+          0 190 94 120 140 -72 -46 -52 -62 4 blend
+          0 rrcurveto
+          140 -62 1 blend
+          0 94 -120 -46 52 2 blend
+          0 -190 72 1 blend
+          rrcurveto
+          0 -190 -94 -124 -140 72 46 50 62 4 blend
+          0 rrcurveto
+          -96 710 -18 -152 2 blend
+          rmoveto
+          18 28 1 blend
+          0 14 12 18 22 2 blend
+          0 20 24 1 blend
+          rrcurveto
+          0 20 -14 12 -18 24 -18 22 -28 4 blend
+          0 rrcurveto
+          -18 -28 1 blend
+          0 -14 -12 -18 -22 2 blend
+          0 -20 -24 1 blend
+          rrcurveto
+          0 -20 14 -12 18 -24 18 -22 28 4 blend
+          0 rrcurveto
+          192 36 1 blend
+          0 rmoveto
+          18 28 1 blend
+          0 14 12 18 22 2 blend
+          0 20 24 1 blend
+          rrcurveto
+          0 20 -14 12 -18 24 -18 22 -28 4 blend
+          0 rrcurveto
+          -18 -28 1 blend
+          0 -14 -12 -18 -22 2 blend
+          0 -20 -24 1 blend
+          rrcurveto
+          0 -20 14 -12 18 -24 18 -22 28 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="Ograve">
+          1 vsindex
+          324 22 1 blend
+          -12 rmoveto
+          156 24 1 blend
+          0 112 136 10 -10 2 blend
+          0 208 6 1 blend
+          rrcurveto
+          0 208 -112 132 -156 5 -10 -11 -24 4 blend
+          0 rrcurveto
+          -156 -24 1 blend
+          0 -112 -132 -10 12 2 blend
+          0 -208 -6 1 blend
+          rrcurveto
+          0 -208 112 -136 156 -6 10 10 24 4 blend
+          0 rrcurveto
+          0 30 118 1 blend
+          rmoveto
+          -140 62 1 blend
+          0 -94 124 46 -50 2 blend
+          0 190 -72 1 blend
+          rrcurveto
+          0 190 94 120 140 -72 -46 -52 -62 4 blend
+          0 rrcurveto
+          140 -62 1 blend
+          0 94 -120 -46 52 2 blend
+          0 -190 72 1 blend
+          rrcurveto
+          0 -190 -94 -124 -140 72 46 50 62 4 blend
+          0 rrcurveto
+          52 692 10 -154 2 blend
+          rmoveto
+          16 16 44 68 2 blend
+          rlineto
+          -152 120 -74 26 2 blend
+          rlineto
+          -20 -24 -50 -86 2 blend
+          rlineto
+          156 -112 80 -8 2 blend
+          rlineto
+        </CharString>
+        <CharString name="Oslash">
+          80 -20 30 44 -20 -26 2 blend
+          rmoveto
+          506 684 28 46 -6 -10 2 blend
+          rlineto
+          -22 16 -48 -66 40 52 2 blend
+          rlineto
+          -506 -684 -27 -46 6 10 2 blend
+          rlineto
+          22 -16 47 66 -40 -52 2 blend
+          rlineto
+          248 8 -19 -26 20 26 2 blend
+          rmoveto
+          156 15 24 1 blend
+          0 112 136 6 10 -6 -10 2 blend
+          0 208 4 6 1 blend
+          rrcurveto
+          0 208 -112 132 -156 3 5 -6 -10 -7 -11 -15 -24 4 blend
+          0 rrcurveto
+          -156 -14 -24 1 blend
+          0 -112 -132 -6 -10 7 12 2 blend
+          0 -208 -3 -6 1 blend
+          rrcurveto
+          0 -208 112 -136 156 -4 -6 6 10 6 10 14 24 4 blend
+          0 rrcurveto
+          0 30 71 118 1 blend
+          rmoveto
+          -140 37 62 1 blend
+          0 -94 124 28 46 -30 -50 2 blend
+          0 190 -43 -72 1 blend
+          rrcurveto
+          0 190 94 120 140 -44 -72 -28 -46 -31 -52 -37 -62 4 blend
+          0 rrcurveto
+          140 -37 -62 1 blend
+          0 94 -120 -28 -46 31 52 2 blend
+          0 -190 44 72 1 blend
+          rrcurveto
+          0 -190 -94 -124 -140 43 72 28 46 30 50 37 62 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="Otilde">
+          1 vsindex
+          324 22 1 blend
+          -12 rmoveto
+          156 24 1 blend
+          0 112 136 10 -10 2 blend
+          0 208 6 1 blend
+          rrcurveto
+          0 208 -112 132 -156 5 -10 -11 -24 4 blend
+          0 rrcurveto
+          -156 -24 1 blend
+          0 -112 -132 -10 12 2 blend
+          0 -208 -6 1 blend
+          rrcurveto
+          0 -208 112 -136 156 -6 10 10 24 4 blend
+          0 rrcurveto
+          0 30 118 1 blend
+          rmoveto
+          -140 62 1 blend
+          0 -94 124 46 -50 2 blend
+          0 190 -72 1 blend
+          rrcurveto
+          0 190 94 120 140 -72 -46 -52 -62 4 blend
+          0 rrcurveto
+          140 -62 1 blend
+          0 94 -120 -46 52 2 blend
+          0 -190 72 1 blend
+          rrcurveto
+          0 -190 -94 -124 -140 72 46 50 62 4 blend
+          0 rrcurveto
+          78 704 -8 -154 2 blend
+          rmoveto
+          52 21 1 blend
+          0 28 49 2 57 29 -7 4 53 4 blend
+          rrcurveto
+          -24 2 -86 6 2 blend
+          rlineto
+          -6 -48 -21 -32 -31 2 14 9 24 15 5 blend
+          0 rrcurveto
+          -58 30 1 blend
+          0 -20 82 -78 -16 -30 8 3 blend
+          0 rrcurveto
+          -52 -21 1 blend
+          0 -28 -49 -2 -57 -29 7 -4 -53 4 blend
+          rrcurveto
+          24 -2 86 -6 2 blend
+          rlineto
+          4 48 23 32 31 -14 -11 -24 -15 4 blend
+          0 rrcurveto
+          58 -30 1 blend
+          0 20 -82 78 16 30 -8 3 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="P">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          32 140 1 blend
+          0 rlineto
+          0 292 -86 1 blend
+          rlineto
+          130 -60 1 blend
+          0 rlineto
+          148 -12 1 blend
+          0 84 62 40 7 2 blend
+          0 126 33 1 blend
+          rrcurveto
+          0 132 -86 48 -150 32 -36 4 8 4 blend
+          0 rrcurveto
+          -158 -80 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+          32 320 140 22 2 blend
+          rmoveto
+          0 312 -140 1 blend
+          rlineto
+          114 -56 1 blend
+          0 rlineto
+          144 -78 1 blend
+          0 70 -36 -32 14 2 blend
+          0 -116 58 1 blend
+          rrcurveto
+          0 -114 -68 -46 -142 56 36 12 74 4 blend
+          0 rrcurveto
+          -118 56 1 blend
+          0 rlineto
+        </CharString>
+        <CharString name="Q">
+          1 vsindex
+          324 22 1 blend
+          -12 rmoveto
+          156 24 1 blend
+          0 112 136 10 -10 2 blend
+          0 208 6 1 blend
+          rrcurveto
+          0 208 -112 132 -156 5 -10 -11 -24 4 blend
+          0 rrcurveto
+          -156 -24 1 blend
+          0 -112 -132 -10 12 2 blend
+          0 -208 -6 1 blend
+          rrcurveto
+          0 -208 112 -136 156 -6 10 10 24 4 blend
+          0 rrcurveto
+          0 28 112 1 blend
+          rmoveto
+          -140 62 1 blend
+          0 -94 126 46 -54 2 blend
+          0 190 -62 1 blend
+          rrcurveto
+          0 190 94 120 140 -72 -46 -52 -62 4 blend
+          0 rrcurveto
+          140 -62 1 blend
+          0 94 -120 -46 52 2 blend
+          0 -190 72 1 blend
+          rrcurveto
+          0 -190 -94 -126 -140 62 46 54 62 4 blend
+          0 rrcurveto
+          190 -168 30 -148 2 blend
+          rmoveto
+          30 25 1 blend
+          0 30 6 16 6 13 4 10 8 4 blend
+          rrcurveto
+          -8 28 -22 94 2 blend
+          rlineto
+          -16 -4 -20 -4 -2 -6 3 blend
+          -4 -30 2 1 blend
+          0 rrcurveto
+          -90 34 1 blend
+          0 -62 44 -28 76 -6 -26 4 -18 4 blend
+          rrcurveto
+          -36 0 -138 -18 2 blend
+          rlineto
+          28 -86 74 -66 112 20 -26 30 -16 38 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="R">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          32 140 1 blend
+          0 rlineto
+          0 312 -94 1 blend
+          rlineto
+          150 -76 1 blend
+          0 rlineto
+          130 10 1 blend
+          0 82 62 38 3 2 blend
+          0 116 41 1 blend
+          rrcurveto
+          0 122 -82 40 -38 2 blend
+          48 -130 -10 1 blend
+          0 rrcurveto
+          -182 -64 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+          32 340 140 14 2 blend
+          rmoveto
+          0 292 -132 1 blend
+          rlineto
+          138 -76 1 blend
+          0 rlineto
+          122 -54 1 blend
+          0 68 -38 -32 20 2 blend
+          0 -104 48 1 blend
+          rrcurveto
+          0 -102 -68 -48 -122 46 32 18 54 4 blend
+          0 rrcurveto
+          -138 76 1 blend
+          0 rlineto
+          334 -340 -156 -14 2 blend
+          rmoveto
+          38 154 1 blend
+          0 rlineto
+          -194 324 -17 53 2 blend
+          rlineto
+          -36 -2 -80 -112 2 blend
+          rlineto
+          192 -322 -57 59 2 blend
+          rlineto
+        </CharString>
+        <CharString name="S">
+          1 vsindex
+          268 10 1 blend
+          -12 rmoveto
+          124 38 1 blend
+          0 82 74 10 24 2 blend
+          0 100 10 1 blend
+          rrcurveto
+          0 102 -67 39 -73 33 -12 21 17 -8 -1 5 blend
+          rrcurveto
+          -102 46 23 -15 2 blend
+          rlineto
+          -47 21 -69 31 -12 2 32 -20 4 blend
+          0 82 -51 1 blend
+          rrcurveto
+          0 76 62 50 92 -47 -36 -35 -50 4 blend
+          0 rrcurveto
+          68 -30 1 blend
+          0 54 -28 38 -42 -10 12 6 12 4 blend
+          rrcurveto
+          20 22 70 90 2 blend
+          rlineto
+          -38 41 -62 37 -80 -21 13 -17 -9 2 5 blend
+          0 rrcurveto
+          -106 -36 1 blend
+          0 -80 -64 -20 -27 2 blend
+          0 -94 -17 1 blend
+          rrcurveto
+          0 -98 78 -39 56 -25 4 -17 -20 14 -3 5 blend
+          rrcurveto
+          102 -46 -21 12 2 blend
+          rlineto
+          66 -30 56 -28 -11 8 -23 18 4 blend
+          0 -88 57 1 blend
+          rrcurveto
+          0 -84 -68 -58 -106 55 46 41 54 4 blend
+          0 rrcurveto
+          -80 28 1 blend
+          0 -70 36 -48 56 8 -16 2 -18 4 blend
+          rrcurveto
+          -22 -22 -68 -90 2 blend
+          rlineto
+          50 -58 72 -42 98 20 -8 18 14 -12 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="T">
+          244 -29 -48 1 blend
+          0 rmoveto
+          32 84 140 1 blend
+          0 rlineto
+          0 632 -76 -126 1 blend
+          rlineto
+          214 -25 -42 1 blend
+          0 rlineto
+          0 28 70 116 1 blend
+          rlineto
+          -460 -34 -56 1 blend
+          0 rlineto
+          0 -28 -70 -116 1 blend
+          rlineto
+          214 -25 -42 1 blend
+          0 rlineto
+          0 -632 76 126 1 blend
+          rlineto
+        </CharString>
+        <CharString name="Thorn">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          32 140 1 blend
+          0 rlineto
+          0 172 -60 1 blend
+          rlineto
+          140 -60 1 blend
+          0 rlineto
+          148 -12 1 blend
+          0 84 62 40 7 2 blend
+          0 126 33 1 blend
+          rrcurveto
+          0 132 -84 48 -148 32 -36 4 8 4 blend
+          0 rrcurveto
+          -140 60 1 blend
+          0 rlineto
+          0 120 -26 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+          32 200 140 48 2 blend
+          rmoveto
+          0 312 -140 1 blend
+          rlineto
+          128 -56 1 blend
+          0 rlineto
+          142 -78 1 blend
+          0 68 -36 -32 14 2 blend
+          0 -116 58 1 blend
+          rrcurveto
+          0 -114 -68 -46 -142 56 36 12 74 4 blend
+          0 rrcurveto
+          -128 56 1 blend
+          0 rlineto
+        </CharString>
+        <CharString name="U">
+          1 vsindex
+          314 24 1 blend
+          -12 rmoveto
+          106 76 1 blend
+          0 112 54 -28 50 2 blend
+          0 204 18 1 blend
+          rrcurveto
+          0 414 -78 1 blend
+          rlineto
+          -30 -136 1 blend
+          0 rlineto
+          0 -406 50 1 blend
+          rlineto
+          0 -182 -90 -54 -98 66 58 12 30 4 blend
+          0 rrcurveto
+          -96 28 1 blend
+          0 -88 54 58 -12 2 blend
+          0 182 -66 1 blend
+          rrcurveto
+          0 406 -50 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -414 78 1 blend
+          rlineto
+          0 -204 110 -54 106 -18 -22 -50 76 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="Uacute">
+          1 vsindex
+          314 24 1 blend
+          -12 rmoveto
+          106 76 1 blend
+          0 112 54 -28 50 2 blend
+          0 204 18 1 blend
+          rrcurveto
+          0 414 -78 1 blend
+          rlineto
+          -30 -136 1 blend
+          0 rlineto
+          0 -406 50 1 blend
+          rlineto
+          0 -182 -90 -54 -98 66 58 12 30 4 blend
+          0 rrcurveto
+          -96 28 1 blend
+          0 -88 54 58 -12 2 blend
+          0 182 -66 1 blend
+          rrcurveto
+          0 406 -50 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -414 78 1 blend
+          rlineto
+          0 -204 110 -54 106 -18 -22 -50 76 4 blend
+          0 rrcurveto
+          -52 722 -12 -36 2 blend
+          rmoveto
+          156 112 80 8 2 blend
+          rlineto
+          -20 24 -50 86 2 blend
+          rlineto
+          -152 -120 -74 -26 2 blend
+          rlineto
+          16 -16 44 -68 2 blend
+          rlineto
+        </CharString>
+        <CharString name="Ucircumflex">
+          1 vsindex
+          314 24 1 blend
+          -12 rmoveto
+          106 76 1 blend
+          0 112 54 -28 50 2 blend
+          0 204 18 1 blend
+          rrcurveto
+          0 414 -78 1 blend
+          rlineto
+          -30 -136 1 blend
+          0 rlineto
+          0 -406 50 1 blend
+          rlineto
+          0 -182 -90 -54 -98 66 58 12 30 4 blend
+          0 rrcurveto
+          -96 28 1 blend
+          0 -88 54 58 -12 2 blend
+          0 182 -66 1 blend
+          rrcurveto
+          0 406 -50 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -414 78 1 blend
+          rlineto
+          0 -204 110 -54 106 -18 -22 -50 76 4 blend
+          0 rrcurveto
+          -116 722 10 -30 2 blend
+          rmoveto
+          114 100 -12 -20 2 blend
+          rlineto
+          4 0 rlineto
+          114 -100 -12 20 2 blend
+          rlineto
+          14 16 60 28 2 blend
+          rlineto
+          -116 114 32 -4 2 blend
+          rlineto
+          -28 -160 1 blend
+          0 rlineto
+          -116 -114 32 4 2 blend
+          rlineto
+          14 -16 60 -28 2 blend
+          rlineto
+        </CharString>
+        <CharString name="Udieresis">
+          1 vsindex
+          314 24 1 blend
+          -12 rmoveto
+          106 76 1 blend
+          0 112 54 -28 50 2 blend
+          0 204 18 1 blend
+          rrcurveto
+          0 414 -78 1 blend
+          rlineto
+          -30 -136 1 blend
+          0 rlineto
+          0 -406 50 1 blend
+          rlineto
+          0 -182 -90 -54 -98 66 58 12 30 4 blend
+          0 rrcurveto
+          -96 28 1 blend
+          0 -88 54 58 -12 2 blend
+          0 182 -66 1 blend
+          rrcurveto
+          0 406 -50 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -414 78 1 blend
+          rlineto
+          0 -204 110 -54 106 -18 -22 -50 76 4 blend
+          0 rrcurveto
+          -96 740 -20 -34 2 blend
+          rmoveto
+          18 28 1 blend
+          0 14 12 18 22 2 blend
+          0 20 24 1 blend
+          rrcurveto
+          0 20 -14 12 -18 24 -18 22 -28 4 blend
+          0 rrcurveto
+          -18 -28 1 blend
+          0 -14 -12 -18 -22 2 blend
+          0 -20 -24 1 blend
+          rrcurveto
+          0 -20 14 -12 18 -24 18 -22 28 4 blend
+          0 rrcurveto
+          192 36 1 blend
+          0 rmoveto
+          18 28 1 blend
+          0 14 12 18 22 2 blend
+          0 20 24 1 blend
+          rrcurveto
+          0 20 -14 12 -18 24 -18 22 -28 4 blend
+          0 rrcurveto
+          -18 -28 1 blend
+          0 -14 -12 -18 -22 2 blend
+          0 -20 -24 1 blend
+          rrcurveto
+          0 -20 14 -12 18 -24 18 -22 28 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="Ugrave">
+          1 vsindex
+          314 24 1 blend
+          -12 rmoveto
+          106 76 1 blend
+          0 112 54 -28 50 2 blend
+          0 204 18 1 blend
+          rrcurveto
+          0 414 -78 1 blend
+          rlineto
+          -30 -136 1 blend
+          0 rlineto
+          0 -406 50 1 blend
+          rlineto
+          0 -182 -90 -54 -98 66 58 12 30 4 blend
+          0 rrcurveto
+          -96 28 1 blend
+          0 -88 54 58 -12 2 blend
+          0 182 -66 1 blend
+          rrcurveto
+          0 406 -50 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -414 78 1 blend
+          rlineto
+          0 -204 110 -54 106 -18 -22 -50 76 4 blend
+          0 rrcurveto
+          52 722 8 -36 2 blend
+          rmoveto
+          16 16 44 68 2 blend
+          rlineto
+          -152 120 -74 26 2 blend
+          rlineto
+          -20 -24 -50 -86 2 blend
+          rlineto
+          156 -112 80 -8 2 blend
+          rlineto
+        </CharString>
+        <CharString name="V">
+          1 vsindex
+          222 -44 1 blend
+          0 rmoveto
+          32 176 1 blend
+          0 rlineto
+          222 660 -26 -10 2 blend
+          rlineto
+          -32 -144 1 blend
+          0 rlineto
+          -132 -396 62 112 2 blend
+          rlineto
+          -27 -82 -17 -60 -28 -81 10 13 4 -7 10 11 6 blend
+          rrcurveto
+          -4 0 rlineto
+          -28 81 -18 60 -26 82 10 -11 4 7 10 -13 6 blend
+          rrcurveto
+          -124 396 60 -112 2 blend
+          rlineto
+          -34 -148 1 blend
+          0 rlineto
+          216 -660 -28 10 2 blend
+          rlineto
+        </CharString>
+        <CharString name="W">
+          182 -34 -60 1 blend
+          0 rmoveto
+          32 118 182 1 blend
+          0 rlineto
+          128 474 -54 -80 -130 -216 2 blend
+          rlineto
+          12 52 14 44 12 52 -1 -2 0 -2 -7 -7 2 10 -4 -5 8 -4 6 blend
+          rrcurveto
+          4 0 rlineto
+          12 -52 12 -44 12 -52 -4 -6 -8 4 -8 -4 -2 -10 0 -2 0 2 6 blend
+          rrcurveto
+          126 -474 -48 -76 130 216 2 blend
+          rlineto
+          32 120 186 1 blend
+          0 rlineto
+          154 660 -29 -44 -6 -10 2 blend
+          rlineto
+          -32 -81 -132 1 blend
+          0 rlineto
+          -90 -400 34 52 70 116 2 blend
+          rlineto
+          -16 -72 -14 -72 -16 -72 6 9 3 6 4 6 3 3 8 9 -4 3 6 blend
+          rrcurveto
+          -4 0 rlineto
+          -18 72 -18 72 -18 72 6 6 4 -3 3 6 -2 -2 3 6 -4 -7 6 blend
+          rrcurveto
+          -106 400 28 46 -70 -116 2 blend
+          rlineto
+          -36 -78 -108 1 blend
+          0 rlineto
+          -110 -400 32 46 70 116 2 blend
+          rlineto
+          -18 -72 -18 -72 -16 -72 3 6 3 5 5 6 3 3 4 4 -4 4 6 blend
+          rrcurveto
+          -4 0 rlineto
+          -16 72 -16 72 -16 72 8 9 4 -4 7 8 -4 -4 5 9 -2 -4 6 blend
+          rrcurveto
+          -86 400 30 52 -70 -116 2 blend
+          rlineto
+          -34 -88 -142 1 blend
+          0 rlineto
+          152 -660 -22 -40 6 10 2 blend
+          rlineto
+        </CharString>
+        <CharString name="X">
+          1 vsindex
+          18 -8 1 blend
+          0 rmoveto
+          32 152 1 blend
+          0 rlineto
+          122 212 -74 -96 2 blend
+          rlineto
+          18 32 18 32 22 -4 2 -4 2 -8 5 blend
+          40 rrcurveto
+          4 0 rlineto
+          24 -8 1 blend
+          -40 20 -32 18 -32 -6 -2 -2 -2 4 blend
+          rrcurveto
+          122 -212 -70 96 2 blend
+          rlineto
+          34 158 1 blend
+          0 rlineto
+          -200 340 24 -14 2 blend
+          rlineto
+          186 320 -20 4 2 blend
+          rlineto
+          -32 -152 1 blend
+          0 rlineto
+          -116 -204 78 98 2 blend
+          rlineto
+          -18 6 1 blend
+          -30 -12 -22 -20 -36 -2 -14 6 -6 4 blend
+          rrcurveto
+          -4 0 rlineto
+          -22 36 4 6 2 blend
+          -14 22 -18 14 4 2 blend
+          30 rrcurveto
+          -116 204 72 -98 2 blend
+          rlineto
+          -34 -158 1 blend
+          0 rlineto
+          186 -318 -20 2 2 blend
+          rlineto
+          -200 -342 24 8 2 blend
+          rlineto
+        </CharString>
+        <CharString name="Y">
+          202 -10 -16 1 blend
+          0 rmoveto
+          32 84 140 1 blend
+          0 rlineto
+          0 272 -29 -48 1 blend
+          rlineto
+          198 388 -1 -2 23 38 2 blend
+          rlineto
+          -32 -89 -148 1 blend
+          0 rlineto
+          -106 -214 35 58 47 78 2 blend
+          rlineto
+          -22 -48 -26 -46 -26 -48 3 5 -1 -1 6 9 1 1 5 9 -2 -3 6 blend
+          rrcurveto
+          -4 0 rlineto
+          -26 48 -22 46 -24 48 5 9 2 3 4 6 -1 -1 5 8 1 1 6 blend
+          rrcurveto
+          -106 214 35 58 -47 -78 2 blend
+          rlineto
+          -34 -90 -150 1 blend
+          0 rlineto
+          198 -388 -2 -2 -23 -38 2 blend
+          rlineto
+          0 -272 29 48 1 blend
+          rlineto
+        </CharString>
+        <CharString name="Yacute">
+          1 vsindex
+          202 -16 1 blend
+          0 rmoveto
+          32 140 1 blend
+          0 rlineto
+          0 272 -48 1 blend
+          rlineto
+          198 388 -2 38 2 blend
+          rlineto
+          -32 -148 1 blend
+          0 rlineto
+          -106 -214 58 78 2 blend
+          rlineto
+          -22 -48 -26 -46 -26 -48 5 -1 9 1 9 -3 6 blend
+          rrcurveto
+          -4 0 rlineto
+          -26 48 -22 46 -24 48 9 3 6 -1 8 1 6 blend
+          rrcurveto
+          -106 214 58 -78 2 blend
+          rlineto
+          -34 -150 1 blend
+          0 rlineto
+          198 -388 -2 -38 2 blend
+          rlineto
+          0 -272 48 1 blend
+          rlineto
+          -36 710 60 -36 2 blend
+          rmoveto
+          156 112 80 8 2 blend
+          rlineto
+          -20 24 -50 86 2 blend
+          rlineto
+          -152 -120 -74 -26 2 blend
+          rlineto
+          16 -16 44 -68 2 blend
+          rlineto
+        </CharString>
+        <CharString name="Z">
+          1 vsindex
+          52 -20 1 blend
+          0 rmoveto
+          436 44 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -396 128 1 blend
+          0 rlineto
+          392 614 -126 -212 2 blend
+          rlineto
+          0 18 86 1 blend
+          rlineto
+          -398 -54 1 blend
+          0 rlineto
+          0 -28 -116 1 blend
+          rlineto
+          358 -118 1 blend
+          0 rlineto
+          -392 -614 126 212 2 blend
+          rlineto
+          0 -18 -86 1 blend
+          rlineto
+        </CharString>
+        <CharString name="a">
+          198 -6 -10 1 blend
+          -12 rmoveto
+          64 -6 -10 1 blend
+          0 60 36 50 40 -12 -16 -8 -12 -6 -10 -2 -4 4 blend
+          rrcurveto
+          2 2 2 1 blend
+          0 rlineto
+          4 -64 6 8 10 16 2 blend
+          rlineto
+          26 70 114 1 blend
+          0 rlineto
+          0 310 -19 -32 1 blend
+          rlineto
+          0 96 -34 84 -112 41 68 -28 -44 -8 -14 -10 -18 4 blend
+          0 rrcurveto
+          -78 0 -66 -38 -30 -24 -4 -6 8 14 -24 -40 -10 -18 4 blend
+          rrcurveto
+          16 -22 26 44 -56 -88 2 blend
+          rlineto
+          30 22 58 34 68 14 22 4 6 -12 -20 -14 -22 -20 -32 5 blend
+          0 rrcurveto
+          100 -34 -56 1 blend
+          0 20 -86 -2 -78 0 2 44 70 4 6 28 42 4 blend
+          rrcurveto
+          -216 -24 -98 -50 14 24 2 4 12 18 -4 -8 4 blend
+          0 -107 -1 3 1 blend
+          rrcurveto
+          0 -91 64 -38 74 5 9 -4 -8 -20 -34 12 20 4 blend
+          0 rrcurveto
+          2 28 34 58 66 104 2 blend
+          rmoveto
+          -58 18 28 1 blend
+          0 -50 28 22 34 -12 -15 2 blend
+          0 74 -32 -51 1 blend
+          rrcurveto
+          0 82 72 48 210 24 -32 -54 -32 -46 -18 -22 -76 -128 -8 -12 5 blend
+          rrcurveto
+          0 -174 70 106 1 blend
+          rlineto
+          -64 -54 -52 -28 -58 28 46 20 34 22 36 12 14 18 30 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="aacute">
+          1 vsindex
+          198 -10 1 blend
+          -12 rmoveto
+          64 -10 1 blend
+          0 60 36 50 40 -16 -12 -10 -4 4 blend
+          rrcurveto
+          2 2 1 blend
+          0 rlineto
+          4 -64 8 16 2 blend
+          rlineto
+          26 114 1 blend
+          0 rlineto
+          0 310 -32 1 blend
+          rlineto
+          0 96 -34 84 -112 68 -44 -14 -18 4 blend
+          0 rrcurveto
+          -78 0 -66 -38 -30 -24 -6 14 -40 -18 4 blend
+          rrcurveto
+          16 -22 44 -88 2 blend
+          rlineto
+          30 22 58 34 68 22 6 -20 -22 -32 5 blend
+          0 rrcurveto
+          100 -56 1 blend
+          0 20 -86 -2 -78 2 70 6 42 4 blend
+          rrcurveto
+          -216 -24 -98 -50 24 4 18 -8 4 blend
+          0 -107 3 1 blend
+          rrcurveto
+          0 -91 64 -38 74 9 -8 -34 20 4 blend
+          0 rrcurveto
+          2 28 58 104 2 blend
+          rmoveto
+          -58 28 1 blend
+          0 -50 28 34 -15 2 blend
+          0 74 -51 1 blend
+          rrcurveto
+          0 82 72 48 210 24 -54 -46 -22 -128 -12 5 blend
+          rrcurveto
+          0 -174 106 1 blend
+          rlineto
+          -64 -54 -52 -28 -58 46 34 36 14 30 5 blend
+          0 rrcurveto
+          16 558 -24 -106 2 blend
+          rmoveto
+          148 150 82 8 2 blend
+          rlineto
+          -24 20 -72 94 2 blend
+          rlineto
+          -142 -154 -76 -34 2 blend
+          rlineto
+          18 -16 66 -68 2 blend
+          rlineto
+        </CharString>
+        <CharString name="acircumflex">
+          1 vsindex
+          198 -10 1 blend
+          -12 rmoveto
+          64 -10 1 blend
+          0 60 36 50 40 -16 -12 -10 -4 4 blend
+          rrcurveto
+          2 2 1 blend
+          0 rlineto
+          4 -64 8 16 2 blend
+          rlineto
+          26 114 1 blend
+          0 rlineto
+          0 310 -32 1 blend
+          rlineto
+          0 96 -34 84 -112 68 -44 -14 -18 4 blend
+          0 rrcurveto
+          -78 0 -66 -38 -30 -24 -6 14 -40 -18 4 blend
+          rrcurveto
+          16 -22 44 -88 2 blend
+          rlineto
+          30 22 58 34 68 22 6 -20 -22 -32 5 blend
+          0 rrcurveto
+          100 -56 1 blend
+          0 20 -86 -2 -78 2 70 6 42 4 blend
+          rrcurveto
+          -216 -24 -98 -50 24 4 18 -8 4 blend
+          0 -107 3 1 blend
+          rrcurveto
+          0 -91 64 -38 74 9 -8 -34 20 4 blend
+          0 rrcurveto
+          2 28 58 104 2 blend
+          rmoveto
+          -58 28 1 blend
+          0 -50 28 34 -15 2 blend
+          0 74 -51 1 blend
+          rrcurveto
+          0 82 72 48 210 24 -54 -46 -22 -128 -12 5 blend
+          rrcurveto
+          0 -174 106 1 blend
+          rlineto
+          -64 -54 -52 -28 -58 46 34 36 14 30 5 blend
+          0 rrcurveto
+          -54 558 -44 -120 2 blend
+          rmoveto
+          112 130 16 -46 2 blend
+          rlineto
+          4 0 rlineto
+          112 -130 16 46 2 blend
+          rlineto
+          18 16 46 44 2 blend
+          rlineto
+          -118 146 12 -18 2 blend
+          rlineto
+          -28 -148 1 blend
+          0 rlineto
+          -118 -146 12 18 2 blend
+          rlineto
+          18 -16 46 -44 2 blend
+          rlineto
+        </CharString>
+        <CharString name="acute">
+          1 vsindex
+          222 574 18 -2 2 blend
+          rmoveto
+          148 150 82 8 2 blend
+          rlineto
+          -24 20 -72 94 2 blend
+          rlineto
+          -142 -154 -76 -34 2 blend
+          rlineto
+          18 -16 66 -68 2 blend
+          rlineto
+        </CharString>
+        <CharString name="adieresis">
+          1 vsindex
+          198 -10 1 blend
+          -12 rmoveto
+          64 -10 1 blend
+          0 60 36 50 40 -16 -12 -10 -4 4 blend
+          rrcurveto
+          2 2 1 blend
+          0 rlineto
+          4 -64 8 16 2 blend
+          rlineto
+          26 114 1 blend
+          0 rlineto
+          0 310 -32 1 blend
+          rlineto
+          0 96 -34 84 -112 68 -44 -14 -18 4 blend
+          0 rrcurveto
+          -78 0 -66 -38 -30 -24 -6 14 -40 -18 4 blend
+          rrcurveto
+          16 -22 44 -88 2 blend
+          rlineto
+          30 22 58 34 68 22 6 -20 -22 -32 5 blend
+          0 rrcurveto
+          100 -56 1 blend
+          0 20 -86 -2 -78 2 70 6 42 4 blend
+          rrcurveto
+          -216 -24 -98 -50 24 4 18 -8 4 blend
+          0 -107 3 1 blend
+          rrcurveto
+          0 -91 64 -38 74 9 -8 -34 20 4 blend
+          0 rrcurveto
+          2 28 58 104 2 blend
+          rmoveto
+          -58 28 1 blend
+          0 -50 28 34 -15 2 blend
+          0 74 -51 1 blend
+          rrcurveto
+          0 82 72 48 210 24 -54 -46 -22 -128 -12 5 blend
+          rrcurveto
+          0 -174 106 1 blend
+          rlineto
+          -64 -54 -52 -28 -58 46 34 36 14 30 5 blend
+          0 rrcurveto
+          -26 586 -56 -144 2 blend
+          rmoveto
+          18 29 1 blend
+          0 14 14 19 21 2 blend
+          0 18 27 1 blend
+          rrcurveto
+          0 18 -14 14 -18 27 -19 21 -29 4 blend
+          0 rrcurveto
+          -18 -29 1 blend
+          0 -14 -14 -19 -21 2 blend
+          0 -18 -27 1 blend
+          rrcurveto
+          0 -18 14 -14 18 -27 19 -21 29 4 blend
+          0 rrcurveto
+          172 56 1 blend
+          0 rmoveto
+          18 29 1 blend
+          0 14 14 19 21 2 blend
+          0 18 27 1 blend
+          rrcurveto
+          0 18 -14 14 -18 27 -19 21 -29 4 blend
+          0 rrcurveto
+          -18 -29 1 blend
+          0 -14 -14 -19 -21 2 blend
+          0 -18 -27 1 blend
+          rrcurveto
+          0 -18 14 -14 18 -27 19 -21 29 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="ae">
+          198 -6 -10 1 blend
+          -12 rmoveto
+          60 4 7 1 blend
+          0 82 40 62 62 -20 -33 -14 -23 6 10 -4 -7 4 blend
+          rrcurveto
+          34 -50 50 -52 88 6 9 2 5 4 7 16 25 -11 -18 5 blend
+          0 rrcurveto
+          72 -9 -16 1 blend
+          0 36 20 36 1 blend
+          20 36 26 12 18 6 12 2 blend
+          rrcurveto
+          -14 22 -26 -40 52 80 2 blend
+          rlineto
+          -34 -26 -40 -14 -54 -2 -2 4 6 6 6 2 4 12 20 5 blend
+          0 rrcurveto
+          -102 32 50 1 blend
+          0 -78 94 2 128 26 36 -50 -68 -14 -14 -42 -72 4 blend
+          rrcurveto
+          338 -38 -62 1 blend
+          0 rlineto
+          2 12 0 10 3 4 14 14 2 blend
+          0 10 12 20 1 blend
+          rrcurveto
+          0 142 -5 -8 1 blend
+          -66 78 -110 21 34 -15 -26 2 blend
+          0 rrcurveto
+          -72 8 16 1 blend
+          0 -64 -50 -34 -76 12 22 16 28 -4 -10 20 34 4 blend
+          rrcurveto
+          -14 76 -46 50 -80 -8 -18 -20 -36 -4 -2 -16 -26 13 22 5 blend
+          0 rrcurveto
+          -72 4 0 1 blend
+          0 -66 -38 -30 -24 -5 -2 8 14 -24 -40 -10 -18 4 blend
+          rrcurveto
+          16 -22 26 44 -56 -88 2 blend
+          rlineto
+          30 22 58 34 62 14 22 4 6 -12 -20 -14 -22 -16 -26 5 blend
+          0 rrcurveto
+          100 -33 -55 1 blend
+          0 20 -86 -2 -78 -1 -1 46 69 4 6 26 43 4 blend
+          rrcurveto
+          -208 -24 -100 -50 10 18 3 4 12 20 -5 -8 4 blend
+          0 -108 0 4 1 blend
+          rrcurveto
+          0 -90 64 -38 74 4 8 -4 -8 -20 -34 12 20 4 blend
+          0 rrcurveto
+          2 28 35 58 66 104 2 blend
+          rmoveto
+          -58 17 28 1 blend
+          0 -50 28 22 34 -12 -15 2 blend
+          0 74 -30 -51 1 blend
+          rrcurveto
+          0 82 76 48 200 24 -33 -53 -31 -47 -19 -23 -75 -125 -8 -12 5 blend
+          rrcurveto
+          0 -28 2 2 6 9 2 blend
+          rlineto
+          0 -48 8 -50 14 -30 3 2 19 31 -4 -4 24 32 -5 -8 7 12 6 blend
+          rrcurveto
+          -58 -64 -78 -36 -54 23 38 28 46 33 55 18 24 15 25 5 blend
+          0 rrcurveto
+          198 248 13 18 -34 -60 2 blend
+          rmoveto
+          10 116 70 82 84 -1 0 -48 -66 -27 -44 -34 -58 -28 -46 5 blend
+          0 rrcurveto
+          90 -30 -52 1 blend
+          0 56 -66 -24 -32 22 38 2 blend
+          0 -132 60 86 1 blend
+          rrcurveto
+          -310 110 174 1 blend
+          0 rlineto
+        </CharString>
+        <CharString name="agrave">
+          1 vsindex
+          198 -10 1 blend
+          -12 rmoveto
+          64 -10 1 blend
+          0 60 36 50 40 -16 -12 -10 -4 4 blend
+          rrcurveto
+          2 2 1 blend
+          0 rlineto
+          4 -64 8 16 2 blend
+          rlineto
+          26 114 1 blend
+          0 rlineto
+          0 310 -32 1 blend
+          rlineto
+          0 96 -34 84 -112 68 -44 -14 -18 4 blend
+          0 rrcurveto
+          -78 0 -66 -38 -30 -24 -6 14 -40 -18 4 blend
+          rrcurveto
+          16 -22 44 -88 2 blend
+          rlineto
+          30 22 58 34 68 22 6 -20 -22 -32 5 blend
+          0 rrcurveto
+          100 -56 1 blend
+          0 20 -86 -2 -78 2 70 6 42 4 blend
+          rrcurveto
+          -216 -24 -98 -50 24 4 18 -8 4 blend
+          0 -107 3 1 blend
+          rrcurveto
+          0 -91 64 -38 74 9 -8 -34 20 4 blend
+          0 rrcurveto
+          2 28 58 104 2 blend
+          rmoveto
+          -58 28 1 blend
+          0 -50 28 34 -15 2 blend
+          0 74 -51 1 blend
+          rrcurveto
+          0 82 72 48 210 24 -54 -46 -22 -128 -12 5 blend
+          rrcurveto
+          0 -174 106 1 blend
+          rlineto
+          -64 -54 -52 -28 -58 46 34 36 14 30 5 blend
+          0 rrcurveto
+          104 558 -32 -106 2 blend
+          rmoveto
+          18 16 66 68 2 blend
+          rlineto
+          -142 154 -76 34 2 blend
+          rlineto
+          -24 -20 -72 -94 2 blend
+          rlineto
+          148 -150 82 -8 2 blend
+          rlineto
+        </CharString>
+        <CharString name="ampersand">
+          1 vsindex
+          224 22 1 blend
+          -12 rmoveto
+          78 38 1 blend
+          0 58 40 50 56 32 6 14 14 4 blend
+          rrcurveto
+          58 69 42 91 28 16 14 6 -2 2 5 blend
+          98 rrcurveto
+          -30 -126 1 blend
+          0 rlineto
+          -26 -94 -38 -82 -56 -64 4 12 -4 18 6 16 6 blend
+          rrcurveto
+          -44 -50 -56 -36 -62 2 12 10 12 20 5 blend
+          0 rrcurveto
+          -84 32 1 blend
+          0 -72 60 40 -32 2 blend
+          0 92 -52 1 blend
+          rrcurveto
+          0 164 294 60 -54 -20 -24 3 blend
+          0 164 12 1 blend
+          rrcurveto
+          0 66 -36 50 -68 28 -32 10 -36 4 blend
+          0 rrcurveto
+          -76 -40 1 blend
+          0 -54 -60 -18 -22 2 blend
+          0 -84 -10 1 blend
+          rrcurveto
+          0 -146 134 -186 128 -114 19 12 9 43 7 5 blend
+          rrcurveto
+          54 -48 50 -30 42 -16 16 4 25 -1 28 4 6 blend
+          rrcurveto
+          12 28 28 110 2 blend
+          rlineto
+          -42 16 -48 30 -50 44 -1 -11 -6 -8 -5 -14 6 blend
+          rrcurveto
+          -120 104 -130 182 -16 -29 -13 -50 4 blend
+          0 138 -42 1 blend
+          rrcurveto
+          0 62 36 52 62 -20 -12 -30 -35 4 blend
+          0 rrcurveto
+          56 -31 1 blend
+          0 20 -46 -7 32 2 blend
+          0 -44 16 1 blend
+          rrcurveto
+          0 -152 -296 -56 30 -10 66 3 blend
+          0 -180 -40 1 blend
+          rrcurveto
+          0 -110 86 -68 100 12 -13 -22 51 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="aring">
+          1 vsindex
+          198 -10 1 blend
+          -12 rmoveto
+          64 -10 1 blend
+          0 60 36 50 40 -16 -12 -10 -4 4 blend
+          rrcurveto
+          2 2 1 blend
+          0 rlineto
+          4 -64 8 16 2 blend
+          rlineto
+          26 114 1 blend
+          0 rlineto
+          0 310 -32 1 blend
+          rlineto
+          0 96 -34 84 -112 68 -44 -14 -18 4 blend
+          0 rrcurveto
+          -78 0 -66 -38 -30 -24 -6 14 -40 -18 4 blend
+          rrcurveto
+          16 -22 44 -88 2 blend
+          rlineto
+          30 22 58 34 68 22 6 -20 -22 -32 5 blend
+          0 rrcurveto
+          100 -56 1 blend
+          0 20 -86 -2 -78 2 70 6 42 4 blend
+          rrcurveto
+          -216 -24 -98 -50 24 4 18 -8 4 blend
+          0 -107 3 1 blend
+          rrcurveto
+          0 -91 64 -38 74 9 -8 -34 20 4 blend
+          0 rrcurveto
+          2 28 58 104 2 blend
+          rmoveto
+          -58 28 1 blend
+          0 -50 28 34 -15 2 blend
+          0 74 -51 1 blend
+          rrcurveto
+          0 82 72 48 210 24 -54 -46 -22 -128 -12 5 blend
+          rrcurveto
+          0 -174 106 1 blend
+          rlineto
+          -64 -54 -52 -28 -58 46 34 36 14 30 5 blend
+          0 rrcurveto
+          60 530 -28 -82 2 blend
+          rmoveto
+          52 42 1 blend
+          0 40 38 6 10 2 blend
+          0 56 2 1 blend
+          rrcurveto
+          0 56 -40 38 -52 2 -6 10 -42 4 blend
+          0 rrcurveto
+          -52 -42 1 blend
+          0 -40 -38 -6 -10 2 blend
+          0 -56 -2 1 blend
+          rrcurveto
+          0 -56 40 -38 52 -2 6 -10 42 4 blend
+          0 rrcurveto
+          0 22 40 1 blend
+          rmoveto
+          -38 17 1 blend
+          0 -30 28 13 -10 2 blend
+          0 44 -18 1 blend
+          rrcurveto
+          0 44 30 28 38 -18 -13 -10 -17 4 blend
+          0 rrcurveto
+          38 -17 1 blend
+          0 30 -28 -13 10 2 blend
+          0 -44 18 1 blend
+          rrcurveto
+          0 -44 -30 -28 -38 18 13 10 17 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="asciicircum">
+          1 vsindex
+          68 292 -22 -22 2 blend
+          rmoveto
+          32 108 1 blend
+          0 rlineto
+          82 214 -44 -104 2 blend
+          rlineto
+          52 132 -8 4 2 blend
+          rlineto
+          4 0 rlineto
+          52 -132 -8 -4 2 blend
+          rlineto
+          82 -214 -44 104 2 blend
+          rlineto
+          32 108 1 blend
+          0 rlineto
+          -150 378 -6 22 2 blend
+          rlineto
+          -36 -100 1 blend
+          0 rlineto
+          -150 -378 -6 -22 2 blend
+          rlineto
+        </CharString>
+        <CharString name="asciitilde">
+          1 vsindex
+          326 270 28 -36 2 blend
+          rmoveto
+          38 14 1 blend
+          0 40 26 26 52 14 2 28 28 4 blend
+          rrcurveto
+          -22 14 -66 54 2 blend
+          rlineto
+          -24 -48 -26 -16 -30 4 14 3 -6 3 5 blend
+          0 rrcurveto
+          -58 4 1 blend
+          0 -48 92 -76 16 -20 -8 3 blend
+          0 rrcurveto
+          -38 -14 1 blend
+          0 -40 -26 -26 -54 -14 -2 -28 -26 4 blend
+          rrcurveto
+          22 -12 66 -56 2 blend
+          rlineto
+          24 48 26 16 30 -4 -14 -2 6 -4 5 blend
+          0 rrcurveto
+          58 -4 1 blend
+          0 48 -92 76 -16 20 8 3 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="asterisk">
+          1 vsindex
+          130 478 22 -157 2 blend
+          rmoveto
+          64 82 20 9 2 blend
+          rlineto
+          62 -82 22 -9 2 blend
+          rlineto
+          22 16 48 35 2 blend
+          rlineto
+          -54 86 -7 21 2 blend
+          rlineto
+          88 34 25 18 2 blend
+          rlineto
+          -8 24 -19 59 2 blend
+          rlineto
+          -92 -24 -29 -1 2 blend
+          rlineto
+          -6 98 -8 25 2 blend
+          rlineto
+          -26 -62 1 blend
+          0 rlineto
+          -6 -100 -8 -22 2 blend
+          rlineto
+          -92 26 -29 -2 2 blend
+          rlineto
+          -8 -24 -19 -59 2 blend
+          rlineto
+          88 -34 24 -18 2 blend
+          rlineto
+          -54 -86 -6 -21 2 blend
+          rlineto
+          22 -16 48 -35 2 blend
+          rlineto
+        </CharString>
+        <CharString name="at">
+          382 -142 34 56 -22 -36 2 blend
+          rmoveto
+          68 2 4 1 blend
+          0 62 18 56 36 1 2 -2 -4 4 6 -2 -4 4 blend
+          rrcurveto
+          -14 24 -17 -22 50 68 2 blend
+          rlineto
+          -48 -30 -54 -20 -68 6 8 8 10 -2 -6 4 4 13 20 5 blend
+          0 rrcurveto
+          -182 27 32 1 blend
+          0 -120 124 -6 -20 -26 -36 2 blend
+          0 194 -6 4 1 blend
+          rrcurveto
+          0 240 174 156 184 -20 -18 -10 -6 -12 -12 -17 -16 4 blend
+          0 rrcurveto
+          170 9 32 1 blend
+          0 110 -110 -28 -40 -8 -22 2 blend
+          0 -176 32 40 1 blend
+          rrcurveto
+          0 -146 -82 -82 -64 32 44 24 28 10 14 9 4 4 blend
+          0 rrcurveto
+          -64 21 24 1 blend
+          0 -22 46 24 96 8 8 -16 -22 -11 -12 -32 -46 4 blend
+          rrcurveto
+          34 184 9 14 32 44 2 blend
+          rlineto
+          -26 -52 -78 1 blend
+          0 rlineto
+          -8 -40 -6 -8 0 -2 2 blend
+          rlineto
+          -2 -2 0 1 blend
+          0 rlineto
+          -20 32 -28 16 -36 4 4 3 4 6 2 -1 -2 -8 4 5 blend
+          0 rrcurveto
+          -118 4 4 1 blend
+          0 -66 -128 -18 -26 0 6 2 blend
+          0 -94 -24 -34 1 blend
+          rrcurveto
+          0 -90 52 -44 60 -8 -2 4 2 -10 -18 16 22 4 blend
+          0 rrcurveto
+          46 -2 -6 1 blend
+          0 40 32 36 38 8 14 -6 -6 -8 -10 4 2 4 blend
+          rrcurveto
+          2 2 0 1 blend
+          0 rlineto
+          4 -52 38 -24 52 6 8 4 4 5 11 -4 -4 5 7 5 blend
+          0 rrcurveto
+          80 20 30 1 blend
+          0 98 90 20 30 3 2 2 blend
+          0 168 15 18 1 blend
+          rrcurveto
+          0 188 -118 124 -190 15 26 -16 -24 17 28 -22 -32 4 blend
+          0 rrcurveto
+          -206 -32 -48 1 blend
+          0 -184 -168 -16 -26 -12 -20 2 blend
+          0 -258 -16 -26 1 blend
+          rrcurveto
+          0 -216 138 -128 192 -28 -48 32 50 4 8 8 10 4 blend
+          0 rrcurveto
+          -26 234 13 22 62 94 2 blend
+          rmoveto
+          -46 15 16 1 blend
+          0 -38 28 14 22 -4 -7 2 blend
+          0 80 -31 -43 1 blend
+          rrcurveto
+          0 88 58 104 94 -23 -34 -16 -26 -18 -26 -32 -42 4 blend
+          0 rrcurveto
+          32 -8 -14 1 blend
+          0 20 -12 26 -40 -4 -5 2 2 -10 -19 16 26 4 blend
+          rrcurveto
+          -32 -178 6 10 38 52 2 blend
+          rlineto
+          -42 -48 -38 -22 -34 12 20 12 18 14 22 8 12 9 16 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="atilde">
+          1 vsindex
+          198 -10 1 blend
+          -12 rmoveto
+          64 -10 1 blend
+          0 60 36 50 40 -16 -12 -10 -4 4 blend
+          rrcurveto
+          2 2 1 blend
+          0 rlineto
+          4 -64 8 16 2 blend
+          rlineto
+          26 114 1 blend
+          0 rlineto
+          0 310 -32 1 blend
+          rlineto
+          0 96 -34 84 -112 68 -44 -14 -18 4 blend
+          0 rrcurveto
+          -78 0 -66 -38 -30 -24 -6 14 -40 -18 4 blend
+          rrcurveto
+          16 -22 44 -88 2 blend
+          rlineto
+          30 22 58 34 68 22 6 -20 -22 -32 5 blend
+          0 rrcurveto
+          100 -56 1 blend
+          0 20 -86 -2 -78 2 70 6 42 4 blend
+          rrcurveto
+          -216 -24 -98 -50 24 4 18 -8 4 blend
+          0 -107 3 1 blend
+          rrcurveto
+          0 -91 64 -38 74 9 -8 -34 20 4 blend
+          0 rrcurveto
+          2 28 58 104 2 blend
+          rmoveto
+          -58 28 1 blend
+          0 -50 28 34 -15 2 blend
+          0 74 -51 1 blend
+          rrcurveto
+          0 82 72 48 210 24 -54 -46 -22 -128 -12 5 blend
+          rrcurveto
+          0 -174 106 1 blend
+          rlineto
+          -64 -54 -52 -28 -58 46 34 36 14 30 5 blend
+          0 rrcurveto
+          137 564 -41 -112 2 blend
+          rmoveto
+          63 17 1 blend
+          0 16 66 4 56 34 -21 -2 57 4 blend
+          rrcurveto
+          -26 2 -80 4 2 blend
+          rlineto
+          -2 -52 -16 -46 -37 -2 16 6 36 21 5 blend
+          0 rrcurveto
+          -59 33 1 blend
+          0 -20 100 -76 -18 -44 16 3 blend
+          0 rrcurveto
+          -64 -16 1 blend
+          0 -16 -65 -4 -57 -34 20 2 -56 4 blend
+          rrcurveto
+          26 -2 80 -4 2 blend
+          rlineto
+          2 54 16 44 38 2 -18 -6 -34 -22 5 blend
+          0 rrcurveto
+          58 -32 1 blend
+          0 20 -100 77 18 44 -17 3 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="b">
+          1 vsindex
+          274 62 1 blend
+          -12 rmoveto
+          114 -8 1 blend
+          0 98 96 4 2 2 blend
+          0 162 11 1 blend
+          rrcurveto
+          0 148 -62 96 -130 5 -15 4 12 4 blend
+          0 rrcurveto
+          -60 16 1 blend
+          0 -60 -36 -50 -42 16 18 15 10 4 blend
+          rrcurveto
+          2 96 2 -24 2 blend
+          rlineto
+          0 214 -52 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -722 26 1 blend
+          rlineto
+          26 108 1 blend
+          0 rlineto
+          4 48 10 6 2 blend
+          rlineto
+          2 2 1 blend
+          0 rlineto
+          46 -36 54 -24 46 -8 -8 -10 2 -2 5 blend
+          0 rrcurveto
+          2 28 -44 112 2 blend
+          rmoveto
+          -38 16 1 blend
+          0 -56 18 -56 48 34 -12 36 -30 4 blend
+          rrcurveto
+          0 296 -112 1 blend
+          rlineto
+          60 54 56 30 50 -38 -28 -36 -20 -24 5 blend
+          0 rrcurveto
+          118 -72 1 blend
+          0 44 -94 -20 60 2 blend
+          0 -122 40 1 blend
+          rrcurveto
+          0 -134 -74 -96 -104 38 40 64 64 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="backslash">
+          1 vsindex
+          322 -112 1 blend
+          -160 rmoveto
+          30 80 1 blend
+          0 rlineto
+          -320 144 1 blend
+          870 rlineto
+          -30 -80 1 blend
+          0 rlineto
+          320 -144 1 blend
+          -870 rlineto
+        </CharString>
+        <CharString name="bar">
+          1 vsindex
+          96 -12 1 blend
+          -250 rmoveto
+          28 82 1 blend
+          0 rlineto
+          0 1000 rlineto
+          -28 -82 1 blend
+          0 rlineto
+          0 -1000 rlineto
+        </CharString>
+        <CharString name="braceleft">
+          1 vsindex
+          222 16 1 blend
+          -152 rmoveto
+          30 40 1 blend
+          0 rlineto
+          0 22 68 1 blend
+          rlineto
+          -32 16 1 blend
+          0 rlineto
+          -64 27 1 blend
+          0 -16 36 5 -26 2 blend
+          0 72 -20 1 blend
+          rrcurveto
+          0 66 6 56 -15 -2 -9 3 blend
+          0 74 -16 1 blend
+          rrcurveto
+          0 54 -10 36 -38 26 -17 -8 -15 4 blend
+          12 rrcurveto
+          0 4 rlineto
+          38 15 1 blend
+          12 10 34 17 -6 2 blend
+          0 56 24 1 blend
+          rrcurveto
+          0 74 -6 56 -16 2 -9 3 blend
+          0 66 -15 1 blend
+          rrcurveto
+          0 72 16 36 64 -20 -5 -26 -27 4 blend
+          0 rrcurveto
+          32 -16 1 blend
+          0 rlineto
+          0 22 68 1 blend
+          rlineto
+          -30 -40 1 blend
+          0 rlineto
+          -72 -20 1 blend
+          0 -36 -26 -4 -10 2 blend
+          0 -100 -10 1 blend
+          rrcurveto
+          0 -74 8 -66 4 2 36 3 blend
+          0 -72 10 1 blend
+          rrcurveto
+          0 -40 -16 -40 -70 0 6 -6 4 6 -2 5 blend
+          rrcurveto
+          0 -24 -76 1 blend
+          rlineto
+          70 0 16 -40 -6 -2 6 4 4 blend
+          0 -42 8 1 blend
+          rrcurveto
+          0 -70 -8 -66 8 -2 36 3 blend
+          0 -74 4 1 blend
+          rrcurveto
+          0 -100 36 -26 72 -10 4 -10 20 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="braceright">
+          1 vsindex
+          18 34 1 blend
+          -152 rmoveto
+          30 40 1 blend
+          0 rlineto
+          72 20 1 blend
+          0 36 26 4 10 2 blend
+          0 100 10 1 blend
+          rrcurveto
+          0 74 -8 66 -4 -2 -36 3 blend
+          0 70 -8 1 blend
+          rrcurveto
+          0 42 16 40 70 0 -8 6 -4 -6 2 5 blend
+          rrcurveto
+          0 24 76 1 blend
+          rlineto
+          -70 0 -16 40 6 2 -6 -4 4 blend
+          0 40 -6 1 blend
+          rrcurveto
+          0 72 8 66 -10 2 -36 3 blend
+          0 74 -4 1 blend
+          rrcurveto
+          0 100 -36 26 -72 10 -4 10 -20 4 blend
+          0 rrcurveto
+          -30 -40 1 blend
+          0 rlineto
+          0 -22 -68 1 blend
+          rlineto
+          32 -16 1 blend
+          0 rlineto
+          64 -27 1 blend
+          0 16 -36 -5 26 2 blend
+          0 -72 20 1 blend
+          rrcurveto
+          0 -66 -6 -56 15 2 9 3 blend
+          0 -74 16 1 blend
+          rrcurveto
+          0 -56 10 -34 38 -24 17 6 15 4 blend
+          -12 rrcurveto
+          0 -4 rlineto
+          -38 -15 1 blend
+          -12 -10 -36 -17 8 2 blend
+          0 -54 -26 1 blend
+          rrcurveto
+          0 -74 6 -56 16 -2 9 3 blend
+          0 -66 15 1 blend
+          rrcurveto
+          0 -72 -16 -36 -64 20 5 26 27 4 blend
+          0 rrcurveto
+          -32 16 1 blend
+          0 rlineto
+          0 -22 -68 1 blend
+          rlineto
+        </CharString>
+        <CharString name="bracketleft">
+          1 vsindex
+          100 -16 1 blend
+          -152 rmoveto
+          152 72 1 blend
+          0 rlineto
+          0 22 68 1 blend
+          rlineto
+          -128 32 1 blend
+          0 rlineto
+          0 816 -136 1 blend
+          rlineto
+          128 -32 1 blend
+          0 rlineto
+          0 22 68 1 blend
+          rlineto
+          -152 -72 1 blend
+          0 rlineto
+          0 -860 rlineto
+        </CharString>
+        <CharString name="bracketright">
+          1 vsindex
+          18 34 1 blend
+          -152 rmoveto
+          152 72 1 blend
+          0 rlineto
+          0 860 rlineto
+          -152 -72 1 blend
+          0 rlineto
+          0 -22 -68 1 blend
+          rlineto
+          128 -32 1 blend
+          0 rlineto
+          0 -816 136 1 blend
+          rlineto
+          -128 32 1 blend
+          0 rlineto
+          0 -22 -68 1 blend
+          rlineto
+        </CharString>
+        <CharString name="brokenbar">
+          1 vsindex
+          96 274 -12 46 2 blend
+          rmoveto
+          28 82 1 blend
+          0 rlineto
+          0 476 -46 1 blend
+          rlineto
+          -28 -82 1 blend
+          0 rlineto
+          0 -476 46 1 blend
+          rlineto
+          0 -524 -46 1 blend
+          rmoveto
+          28 82 1 blend
+          0 rlineto
+          0 472 -22 1 blend
+          rlineto
+          -28 -82 1 blend
+          0 rlineto
+          0 -472 22 1 blend
+          rlineto
+        </CharString>
+        <CharString name="c">
+          1 vsindex
+          268 16 1 blend
+          -12 rmoveto
+          62 -10 1 blend
+          0 50 26 40 38 14 -12 10 6 4 blend
+          rrcurveto
+          -18 20 -48 88 2 blend
+          rlineto
+          -33 -31 -47 -25 -54 9 13 21 15 24 5 blend
+          0 rrcurveto
+          -110 56 1 blend
+          0 -72 90 30 -42 2 blend
+          0 132 -56 1 blend
+          rrcurveto
+          0 132 80 92 102 -56 -42 -44 -38 4 blend
+          0 rrcurveto
+          52 -34 1 blend
+          0 40 -22 30 -30 -24 18 -8 14 4 blend
+          rrcurveto
+          18 20 62 86 2 blend
+          rlineto
+          -32 -6 1 blend
+          32 -42 28 -66 -6 -8 6 3 blend
+          0 rrcurveto
+          -114 -28 1 blend
+          0 -100 -92 -26 -4 2 blend
+          0 -160 -6 1 blend
+          rrcurveto
+          0 -158 92 -92 122 -8 18 -4 20 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="ccedilla">
+          1 vsindex
+          268 16 1 blend
+          -12 rmoveto
+          62 -10 1 blend
+          0 50 26 40 38 14 -12 10 6 4 blend
+          rrcurveto
+          -18 20 -48 88 2 blend
+          rlineto
+          -33 -31 -47 -25 -54 9 13 21 15 24 5 blend
+          0 rrcurveto
+          -110 56 1 blend
+          0 -72 90 30 -42 2 blend
+          0 132 -56 1 blend
+          rrcurveto
+          0 132 80 92 102 -56 -42 -44 -38 4 blend
+          0 rrcurveto
+          52 -34 1 blend
+          0 40 -22 30 -30 -24 18 -8 14 4 blend
+          rrcurveto
+          18 20 62 86 2 blend
+          rlineto
+          -32 -6 1 blend
+          32 -42 28 -66 -6 -8 6 3 blend
+          0 rrcurveto
+          -114 -28 1 blend
+          0 -100 -92 -26 -4 2 blend
+          0 -160 -6 1 blend
+          rrcurveto
+          0 -158 92 -92 122 -8 18 -4 20 4 blend
+          0 rrcurveto
+          -72 -204 -60 -28 2 blend
+          rmoveto
+          90 6 48 26 42 -2 30 6 4 blend
+          0 50 22 1 blend
+          rrcurveto
+          0 40 -28 18 -42 10 2 2 4 -10 2 5 blend
+          rrcurveto
+          30 68 -2 -4 2 blend
+          rlineto
+          -28 -70 1 blend
+          0 rlineto
+          -40 -86 -10 -14 2 blend
+          rlineto
+          54 8 1 blend
+          -8 24 -10 1 blend
+          -14 0 -30 12 1 blend
+          rrcurveto
+          0 -30 -26 -18 -88 -6 2 2 8 12 2 5 blend
+          rrcurveto
+          6 -26 6 -40 2 blend
+          rlineto
+        </CharString>
+        <CharString name="cedilla">
+          1 vsindex
+          202 -216 -30 -28 2 blend
+          rmoveto
+          90 6 48 26 42 -2 30 6 4 blend
+          0 50 22 1 blend
+          rrcurveto
+          0 40 -28 18 -42 10 2 2 4 -10 2 5 blend
+          rrcurveto
+          30 68 -2 -4 2 blend
+          rlineto
+          -28 -70 1 blend
+          0 rlineto
+          -40 -86 -10 -14 2 blend
+          rlineto
+          54 8 1 blend
+          -8 24 -10 1 blend
+          -14 0 -30 12 1 blend
+          rrcurveto
+          0 -30 -26 -18 -88 -6 2 2 8 12 2 5 blend
+          rrcurveto
+          6 -26 6 -40 2 blend
+          rlineto
+        </CharString>
+        <CharString name="cent">
+          1 vsindex
+          276 84 56 -40 2 blend
+          rmoveto
+          62 -10 1 blend
+          0 50 28 40 36 16 -10 10 8 4 blend
+          rrcurveto
+          -18 20 -50 88 2 blend
+          rlineto
+          -34 -31 -46 -25 -54 12 15 20 9 22 5 blend
+          0 rrcurveto
+          -110 28 1 blend
+          0 -72 80 28 -32 2 blend
+          0 120 -44 1 blend
+          rrcurveto
+          0 120 80 80 102 -44 -40 -32 -10 4 blend
+          0 rrcurveto
+          50 -32 1 blend
+          0 40 -22 32 -30 -22 16 -10 12 4 blend
+          rrcurveto
+          18 20 60 86 2 blend
+          rlineto
+          -32 30 -42 30 -66 -2 4 -10 -8 6 5 blend
+          0 rrcurveto
+          -114 -48 1 blend
+          0 -100 -80 -26 -16 2 blend
+          0 -148 -18 1 blend
+          rrcurveto
+          0 -146 92 -82 122 -20 16 -14 42 4 blend
+          0 rrcurveto
+          -24 -110 -28 22 2 blend
+          rmoveto
+          28 64 1 blend
+          0 rlineto
+          0 678 22 1 blend
+          rlineto
+          -28 -64 1 blend
+          0 rlineto
+          0 -678 -22 1 blend
+          rlineto
+        </CharString>
+        <CharString name="colon">
+          1 vsindex
+          104 378 56 -80 2 blend
+          rmoveto
+          18 40 1 blend
+          0 18 14 24 32 2 blend
+          0 24 34 1 blend
+          rrcurveto
+          0 26 -18 14 -18 32 -24 32 -40 4 blend
+          0 rrcurveto
+          -18 -40 1 blend
+          0 -18 -14 -24 -32 2 blend
+          0 -26 -32 1 blend
+          rrcurveto
+          0 -24 18 -14 18 -34 24 -32 40 4 blend
+          0 rrcurveto
+          0 -390 80 1 blend
+          rmoveto
+          18 40 1 blend
+          0 18 14 24 32 2 blend
+          0 24 34 1 blend
+          rrcurveto
+          0 26 -18 14 -18 32 -24 32 -40 4 blend
+          0 rrcurveto
+          -18 -40 1 blend
+          0 -18 -14 -24 -32 2 blend
+          0 -26 -32 1 blend
+          rrcurveto
+          0 -24 18 -14 18 -34 24 -32 40 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="comma">
+          1 vsindex
+          60 -150 20 -54 2 blend
+          rmoveto
+          52 32 40 54 78 4 28 36 4 blend
+          0 68 50 1 blend
+          rrcurveto
+          0 38 -18 24 -26 60 -22 34 -48 4 blend
+          0 rrcurveto
+          -18 -40 1 blend
+          0 -18 -12 -28 -26 2 blend
+          0 -24 -32 1 blend
+          rrcurveto
+          0 -24 16 -12 20 -36 32 -22 32 4 blend
+          0 rrcurveto
+          12 10 1 blend
+          0 12 2 8 14 8 5 8 -2 4 blend
+          rrcurveto
+          -34 42 -17 49 2 blend
+          rlineto
+          14 -54 -14 -54 2 blend
+          rlineto
+          0 -58 -30 -42 -42 -24 1 8 -11 -6 -39 -2 6 blend
+          rrcurveto
+          12 -24 22 -66 2 blend
+          rlineto
+        </CharString>
+        <CharString name="copyright">
+          1 vsindex
+          370 -12 6 4 2 blend
+          rmoveto
+          172 6 1 blend
+          0 146 132 8 -6 2 blend
+          0 202 6 1 blend
+          rrcurveto
+          0 200 -146 130 -172 7 -8 -7 -6 4 blend
+          0 rrcurveto
+          -172 -6 1 blend
+          0 -146 -130 -8 8 2 blend
+          0 -200 -8 1 blend
+          rrcurveto
+          0 -202 146 -132 172 -6 8 6 6 4 blend
+          0 rrcurveto
+          0 26 42 1 blend
+          rmoveto
+          -154 8 1 blend
+          0 -134 124 24 -18 2 blend
+          0 184 -24 1 blend
+          rrcurveto
+          0 182 134 122 154 -22 -24 -20 -8 4 blend
+          0 rrcurveto
+          154 -8 1 blend
+          0 134 -122 -24 20 2 blend
+          0 -182 22 1 blend
+          rrcurveto
+          0 -184 -134 -124 -154 24 24 18 8 4 blend
+          0 rrcurveto
+          4 110 10 -42 2 blend
+          rmoveto
+          66 -17 1 blend
+          0 36 24 34 38 7 -4 4 -8 4 blend
+          rrcurveto
+          -18 18 -36 60 2 blend
+          rlineto
+          -32 -32 -28 -18 -56 8 14 10 6 26 5 blend
+          0 rrcurveto
+          -84 34 1 blend
+          0 -56 60 25 -22 2 blend
+          0 98 -38 1 blend
+          rrcurveto
+          0 100 62 66 80 -48 -34 -22 -21 4 blend
+          0 rrcurveto
+          42 -18 1 blend
+          0 34 -16 26 -30 -16 4 -7 10 4 blend
+          rrcurveto
+          20 18 43 52 2 blend
+          rlineto
+          -28 34 -4 -2 2 blend
+          -40 24 -52 4 -12 2 blend
+          0 rrcurveto
+          -94 -8 1 blend
+          0 -84 -74 -10 -2 2 blend
+          0 -122 4 1 blend
+          rrcurveto
+          0 -120 78 -68 94 4 -8 22 3 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="currency">
+          1 vsindex
+          52 118 50 -42 2 blend
+          rmoveto
+          65 68 6 3 2 blend
+          rlineto
+          32 -31 42 -17 45 -1 18 -9 11 -12 5 blend
+          0 rrcurveto
+          44 -12 1 blend
+          0 43 17 -9 -11 2 blend
+          31 31 -18 1 blend
+          rrcurveto
+          66 -68 5 -3 2 blend
+          rlineto
+          20 22 65 63 2 blend
+          rlineto
+          -66 68 5 -8 2 blend
+          rlineto
+          23 32 15 41 -2 -2 -2 -5 4 blend
+          0 47 -4 1 blend
+          rrcurveto
+          0 49 -15 42 -24 32 -7 3 -6 3 -3 5 blend
+          rrcurveto
+          67 69 -7 -9 2 blend
+          rlineto
+          -20 22 -65 63 2 blend
+          rlineto
+          -66 -69 -4 -1 2 blend
+          rlineto
+          -32 30 -42 17 -44 1 -17 8 -10 11 5 blend
+          0 rrcurveto
+          -45 12 1 blend
+          0 -42 -17 8 10 2 blend
+          -31 -30 17 1 blend
+          rrcurveto
+          -66 69 -4 1 2 blend
+          rlineto
+          -20 -22 -65 -63 2 blend
+          rlineto
+          66 -69 -7 9 2 blend
+          rlineto
+          -24 -32 -14 -42 4 3 2 6 4 blend
+          0 -49 7 1 blend
+          rrcurveto
+          0 -47 14 -41 24 -32 4 -2 5 -3 2 5 blend
+          rrcurveto
+          -66 -68 6 8 2 blend
+          rlineto
+          20 -22 65 -63 2 blend
+          rlineto
+          184 48 -16 122 2 blend
+          rmoveto
+          -78 36 1 blend
+          0 -66 66 34 -34 2 blend
+          0 96 -44 1 blend
+          rrcurveto
+          0 96 66 68 78 -44 -34 -36 -36 4 blend
+          0 rrcurveto
+          78 -36 1 blend
+          0 66 -68 -34 36 2 blend
+          0 -96 44 1 blend
+          rrcurveto
+          0 -96 -66 -66 -78 44 34 34 36 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="d">
+          1 vsindex
+          252 -12 1 blend
+          -12 rmoveto
+          66 -22 1 blend
+          0 54 36 40 40 -6 -12 -6 -6 4 blend
+          rrcurveto
+          2 2 1 blend
+          0 rlineto
+          4 -64 8 18 2 blend
+          rlineto
+          26 114 1 blend
+          0 rlineto
+          0 722 -26 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -202 40 1 blend
+          rlineto
+          2 -90 4 18 2 blend
+          rlineto
+          -50 38 -40 22 -58 20 -8 8 -2 4 5 blend
+          0 rrcurveto
+          -116 14 1 blend
+          0 -98 -4 1 blend
+          -98 0 -154 -10 1 blend
+          rrcurveto
+          0 -162 78 -88 120 2 -12 4 3 blend
+          0 rrcurveto
+          2 28 44 112 2 blend
+          rmoveto
+          -108 62 1 blend
+          0 -60 90 32 -56 2 blend
+          0 132 -42 1 blend
+          rrcurveto
+          0 124 78 100 102 -36 -44 -68 -66 4 blend
+          0 rrcurveto
+          50 -28 1 blend
+          0 44 -18 54 -48 -18 12 -34 30 4 blend
+          rrcurveto
+          0 -296 112 1 blend
+          rlineto
+          -54 -54 -50 -30 -56 36 26 30 22 30 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="degree">
+          1 vsindex
+          152 454 38 -68 2 blend
+          rmoveto
+          56 30 1 blend
+          0 54 42 12 22 2 blend
+          0 72 14 1 blend
+          rrcurveto
+          0 74 -54 42 -56 12 -12 22 -30 4 blend
+          0 rrcurveto
+          -56 -30 1 blend
+          0 -54 -42 -12 -22 2 blend
+          0 -74 -12 1 blend
+          rrcurveto
+          0 -72 54 -42 56 -14 12 -22 30 4 blend
+          0 rrcurveto
+          0 26 54 1 blend
+          rmoveto
+          -48 10 1 blend
+          0 -34 38 8 -10 2 blend
+          0 50 -8 1 blend
+          rrcurveto
+          0 52 34 38 48 -10 -8 -10 -10 4 blend
+          0 rrcurveto
+          48 -10 1 blend
+          0 34 -38 -8 10 2 blend
+          0 -52 10 1 blend
+          rrcurveto
+          0 -50 -34 -38 -48 8 8 10 10 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="dieresis">
+          1 vsindex
+          180 602 -14 -40 2 blend
+          rmoveto
+          18 29 1 blend
+          0 14 14 19 21 2 blend
+          0 18 27 1 blend
+          rrcurveto
+          0 18 -14 14 -18 27 -19 21 -29 4 blend
+          0 rrcurveto
+          -18 -29 1 blend
+          0 -14 -14 -19 -21 2 blend
+          0 -18 -27 1 blend
+          rrcurveto
+          0 -18 14 -14 18 -27 19 -21 29 4 blend
+          0 rrcurveto
+          172 56 1 blend
+          0 rmoveto
+          18 29 1 blend
+          0 14 14 19 21 2 blend
+          0 18 27 1 blend
+          rrcurveto
+          0 18 -14 14 -18 27 -19 21 -29 4 blend
+          0 rrcurveto
+          -18 -29 1 blend
+          0 -14 -14 -19 -21 2 blend
+          0 -18 -27 1 blend
+          rrcurveto
+          0 -18 14 -14 18 -27 19 -21 29 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="divide">
+          1 vsindex
+          34 316 -46 1 blend
+          rmoveto
+          404 68 1 blend
+          0 rlineto
+          0 28 92 1 blend
+          rlineto
+          -404 -68 1 blend
+          0 rlineto
+          0 -28 -92 1 blend
+          rlineto
+          202 -202 34 -4 2 blend
+          rmoveto
+          18 34 1 blend
+          0 14 14 26 22 2 blend
+          0 22 28 1 blend
+          rrcurveto
+          0 20 -14 14 -18 30 -26 22 -34 4 blend
+          0 rrcurveto
+          -18 -34 1 blend
+          0 -14 -14 -26 -22 2 blend
+          0 -20 -30 1 blend
+          rrcurveto
+          0 -22 14 -14 18 -28 26 -22 34 4 blend
+          0 rrcurveto
+          0 360 rmoveto
+          18 34 1 blend
+          0 14 14 26 22 2 blend
+          0 22 28 1 blend
+          rrcurveto
+          0 20 -14 14 -18 30 -26 22 -34 4 blend
+          0 rrcurveto
+          -18 -34 1 blend
+          0 -14 -14 -26 -22 2 blend
+          0 -20 -30 1 blend
+          rrcurveto
+          0 -22 14 -14 18 -28 26 -22 34 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="dollar">
+          1 vsindex
+          244 2 1 blend
+          -12 rmoveto
+          92 66 1 blend
+          0 76 64 24 1 blend
+          0 106 12 1 blend
+          rrcurveto
+          0 194 -292 -10 -12 34 14 3 blend
+          0 160 -84 1 blend
+          rrcurveto
+          0 68 50 54 72 -30 -29 -40 -33 4 blend
+          0 rrcurveto
+          64 -26 1 blend
+          0 38 -22 30 -38 -2 6 4 8 4 blend
+          rrcurveto
+          20 16 66 78 2 blend
+          rlineto
+          -32 42 -46 30 -72 -18 12 -16 6 -16 5 blend
+          0 rrcurveto
+          -88 -47 1 blend
+          0 -68 -64 -15 -12 2 blend
+          0 -88 -34 1 blend
+          rrcurveto
+          0 -180 292 10 5 -34 -21 3 blend
+          0 -174 92 1 blend
+          rrcurveto
+          0 -82 -48 -58 -88 46 28 40 38 4 blend
+          0 rrcurveto
+          -72 30 1 blend
+          0 -56 32 -36 38 14 -22 -16 4 4 blend
+          rrcurveto
+          -18 -18 -58 -88 2 blend
+          rlineto
+          36 -46 68 -34 78 24 -14 10 10 -4 5 blend
+          0 rrcurveto
+          -16 -18 1 blend
+          -98 rmoveto
+          30 82 1 blend
+          0 rlineto
+          0 102 68 1 blend
+          rlineto
+          -30 -82 1 blend
+          0 rlineto
+          0 -102 -68 1 blend
+          rlineto
+          0 744 -40 1 blend
+          rmoveto
+          30 82 1 blend
+          0 rlineto
+          0 116 34 1 blend
+          rlineto
+          -30 -82 1 blend
+          0 rlineto
+          0 -116 -34 1 blend
+          rlineto
+        </CharString>
+        <CharString name="e">
+          272 10 18 1 blend
+          -12 rmoveto
+          72 -8 -16 1 blend
+          0 40 22 36 24 20 32 -4 -2 10 18 10 14 4 blend
+          rrcurveto
+          -14 22 -26 -40 52 80 2 blend
+          rlineto
+          -34 -24 -44 -16 -54 0 -2 2 4 6 10 4 6 12 20 5 blend
+          0 rrcurveto
+          -114 36 58 1 blend
+          0 -74 94 0 128 22 30 -46 -74 -12 -16 -46 -68 4 blend
+          rrcurveto
+          352 -42 -67 1 blend
+          0 rlineto
+          2 12 0 10 2 1 6 0 2 4 8 20 4 blend
+          0 10 14 20 1 blend
+          rrcurveto
+          0 142 -70 78 -110 -4 -8 -2 0 18 30 -23 -38 4 blend
+          0 rrcurveto
+          -106 -9 -16 1 blend
+          0 -100 -96 -12 -18 -2 -4 2 blend
+          0 -156 -4 -6 1 blend
+          rrcurveto
+          0 -156 98 -94 120 -8 -10 8 14 0 -2 16 26 4 blend
+          0 rrcurveto
+          -186 278 60 92 32 44 2 blend
+          rmoveto
+          10 122 78 74 86 -48 -72 -30 -46 -34 -52 -30 -48 4 blend
+          0 rrcurveto
+          90 -26 -38 1 blend
+          0 60 -64 -26 -44 22 30 2 blend
+          0 -132 60 94 1 blend
+          rrcurveto
+          -324 112 176 1 blend
+          0 rlineto
+        </CharString>
+        <CharString name="eacute">
+          1 vsindex
+          272 18 1 blend
+          -12 rmoveto
+          72 -16 1 blend
+          0 40 22 36 24 32 -2 18 14 4 blend
+          rrcurveto
+          -14 22 -40 80 2 blend
+          rlineto
+          -34 -24 -44 -16 -54 -2 4 10 6 20 5 blend
+          0 rrcurveto
+          -114 58 1 blend
+          0 -74 94 0 128 30 -74 -16 -68 4 blend
+          rrcurveto
+          352 -67 1 blend
+          0 rlineto
+          2 1 1 blend
+          12 0 10 4 20 2 blend
+          0 10 20 1 blend
+          rrcurveto
+          0 142 -8 1 blend
+          -70 78 -110 30 -38 2 blend
+          0 rrcurveto
+          -106 -16 1 blend
+          0 -100 -96 -18 -4 2 blend
+          0 -156 -6 1 blend
+          rrcurveto
+          0 -156 98 -94 120 -10 14 -2 26 4 blend
+          0 rrcurveto
+          -186 278 92 44 2 blend
+          rmoveto
+          10 122 78 74 86 -72 -46 -52 -48 4 blend
+          0 rrcurveto
+          90 -38 1 blend
+          0 60 -64 -44 30 2 blend
+          0 -132 94 1 blend
+          rrcurveto
+          -324 176 1 blend
+          0 rlineto
+          130 308 -96 -46 2 blend
+          rmoveto
+          148 150 82 8 2 blend
+          rlineto
+          -24 20 -72 94 2 blend
+          rlineto
+          -142 -154 -76 -34 2 blend
+          rlineto
+          18 -16 66 -68 2 blend
+          rlineto
+        </CharString>
+        <CharString name="ecircumflex">
+          1 vsindex
+          272 18 1 blend
+          -12 rmoveto
+          72 -16 1 blend
+          0 40 22 36 24 32 -2 18 14 4 blend
+          rrcurveto
+          -14 22 -40 80 2 blend
+          rlineto
+          -34 -24 -44 -16 -54 -2 4 10 6 20 5 blend
+          0 rrcurveto
+          -114 58 1 blend
+          0 -74 94 0 128 30 -74 -16 -68 4 blend
+          rrcurveto
+          352 -67 1 blend
+          0 rlineto
+          2 1 1 blend
+          12 0 10 4 20 2 blend
+          0 10 20 1 blend
+          rrcurveto
+          0 142 -8 1 blend
+          -70 78 -110 30 -38 2 blend
+          0 rrcurveto
+          -106 -16 1 blend
+          0 -100 -96 -18 -4 2 blend
+          0 -156 -6 1 blend
+          rrcurveto
+          0 -156 98 -94 120 -10 14 -2 26 4 blend
+          0 rrcurveto
+          -186 278 92 44 2 blend
+          rmoveto
+          10 122 78 74 86 -72 -46 -52 -48 4 blend
+          0 rrcurveto
+          90 -38 1 blend
+          0 60 -64 -44 30 2 blend
+          0 -132 94 1 blend
+          rrcurveto
+          -324 176 1 blend
+          0 rlineto
+          60 308 -116 -60 2 blend
+          rmoveto
+          112 130 16 -46 2 blend
+          rlineto
+          4 0 rlineto
+          112 -130 16 46 2 blend
+          rlineto
+          18 16 46 44 2 blend
+          rlineto
+          -118 146 12 -18 2 blend
+          rlineto
+          -28 -148 1 blend
+          0 rlineto
+          -118 -146 12 18 2 blend
+          rlineto
+          18 -16 46 -44 2 blend
+          rlineto
+        </CharString>
+        <CharString name="edieresis">
+          1 vsindex
+          272 18 1 blend
+          -12 rmoveto
+          72 -16 1 blend
+          0 40 22 36 24 32 -2 18 14 4 blend
+          rrcurveto
+          -14 22 -40 80 2 blend
+          rlineto
+          -34 -24 -44 -16 -54 -2 4 10 6 20 5 blend
+          0 rrcurveto
+          -114 58 1 blend
+          0 -74 94 0 128 30 -74 -16 -68 4 blend
+          rrcurveto
+          352 -67 1 blend
+          0 rlineto
+          2 1 1 blend
+          12 0 10 4 20 2 blend
+          0 10 20 1 blend
+          rrcurveto
+          0 142 -8 1 blend
+          -70 78 -110 30 -38 2 blend
+          0 rrcurveto
+          -106 -16 1 blend
+          0 -100 -96 -18 -4 2 blend
+          0 -156 -6 1 blend
+          rrcurveto
+          0 -156 98 -94 120 -10 14 -2 26 4 blend
+          0 rrcurveto
+          -186 278 92 44 2 blend
+          rmoveto
+          10 122 78 74 86 -72 -46 -52 -48 4 blend
+          0 rrcurveto
+          90 -38 1 blend
+          0 60 -64 -44 30 2 blend
+          0 -132 94 1 blend
+          rrcurveto
+          -324 176 1 blend
+          0 rlineto
+          88 336 -128 -84 2 blend
+          rmoveto
+          18 29 1 blend
+          0 14 14 19 21 2 blend
+          0 18 27 1 blend
+          rrcurveto
+          0 18 -14 14 -18 27 -19 21 -29 4 blend
+          0 rrcurveto
+          -18 -29 1 blend
+          0 -14 -14 -19 -21 2 blend
+          0 -18 -27 1 blend
+          rrcurveto
+          0 -18 14 -14 18 -27 19 -21 29 4 blend
+          0 rrcurveto
+          172 56 1 blend
+          0 rmoveto
+          18 29 1 blend
+          0 14 14 19 21 2 blend
+          0 18 27 1 blend
+          rrcurveto
+          0 18 -14 14 -18 27 -19 21 -29 4 blend
+          0 rrcurveto
+          -18 -29 1 blend
+          0 -14 -14 -19 -21 2 blend
+          0 -18 -27 1 blend
+          rrcurveto
+          0 -18 14 -14 18 -27 19 -21 29 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="egrave">
+          1 vsindex
+          272 18 1 blend
+          -12 rmoveto
+          72 -16 1 blend
+          0 40 22 36 24 32 -2 18 14 4 blend
+          rrcurveto
+          -14 22 -40 80 2 blend
+          rlineto
+          -34 -24 -44 -16 -54 -2 4 10 6 20 5 blend
+          0 rrcurveto
+          -114 58 1 blend
+          0 -74 94 0 128 30 -74 -16 -68 4 blend
+          rrcurveto
+          352 -67 1 blend
+          0 rlineto
+          2 1 1 blend
+          12 0 10 4 20 2 blend
+          0 10 20 1 blend
+          rrcurveto
+          0 142 -8 1 blend
+          -70 78 -110 30 -38 2 blend
+          0 rrcurveto
+          -106 -16 1 blend
+          0 -100 -96 -18 -4 2 blend
+          0 -156 -6 1 blend
+          rrcurveto
+          0 -156 98 -94 120 -10 14 -2 26 4 blend
+          0 rrcurveto
+          -186 278 92 44 2 blend
+          rmoveto
+          10 122 78 74 86 -72 -46 -52 -48 4 blend
+          0 rrcurveto
+          90 -38 1 blend
+          0 60 -64 -44 30 2 blend
+          0 -132 94 1 blend
+          rrcurveto
+          -324 176 1 blend
+          0 rlineto
+          218 308 -104 -46 2 blend
+          rmoveto
+          18 16 66 68 2 blend
+          rlineto
+          -142 154 -76 34 2 blend
+          rlineto
+          -24 -20 -72 -94 2 blend
+          rlineto
+          148 -150 82 -8 2 blend
+          rlineto
+        </CharString>
+        <CharString name="eight">
+          1 vsindex
+          240 28 1 blend
+          -12 rmoveto
+          114 25 1 blend
+          0 76 74 17 2 2 blend
+          0 92 10 1 blend
+          rrcurveto
+          0 86 -58 42 -54 34 -2 11 8 -8 -1 5 blend
+          rrcurveto
+          0 4 rlineto
+          36 30 56 64 9 -1 -20 -18 4 blend
+          0 72 -14 1 blend
+          rrcurveto
+          0 94 -62 72 -108 14 -18 -4 -10 4 blend
+          0 rrcurveto
+          -90 -34 1 blend
+          0 -72 -64 -16 -4 2 blend
+          0 -90 -22 1 blend
+          rrcurveto
+          0 -68 46 -48 46 -30 2 -12 2 4 -8 5 blend
+          rrcurveto
+          0 -4 rlineto
+          -60 -32 -70 -64 26 20 2 blend
+          0 -88 14 1 blend
+          rrcurveto
+          0 -100 84 -76 116 -4 13 6 13 4 blend
+          0 rrcurveto
+          48 342 -10 48 2 blend
+          rmoveto
+          -86 34 -92 38 26 -10 58 -16 4 blend
+          0 96 -54 1 blend
+          rrcurveto
+          0 72 54 54 76 -28 -27 -36 -45 4 blend
+          0 rrcurveto
+          88 -48 1 blend
+          0 50 -64 -26 38 2 blend
+          0 -74 30 1 blend
+          rrcurveto
+          0 -58 -32 -52 -58 -46 30 22 26 40 20 5 blend
+          rrcurveto
+          -48 -314 14 42 2 blend
+          rmoveto
+          -98 54 1 blend
+          0 -70 66 31 -40 2 blend
+          0 82 -32 1 blend
+          rrcurveto
+          0 74 52 56 70 40 -42 -38 -24 -51 -18 5 blend
+          rrcurveto
+          102 -40 102 -36 -27 8 -58 18 4 blend
+          0 -104 58 1 blend
+          rrcurveto
+          0 -76 -62 -62 -96 28 31 44 58 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="equal">
+          1 vsindex
+          34 416 -26 1 blend
+          rmoveto
+          404 68 1 blend
+          0 rlineto
+          0 28 92 1 blend
+          rlineto
+          -404 -68 1 blend
+          0 rlineto
+          0 -28 -92 1 blend
+          rlineto
+          0 -200 -40 1 blend
+          rmoveto
+          404 68 1 blend
+          0 rlineto
+          0 28 92 1 blend
+          rlineto
+          -404 -68 1 blend
+          0 rlineto
+          0 -28 -92 1 blend
+          rlineto
+        </CharString>
+        <CharString name="eth">
+          1 vsindex
+          266 8 1 blend
+          -12 rmoveto
+          116 38 1 blend
+          0 82 102 10 18 2 blend
+          0 160 2 1 blend
+          rrcurveto
+          0 260 -138 128 -154 84 -4 -34 4 -17 2 5 blend
+          rrcurveto
+          -14 -22 -60 -82 2 blend
+          rlineto
+          146 -86 128 -104 33 -4 -50 7 4 blend
+          0 -260 67 1 blend
+          rrcurveto
+          0 -128 -50 -106 -116 30 14 70 72 4 blend
+          0 rrcurveto
+          -94 48 1 blend
+          0 -78 84 38 -50 2 blend
+          0 118 -48 1 blend
+          rrcurveto
+          0 102 59 92 115 -27 -22 -65 -69 4 blend
+          0 rrcurveto
+          54 -21 1 blend
+          0 56 -18 56 -86 -26 7 -30 57 4 blend
+          rrcurveto
+          0 38 -2 48 2 blend
+          rlineto
+          -42 62 -58 32 -64 22 -2 4 -12 14 5 blend
+          0 rrcurveto
+          -126 26 1 blend
+          0 -82 -92 -20 10 2 blend
+          0 -130 -16 1 blend
+          rrcurveto
+          0 -144 100 -86 104 -4 8 -8 24 4 blend
+          0 rrcurveto
+          -104 532 -54 -55 2 blend
+          rmoveto
+          302 158 84 35 2 blend
+          rlineto
+          -12 22 -32 53 2 blend
+          rlineto
+          -302 -158 -84 -36 2 blend
+          rlineto
+          12 -22 32 -52 2 blend
+          rlineto
+        </CharString>
+        <CharString name="exclam">
+          1 vsindex
+          112 172 12 72 2 blend
+          rmoveto
+          24 88 1 blend
+          0 rlineto
+          4 436 20 -158 2 blend
+          rlineto
+          0 62 6 86 2 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -62 6 -86 2 blend
+          rlineto
+          4 -436 20 158 2 blend
+          rlineto
+          12 -184 44 -72 2 blend
+          rmoveto
+          18 40 1 blend
+          0 18 14 24 32 2 blend
+          0 24 34 1 blend
+          rrcurveto
+          0 26 -18 14 -18 32 -24 32 -40 4 blend
+          0 rrcurveto
+          -18 -40 1 blend
+          0 -18 -14 -24 -32 2 blend
+          0 -26 -32 1 blend
+          rrcurveto
+          0 -24 18 -14 18 -34 24 -32 40 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="exclamdown">
+          1 vsindex
+          108 -192 -14 22 2 blend
+          rmoveto
+          32 140 1 blend
+          0 rlineto
+          0 62 -6 86 2 blend
+          rlineto
+          -4 436 -20 -158 2 blend
+          rlineto
+          -24 -88 1 blend
+          0 rlineto
+          -4 -436 -20 158 2 blend
+          rlineto
+          0 -62 -6 -86 2 blend
+          rlineto
+          16 604 70 -130 2 blend
+          rmoveto
+          18 40 1 blend
+          0 18 14 24 32 2 blend
+          0 26 32 1 blend
+          rrcurveto
+          0 24 -18 14 -18 34 -24 32 -40 4 blend
+          0 rrcurveto
+          -18 -40 1 blend
+          0 -18 -14 -24 -32 2 blend
+          0 -24 -34 1 blend
+          rrcurveto
+          0 -26 18 -14 18 -32 24 -32 40 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="f">
+          1 vsindex
+          100 -12 1 blend
+          0 rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 592 -80 1 blend
+          rlineto
+          0 72 24 42 54 -26 -4 -26 -22 4 blend
+          0 rrcurveto
+          18 -2 1 blend
+          0 19 -4 21 -8 -3 2 -5 4 4 blend
+          rrcurveto
+          10 24 22 98 2 blend
+          rlineto
+          -20 10 -26 6 -20 -2 -2 -12 4 -26 5 blend
+          0 rrcurveto
+          -68 -80 1 blend
+          0 -42 -44 -8 -51 2 blend
+          0 -94 -13 1 blend
+          rrcurveto
+          0 -596 90 1 blend
+          rlineto
+          -66 450 -84 1 blend
+          rmoveto
+          210 112 1 blend
+          0 rlineto
+          0 28 106 1 blend
+          rlineto
+          -144 -102 1 blend
+          0 rlineto
+          -66 -4 -10 -2 2 blend
+          rlineto
+          0 -24 -104 1 blend
+          rlineto
+        </CharString>
+        <CharString name="five">
+          1 vsindex
+          224 28 1 blend
+          -12 rmoveto
+          100 29 1 blend
+          0 100 76 11 6 2 blend
+          0 136 6 1 blend
+          rrcurveto
+          0 140 -86 -6 -8 2 blend
+          62 -108 -2 1 blend
+          0 rrcurveto
+          -50 29 1 blend
+          0 -36 -15 -34 -21 19 13 12 13 4 blend
+          rrcurveto
+          22 246 -14 -154 2 blend
+          rlineto
+          258 -30 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -286 -90 1 blend
+          0 rlineto
+          -24 -296 8 -30 2 blend
+          rlineto
+          26 -16 48 -32 2 blend
+          rlineto
+          38 26 34 18 50 -2 -18 -12 -16 4 blend
+          0 rrcurveto
+          100 -50 1 blend
+          0 64 -66 -28 38 2 blend
+          0 -108 54 1 blend
+          rrcurveto
+          0 -108 -78 -74 -88 52 44 48 28 4 blend
+          0 rrcurveto
+          -92 46 1 blend
+          0 -50 40 6 -14 2 blend
+          -38 40 -6 1 blend
+          rrcurveto
+          -20 -22 -56 -86 2 blend
+          rlineto
+          40 -40 56 -46 102 12 -12 18 8 2 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="four">
+          1 vsindex
+          312 -22 1 blend
+          0 rmoveto
+          30 130 1 blend
+          0 rlineto
+          0 640 -6 1 blend
+          rlineto
+          -20 -194 1 blend
+          0 rlineto
+          -306 -428 90 56 2 blend
+          rlineto
+          0 -16 -104 1 blend
+          rlineto
+          424 74 1 blend
+          0 rlineto
+          0 28 102 1 blend
+          rlineto
+          -382 46 1 blend
+          0 rlineto
+          202 282 -144 -174 2 blend
+          rlineto
+          18 28 10 1 blend
+          18 22 16 1 blend
+          16 26 12 1 blend
+          rrcurveto
+          4 0 rlineto
+          -2 -28 -2 -50 -15 -2 -14 3 blend
+          0 -28 -15 1 blend
+          rrcurveto
+          0 -476 132 1 blend
+          rlineto
+        </CharString>
+        <CharString name="g">
+          1 vsindex
+          250 -234 -10 28 2 blend
+          rmoveto
+          134 44 1 blend
+          0 86 80 26 -6 2 blend
+          0 80 28 1 blend
+          rrcurveto
+          0 74 -48 34 -106 18 -24 4 -19 4 blend
+          0 rrcurveto
+          -106 31 1 blend
+          0 rlineto
+          -74 24 1 blend
+          0 -20 30 -22 1 blend
+          0 36 -14 1 blend
+          rrcurveto
+          0 34 20 22 22 18 -20 -18 -16 -12 -9 5 blend
+          rrcurveto
+          22 -14 32 -8 28 9 -14 6 -12 4 blend
+          0 rrcurveto
+          92 20 1 blend
+          0 72 74 18 -26 2 blend
+          0 96 22 1 blend
+          rrcurveto
+          0 54 -24 46 -34 28 -34 20 -26 30 -16 5 blend
+          rrcurveto
+          116 -44 1 blend
+          0 rlineto
+          0 28 96 1 blend
+          rlineto
+          -160 -26 1 blend
+          0 rlineto
+          -14 6 -22 6 -26 -10 2 -6 -2 -2 5 blend
+          0 rrcurveto
+          -92 -18 1 blend
+          0 -72 -72 -32 14 2 blend
+          0 -96 -28 1 blend
+          rrcurveto
+          0 -58 30 -48 30 -26 2 2 6 2 4 blend
+          rrcurveto
+          0 -4 rlineto
+          -20 -14 -32 -30 -14 -10 10 -6 4 blend
+          0 -44 10 1 blend
+          rrcurveto
+          0 -36 18 -6 2 2 blend
+          -26 24 -14 2 -4 2 blend
+          rrcurveto
+          0 -4 rlineto
+          -44 -32 -28 -44 -2 8 4 13 4 blend
+          0 -42 1 1 blend
+          rrcurveto
+          0 -80 74 -54 122 -10 22 20 -8 4 blend
+          0 rrcurveto
+          -10 414 26 52 2 blend
+          rmoveto
+          -70 38 1 blend
+          0 -62 58 40 -36 2 blend
+          0 84 -36 1 blend
+          rrcurveto
+          0 86 60 54 72 -40 -38 -32 -40 4 blend
+          0 rrcurveto
+          72 -40 1 blend
+          0 60 -55 -38 33 2 blend
+          0 -85 39 1 blend
+          rrcurveto
+          0 -84 -62 -58 -70 36 40 36 38 4 blend
+          0 rrcurveto
+          12 -386 26 1 blend
+          rmoveto
+          -106 48 1 blend
+          0 -60 44 20 -30 2 blend
+          0 64 -32 1 blend
+          rrcurveto
+          0 36 20 40 48 32 -22 -14 -30 -36 -20 5 blend
+          rrcurveto
+          26 -6 26 -12 2 -8 3 blend
+          -2 6 34 1 blend
+          0 rrcurveto
+          110 -71 1 blend
+          0 rlineto
+          76 -33 1 blend
+          0 40 -22 -16 18 2 blend
+          0 -56 30 1 blend
+          rrcurveto
+          0 -64 -72 -66 -114 36 30 48 58 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="germandbls">
+          1 vsindex
+          360 74 1 blend
+          -12 rmoveto
+          80 50 1 blend
+          0 60 58 4 18 2 blend
+          0 78 16 1 blend
+          rrcurveto
+          0 170 -204 -38 -20 50 42 3 blend
+          0 122 -68 1 blend
+          rrcurveto
+          0 84 112 36 -40 -34 -8 3 blend
+          0 104 -10 1 blend
+          rrcurveto
+          0 74 -54 56 -86 14 -28 30 -62 4 blend
+          0 rrcurveto
+          -102 -74 1 blend
+          0 -70 -72 -18 -28 2 blend
+          0 -122 -8 1 blend
+          rrcurveto
+          0 -538 62 1 blend
+          rlineto
+          30 140 1 blend
+          0 rlineto
+          0 524 -66 1 blend
+          rlineto
+          0 124 56 56 84 -56 -20 -10 -26 4 blend
+          0 rrcurveto
+          72 -36 1 blend
+          0 38 -44 -8 18 2 blend
+          0 -60 26 1 blend
+          rrcurveto
+          0 -92 -112 -32 22 42 6 3 blend
+          0 -100 28 1 blend
+          rrcurveto
+          0 -146 204 40 18 -50 -46 3 blend
+          0 -148 88 1 blend
+          rrcurveto
+          0 -54 -36 -52 -72 32 18 38 46 4 blend
+          0 rrcurveto
+          -44 16 1 blend
+          0 -36 12 -36 32 6 -2 4 -8 4 blend
+          rrcurveto
+          -18 -20 -40 -96 2 blend
+          rlineto
+          36 -36 46 14 8 -2 3 blend
+          -16 52 8 1 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00084">
+          1 vsindex
+          100 -28 1 blend
+          0 rmoveto
+          342 76 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -310 64 1 blend
+          0 rlineto
+          0 632 -126 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+          250 284 101 -58 2 blend
+          rmoveto
+          18 40 1 blend
+          0 18 14 24 32 2 blend
+          0 24 34 1 blend
+          rrcurveto
+          0 26 -18 14 -18 32 -24 32 -40 4 blend
+          0 rrcurveto
+          -18 -40 1 blend
+          0 -18 -14 -24 -32 2 blend
+          0 -26 -32 1 blend
+          rrcurveto
+          0 -24 18 -14 18 -34 24 -32 40 4 blend
+          0 rrcurveto
+          210 -284 -31 58 2 blend
+          rmoveto
+          342 76 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -310 64 1 blend
+          0 rlineto
+          0 632 -126 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -660 10 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00117">
+          1 vsindex
+          144 68 1 blend
+          -12 rmoveto
+          10 28 1 blend
+          0 8 2 8 4 20 4 10 4 4 blend
+          rrcurveto
+          -6 24 -14 102 2 blend
+          rlineto
+          -8 -2 -4 0 -4 -2 1 blend
+          0 rrcurveto
+          -14 2 1 blend
+          0 -8 8 -8 2 2 blend
+          0 22 12 1 blend
+          rrcurveto
+          0 676 -150 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -670 150 1 blend
+          rlineto
+          0 -46 18 -18 30 -66 20 -58 86 4 blend
+          0 rrcurveto
+          110 296 66 -58 2 blend
+          rmoveto
+          18 40 1 blend
+          0 18 14 24 32 2 blend
+          0 24 34 1 blend
+          rrcurveto
+          0 26 -18 14 -18 32 -24 32 -40 4 blend
+          0 rrcurveto
+          -18 -40 1 blend
+          0 -18 -14 -24 -32 2 blend
+          0 -26 -32 1 blend
+          rrcurveto
+          0 -24 18 -14 18 -34 24 -32 40 4 blend
+          0 rrcurveto
+          178 -296 134 58 2 blend
+          rmoveto
+          10 28 1 blend
+          0 8 2 8 4 20 4 10 4 4 blend
+          rrcurveto
+          -6 24 -14 102 2 blend
+          rlineto
+          -8 -2 -4 0 -4 -2 1 blend
+          0 rrcurveto
+          -14 2 1 blend
+          0 -8 8 -8 2 2 blend
+          0 22 12 1 blend
+          rrcurveto
+          0 676 -150 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -670 150 1 blend
+          rlineto
+          0 -46 18 -18 30 -66 20 -58 86 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00118">
+          1 vsindex
+          100 -12 1 blend
+          0 rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 572 -64 1 blend
+          rlineto
+          0 78 30 46 60 -38 -6 -30 -32 4 blend
+          0 rrcurveto
+          22 6 1 blend
+          0 23 -9 1 blend
+          -4 25 -12 -11 6 2 blend
+          rrcurveto
+          10 26 20 100 2 blend
+          rlineto
+          -26 12 -28 6 -24 4 -3 -12 3 -22 5 blend
+          0 rrcurveto
+          -74 -74 1 blend
+          0 -48 -48 -6 -42 2 blend
+          0 -100 -2 1 blend
+          rrcurveto
+          0 -576 70 1 blend
+          rlineto
+          260 68 1 blend
+          0 rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 592 -80 1 blend
+          rlineto
+          0 72 24 42 54 -25 -4 -27 -22 4 blend
+          0 rrcurveto
+          18 -2 1 blend
+          0 20 -2 1 blend
+          -4 20 -10 -4 4 2 blend
+          rrcurveto
+          10 26 20 100 2 blend
+          rlineto
+          -22 10 -24 6 -20 -2 -14 4 -26 4 blend
+          0 rrcurveto
+          -68 -80 1 blend
+          0 -42 -44 -8 -51 2 blend
+          0 -94 -13 1 blend
+          rrcurveto
+          0 -596 90 1 blend
+          rlineto
+          -326 450 -68 -84 2 blend
+          rmoveto
+          470 180 1 blend
+          0 rlineto
+          0 28 106 1 blend
+          rlineto
+          -404 -170 1 blend
+          0 rlineto
+          -66 -4 -10 -2 2 blend
+          rlineto
+          0 -24 -104 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00119">
+          1 vsindex
+          100 -12 1 blend
+          0 rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 592 -80 1 blend
+          rlineto
+          0 72 24 42 54 -25 -4 -27 -22 4 blend
+          0 rrcurveto
+          18 -2 1 blend
+          0 20 -2 1 blend
+          -4 20 -10 -4 4 2 blend
+          rrcurveto
+          10 26 20 100 2 blend
+          rlineto
+          -22 10 -24 6 -20 -2 -14 4 -26 4 blend
+          0 rrcurveto
+          -68 -80 1 blend
+          0 -42 -44 -8 -51 2 blend
+          0 -94 -13 1 blend
+          rrcurveto
+          0 -596 90 1 blend
+          rlineto
+          334 166 1 blend
+          -12 rmoveto
+          16 39 1 blend
+          0 30 8 28 10 7 2 -2 -2 4 blend
+          rrcurveto
+          -10 26 -16 98 2 blend
+          rlineto
+          -18 -8 -26 -8 -18 6 4 10 4 2 5 blend
+          0 rrcurveto
+          -70 38 1 blend
+          0 -14 44 -14 -26 2 blend
+          0 62 -7 1 blend
+          rrcurveto
+          0 328 -157 1 blend
+          rlineto
+          142 -28 1 blend
+          0 rlineto
+          0 28 106 1 blend
+          rlineto
+          -142 28 1 blend
+          0 rlineto
+          0 140 -10 1 blend
+          rlineto
+          -26 -116 1 blend
+          0 rlineto
+          -4 -140 -16 10 2 blend
+          rlineto
+          -222 -94 1 blend
+          0 rlineto
+          -66 -4 -10 -2 2 blend
+          rlineto
+          0 -24 -104 1 blend
+          rlineto
+          288 94 1 blend
+          0 rlineto
+          0 -324 150 1 blend
+          rlineto
+          0 -82 24 -56 88 -40 30 -26 42 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00120">
+          1 vsindex
+          100 -12 1 blend
+          0 rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 572 -64 1 blend
+          rlineto
+          0 78 30 46 60 -38 -6 -30 -32 4 blend
+          0 rrcurveto
+          22 6 1 blend
+          0 23 -9 1 blend
+          -4 25 -12 -11 6 2 blend
+          rrcurveto
+          10 26 20 100 2 blend
+          rlineto
+          -26 12 -28 6 -24 4 -3 -12 3 -22 5 blend
+          0 rrcurveto
+          -74 -74 1 blend
+          0 -48 -48 -6 -42 2 blend
+          0 -100 -2 1 blend
+          rrcurveto
+          0 -576 70 1 blend
+          rlineto
+          260 68 1 blend
+          0 rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 592 -80 1 blend
+          rlineto
+          0 72 24 42 54 -25 -4 -27 -22 4 blend
+          0 rrcurveto
+          18 -2 1 blend
+          0 20 -2 1 blend
+          -4 20 -10 -4 4 2 blend
+          rrcurveto
+          10 26 20 100 2 blend
+          rlineto
+          -22 10 -24 6 -20 -2 -14 4 -26 4 blend
+          0 rrcurveto
+          -68 -80 1 blend
+          0 -42 -44 -8 -51 2 blend
+          0 -94 -13 1 blend
+          rrcurveto
+          0 -596 90 1 blend
+          rlineto
+          334 166 1 blend
+          -12 rmoveto
+          16 39 1 blend
+          0 30 8 28 10 7 2 -2 -2 4 blend
+          rrcurveto
+          -10 26 -16 98 2 blend
+          rlineto
+          -18 -8 -26 -8 -18 6 4 10 4 2 5 blend
+          0 rrcurveto
+          -70 38 1 blend
+          0 -14 44 -14 -26 2 blend
+          0 62 -7 1 blend
+          rrcurveto
+          0 328 -157 1 blend
+          rlineto
+          142 -28 1 blend
+          0 rlineto
+          0 28 106 1 blend
+          rlineto
+          -142 28 1 blend
+          0 rlineto
+          0 140 -10 1 blend
+          rlineto
+          -26 -116 1 blend
+          0 rlineto
+          -4 -140 -16 10 2 blend
+          rlineto
+          -482 -162 1 blend
+          0 rlineto
+          -66 -4 -10 -2 2 blend
+          rlineto
+          0 -24 -104 1 blend
+          rlineto
+          548 162 1 blend
+          0 rlineto
+          0 -324 150 1 blend
+          rlineto
+          0 -82 24 -56 88 -40 30 -26 42 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00165">
+          1 vsindex
+          180 398 10 -42 2 blend
+          rmoveto
+          86 10 1 blend
+          0 52 74 20 4 2 blend
+          0 134 -4 1 blend
+          rrcurveto
+          0 132 -52 74 -86 -2 -20 2 -10 4 blend
+          0 rrcurveto
+          -86 -10 1 blend
+          0 -52 -74 -20 -2 2 blend
+          0 -132 2 1 blend
+          rrcurveto
+          0 -134 52 -74 86 4 20 -4 10 4 blend
+          0 rrcurveto
+          0 26 68 1 blend
+          rmoveto
+          -66 40 1 blend
+          0 -42 68 18 -42 2 blend
+          0 114 -26 1 blend
+          rrcurveto
+          0 114 42 66 66 -26 -18 -42 -40 4 blend
+          0 rrcurveto
+          66 -40 1 blend
+          0 42 -66 -18 42 2 blend
+          0 -114 26 1 blend
+          rrcurveto
+          0 -114 -42 -68 -66 26 18 42 40 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00169">
+          1 vsindex
+          224 410 -12 -42 2 blend
+          rmoveto
+          28 82 1 blend
+          0 rlineto
+          0 390 rlineto
+          -22 -136 1 blend
+          0 rlineto
+          -182 -256 50 8 2 blend
+          rlineto
+          0 -16 -46 1 blend
+          rlineto
+          262 86 1 blend
+          0 rlineto
+          0 26 54 1 blend
+          rlineto
+          -222 -14 1 blend
+          0 rlineto
+          78 112 -44 -38 2 blend
+          rlineto
+          58 84 -22 -8 2 blend
+          rlineto
+          4 0 rlineto
+          -4 -102 -2 -18 2 blend
+          rlineto
+          0 -238 48 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00170">
+          1 vsindex
+          180 398 8 -42 2 blend
+          rmoveto
+          72 20 1 blend
+          0 58 52 6 7 2 blend
+          0 82 -5 1 blend
+          rrcurveto
+          0 88 -56 46 -72 -10 -3 2 4 4 blend
+          0 rrcurveto
+          -32 26 1 blend
+          0 -24 -10 -20 -12 7 10 4 9 4 blend
+          rrcurveto
+          14 128 -10 -89 2 blend
+          rlineto
+          168 -21 1 blend
+          0 rlineto
+          0 28 76 1 blend
+          rlineto
+          -194 -51 1 blend
+          0 rlineto
+          -20 -184 4 -12 2 blend
+          rlineto
+          20 -14 31 -22 2 blend
+          rlineto
+          22 18 26 20 38 -3 -2 -12 -16 -19 5 blend
+          0 rrcurveto
+          60 -33 1 blend
+          0 40 -42 -16 26 2 blend
+          0 -66 34 1 blend
+          rrcurveto
+          0 -64 -42 -44 -56 39 22 21 28 4 blend
+          0 rrcurveto
+          -54 24 1 blend
+          0 -36 28 -26 38 14 -16 2 -6 4 blend
+          rrcurveto
+          -24 -18 -50 -40 2 blend
+          rlineto
+          28 -38 42 -36 68 8 -16 16 10 2 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00171">
+          1 vsindex
+          192 398 12 -42 2 blend
+          rmoveto
+          70 10 1 blend
+          0 52 56 10 4 2 blend
+          0 72 8 1 blend
+          rrcurveto
+          0 72 -42 54 -80 4 -6 -8 6 4 blend
+          0 rrcurveto
+          -44 10 1 blend
+          0 -38 -18 -34 -34 6 4 13 7 4 blend
+          rrcurveto
+          0 -35 5 -34 2 blend
+          rlineto
+          42 47 32 14 40 -26 -29 -13 -4 -23 5 blend
+          0 rrcurveto
+          62 -36 1 blend
+          0 32 -44 -16 30 2 blend
+          0 -56 26 1 blend
+          rrcurveto
+          0 -56 -36 -46 -54 24 17 36 35 4 blend
+          0 rrcurveto
+          -70 44 1 blend
+          0 -42 62 14 -40 2 blend
+          0 104 -32 1 blend
+          rrcurveto
+          0 142 68 54 60 -66 -52 2 8 4 blend
+          0 rrcurveto
+          28 -1 1 blend
+          0 22 -10 18 -12 -3 -2 2 -3 4 blend
+          rrcurveto
+          14 26 34 50 2 blend
+          rlineto
+          -22 14 -22 8 -36 -2 7 -16 16 -25 5 blend
+          0 rrcurveto
+          -80 -43 1 blend
+          0 -80 -58 16 -33 2 blend
+          0 -166 51 1 blend
+          rrcurveto
+          0 -122 58 -68 82 -2 3 -16 29 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00172">
+          1 vsindex
+          142 410 -30 -42 2 blend
+          rmoveto
+          30 102 1 blend
+          0 rlineto
+          8 140 26 104 100 128 -2 -10 -10 -20 -14 -18 6 blend
+          rrcurveto
+          0 18 48 1 blend
+          rlineto
+          -256 -46 1 blend
+          0 rlineto
+          0 -26 -78 1 blend
+          rlineto
+          222 -58 1 blend
+          0 rlineto
+          -88 -114 24 14 2 blend
+          -32 -104 -10 -146 34 4 30 3 blend
+          rrcurveto
+        </CharString>
+        <CharString name="glyph00173">
+          1 vsindex
+          178 398 12 -42 2 blend
+          rmoveto
+          72 18 1 blend
+          0 56 48 8 2 2 blend
+          0 64 -2 1 blend
+          rrcurveto
+          0 46 -26 28 -48 24 4 -6 8 10 -4 5 blend
+          rrcurveto
+          0 4 rlineto
+          22 12 1 blend
+          18 38 30 -14 2 2 blend
+          0 52 -18 1 blend
+          rrcurveto
+          0 60 -50 8 -12 2 blend
+          40 -64 -16 1 blend
+          0 rrcurveto
+          -62 -16 1 blend
+          0 -48 -42 -16 2 2 blend
+          0 -58 -10 1 blend
+          rrcurveto
+          0 -42 2 1 blend
+          24 -24 -4 1 blend
+          34 -22 -2 1 blend
+          rrcurveto
+          0 -4 rlineto
+          -40 -22 6 2 2 blend
+          -36 -40 5 1 blend
+          0 -52 9 1 blend
+          rrcurveto
+          0 -58 50 -4 14 2 blend
+          -50 78 12 1 blend
+          0 rrcurveto
+          28 222 -14 34 2 blend
+          rmoveto
+          -60 18 -48 26 34 -6 28 -16 4 blend
+          0 48 -24 1 blend
+          rrcurveto
+          0 42 36 30 44 -26 -22 -18 -27 4 blend
+          0 rrcurveto
+          46 -27 1 blend
+          0 38 -28 -24 16 2 blend
+          0 -42 20 1 blend
+          rrcurveto
+          0 -34 -18 -32 -38 -28 22 12 18 26 14 5 blend
+          rrcurveto
+          -28 -196 14 22 2 blend
+          rmoveto
+          -60 36 1 blend
+          0 -38 42 20 -24 2 blend
+          0 42 -18 1 blend
+          rrcurveto
+          0 40 24 34 46 26 -22 -14 -16 -30 -14 5 blend
+          rrcurveto
+          64 -24 62 -14 -30 6 -38 6 4 blend
+          0 -62 38 1 blend
+          rrcurveto
+          0 -46 -44 -38 -54 24 26 20 30 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00174">
+          1 vsindex
+          144 398 17 -42 2 blend
+          rmoveto
+          80 43 1 blend
+          0 80 58 -16 33 2 blend
+          0 166 -51 1 blend
+          rrcurveto
+          0 122 -58 68 -82 2 -3 16 -29 4 blend
+          0 rrcurveto
+          -70 -10 1 blend
+          0 -52 -56 -10 -4 2 blend
+          0 -72 -8 1 blend
+          rrcurveto
+          0 -72 42 -54 80 -4 6 8 -6 4 blend
+          0 rrcurveto
+          44 -10 1 blend
+          0 38 18 34 34 -6 -4 -13 -7 4 blend
+          rrcurveto
+          0 35 -5 34 2 blend
+          rlineto
+          -42 -47 -32 -14 -40 26 29 13 4 23 5 blend
+          0 rrcurveto
+          -62 36 1 blend
+          0 -32 44 16 -30 2 blend
+          0 56 -26 1 blend
+          rrcurveto
+          0 56 36 46 54 -24 -17 -36 -35 4 blend
+          0 rrcurveto
+          70 -44 1 blend
+          0 42 -62 -14 40 2 blend
+          0 -104 32 1 blend
+          rrcurveto
+          0 -142 -68 -54 -60 66 52 -2 -8 4 blend
+          0 rrcurveto
+          -28 1 1 blend
+          0 -22 10 -18 12 3 2 -2 3 4 blend
+          rrcurveto
+          -14 -26 -34 -50 2 blend
+          rlineto
+          22 -14 22 -8 36 2 -7 16 -16 25 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00175">
+          1 vsindex
+          164 450 -24 -55 2 blend
+          rmoveto
+          30 70 1 blend
+          0 rlineto
+          0 144 -19 1 blend
+          rlineto
+          132 -16 1 blend
+          0 rlineto
+          0 28 68 1 blend
+          rlineto
+          -132 16 1 blend
+          0 rlineto
+          0 144 -20 1 blend
+          rlineto
+          -30 -70 1 blend
+          0 rlineto
+          0 -144 20 1 blend
+          rlineto
+          -130 14 1 blend
+          0 rlineto
+          0 -28 -68 1 blend
+          rlineto
+          130 -14 1 blend
+          0 rlineto
+          0 -144 19 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00176">
+          1 vsindex
+          34 674 -10 -64 2 blend
+          rmoveto
+          292 40 1 blend
+          0 rlineto
+          0 28 68 1 blend
+          rlineto
+          -292 -40 1 blend
+          0 rlineto
+          0 -28 -68 1 blend
+          rlineto
+          0 -160 -20 1 blend
+          rmoveto
+          292 40 1 blend
+          0 rlineto
+          0 28 68 1 blend
+          rlineto
+          -292 -40 1 blend
+          0 rlineto
+          0 -28 -68 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00177">
+          1 vsindex
+          152 340 2 -66 2 blend
+          rmoveto
+          18 14 74 22 2 blend
+          rlineto
+          -56 78 -18 84 14 4 -6 -2 4 blend
+          0 88 2 1 blend
+          rrcurveto
+          0 88 18 84 56 76 2 6 -2 -14 6 5 blend
+          rrcurveto
+          -18 14 -74 22 2 blend
+          rlineto
+          -56 -76 -30 -80 -2 -14 -4 2 4 blend
+          0 -106 -16 1 blend
+          rrcurveto
+          0 -108 30 -80 56 -76 -14 4 2 2 -14 5 blend
+          rrcurveto
+        </CharString>
+        <CharString name="glyph00178">
+          1 vsindex
+          62 340 64 -66 2 blend
+          rmoveto
+          54 76 30 80 4 14 4 -2 4 blend
+          0 108 14 1 blend
+          rrcurveto
+          0 106 -30 80 -54 76 16 -4 -2 -4 14 5 blend
+          rrcurveto
+          -20 -14 -72 -22 2 blend
+          rlineto
+          56 -76 18 -84 -14 -6 6 2 4 blend
+          0 -88 -2 1 blend
+          rrcurveto
+          0 -88 -18 -84 -56 -78 -2 -6 2 14 -4 5 blend
+          rrcurveto
+          20 -14 72 -22 2 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00179">
+          1 vsindex
+          76 402 34 -42 2 blend
+          rmoveto
+          18 22 1 blend
+          0 14 12 16 18 2 blend
+          0 22 18 1 blend
+          rrcurveto
+          0 22 -14 12 -18 18 -16 20 -22 4 blend
+          0 rrcurveto
+          -18 -22 1 blend
+          0 -14 -12 -16 -20 2 blend
+          0 -22 -18 1 blend
+          rrcurveto
+          0 -22 14 -12 18 -18 16 -18 22 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00180">
+          1 vsindex
+          46 306 8 -74 2 blend
+          rmoveto
+          42 20 30 44 46 4 18 14 4 blend
+          0 46 36 1 blend
+          rrcurveto
+          0 36 -16 18 -24 32 -12 20 -26 4 blend
+          0 rrcurveto
+          -16 -24 1 blend
+          0 -16 -12 -16 -16 2 blend
+          0 -22 -16 1 blend
+          rrcurveto
+          0 -20 16 -8 16 -22 17 -16 20 4 blend
+          0 rrcurveto
+          8 7 1 blend
+          0 10 2 6 4 6 4 3 blend
+          8 rrcurveto
+          -24 32 -10 30 2 blend
+          rlineto
+          10 -38 -12 -38 2 blend
+          rlineto
+          0 1 1 blend
+          -40 -22 -30 -32 -14 -6 9 -23 -3 4 blend
+          rrcurveto
+          12 -22 12 -40 2 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00181">
+          1 vsindex
+          180 10 1 blend
+          -12 rmoveto
+          86 10 1 blend
+          0 52 74 20 4 2 blend
+          0 134 -4 1 blend
+          rrcurveto
+          0 132 -52 74 -86 -2 -20 2 -10 4 blend
+          0 rrcurveto
+          -86 -10 1 blend
+          0 -52 -74 -20 -2 2 blend
+          0 -132 2 1 blend
+          rrcurveto
+          0 -134 52 -74 86 4 20 -4 10 4 blend
+          0 rrcurveto
+          0 26 68 1 blend
+          rmoveto
+          -66 40 1 blend
+          0 -42 68 18 -42 2 blend
+          0 114 -26 1 blend
+          rrcurveto
+          0 114 42 66 66 -26 -18 -42 -40 4 blend
+          0 rrcurveto
+          66 -40 1 blend
+          0 42 -66 -18 42 2 blend
+          0 -114 26 1 blend
+          rrcurveto
+          0 -114 -42 -68 -66 26 18 42 40 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00182">
+          1 vsindex
+          178 -16 1 blend
+          0 rmoveto
+          28 98 1 blend
+          0 rlineto
+          0 390 rlineto
+          -26 -72 1 blend
+          0 rlineto
+          -22 -18 -26 -14 -6 2 3 blend
+          -12 -36 -22 1 blend
+          -8 rrcurveto
+          0 -22 -54 1 blend
+          rlineto
+          82 8 1 blend
+          0 rlineto
+          0 -330 60 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00183">
+          1 vsindex
+          58 -16 1 blend
+          0 rmoveto
+          250 48 1 blend
+          0 rlineto
+          0 26 78 1 blend
+          rlineto
+          -202 102 1 blend
+          0 rlineto
+          106 104 72 66 -62 -52 -28 -13 4 blend
+          0 84 -25 1 blend
+          rrcurveto
+          0 82 -48 40 -70 2 -12 10 -20 4 blend
+          0 rrcurveto
+          -48 -14 1 blend
+          0 -46 -34 -22 -38 -4 8 -22 -18 4 blend
+          rrcurveto
+          20 -18 50 -46 2 blend
+          rlineto
+          22 34 34 30 38 -6 -14 -14 -14 4 blend
+          0 rrcurveto
+          54 -22 1 blend
+          0 36 -38 -18 18 2 blend
+          0 -60 26 1 blend
+          rrcurveto
+          0 -68 -58 -60 -138 -130 24 -16 -4 46 58 5 blend
+          rrcurveto
+          0 -20 -46 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00184">
+          1 vsindex
+          176 12 1 blend
+          -12 rmoveto
+          72 10 1 blend
+          0 56 42 18 8 2 blend
+          0 72 rrcurveto
+          0 56 -46 34 -48 8 -12 18 -2 10 10 5 blend
+          rrcurveto
+          44 16 34 34 -10 6 -16 -8 4 blend
+          0 50 -10 1 blend
+          rrcurveto
+          0 64 -52 38 -64 4 -14 4 -10 4 blend
+          0 rrcurveto
+          -48 -16 1 blend
+          0 -40 -28 -26 -34 8 -20 -14 3 blend
+          rrcurveto
+          20 -18 50 -44 2 blend
+          rlineto
+          26 32 34 22 32 -10 -12 -16 -6 -8 5 blend
+          0 rrcurveto
+          54 -30 1 blend
+          0 34 -32 -18 20 2 blend
+          0 -46 24 1 blend
+          rrcurveto
+          0 -46 -46 -42 -82 16 19 32 41 4 blend
+          0 rrcurveto
+          0 -24 -46 1 blend
+          rlineto
+          88 -31 1 blend
+          0 56 -30 -31 16 2 blend
+          0 -54 24 1 blend
+          rrcurveto
+          0 -56 -44 -32 -52 32 23 18 25 4 blend
+          0 rrcurveto
+          -46 16 1 blend
+          0 -42 28 20 -16 2 blend
+          -24 38 -6 1 blend
+          rrcurveto
+          -24 -18 -50 -40 2 blend
+          rlineto
+          26 -38 48 -36 60 10 -16 10 10 10 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00185">
+          1 vsindex
+          224 -12 1 blend
+          0 rmoveto
+          28 82 1 blend
+          0 rlineto
+          0 390 rlineto
+          -22 -136 1 blend
+          0 rlineto
+          -182 -256 50 8 2 blend
+          rlineto
+          0 -16 -46 1 blend
+          rlineto
+          262 86 1 blend
+          0 rlineto
+          0 26 54 1 blend
+          rlineto
+          -222 -14 1 blend
+          0 rlineto
+          78 112 -44 -38 2 blend
+          rlineto
+          58 84 -22 -8 2 blend
+          rlineto
+          4 0 rlineto
+          -4 -102 -2 -18 2 blend
+          rlineto
+          0 -238 48 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00186">
+          1 vsindex
+          180 8 1 blend
+          -12 rmoveto
+          72 20 1 blend
+          0 58 52 6 7 2 blend
+          0 82 -5 1 blend
+          rrcurveto
+          0 88 -56 46 -72 -10 -3 2 4 4 blend
+          0 rrcurveto
+          -32 26 1 blend
+          0 -24 -10 -20 -12 7 10 4 9 4 blend
+          rrcurveto
+          14 128 -10 -89 2 blend
+          rlineto
+          168 -21 1 blend
+          0 rlineto
+          0 28 76 1 blend
+          rlineto
+          -194 -51 1 blend
+          0 rlineto
+          -20 -184 4 -12 2 blend
+          rlineto
+          20 -14 31 -22 2 blend
+          rlineto
+          22 18 26 20 38 -3 -2 -12 -16 -19 5 blend
+          0 rrcurveto
+          60 -33 1 blend
+          0 40 -42 -16 26 2 blend
+          0 -66 34 1 blend
+          rrcurveto
+          0 -64 -42 -44 -56 39 22 21 28 4 blend
+          0 rrcurveto
+          -54 24 1 blend
+          0 -36 28 -26 38 14 -16 2 -6 4 blend
+          rrcurveto
+          -24 -18 -50 -40 2 blend
+          rlineto
+          28 -38 42 -36 68 8 -16 16 10 2 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00187">
+          1 vsindex
+          192 12 1 blend
+          -12 rmoveto
+          70 10 1 blend
+          0 52 56 10 4 2 blend
+          0 72 8 1 blend
+          rrcurveto
+          0 72 -42 54 -80 4 -6 -8 6 4 blend
+          0 rrcurveto
+          -44 10 1 blend
+          0 -38 -18 -34 -34 6 4 13 7 4 blend
+          rrcurveto
+          0 -35 5 -34 2 blend
+          rlineto
+          42 47 32 14 40 -26 -29 -13 -4 -23 5 blend
+          0 rrcurveto
+          62 -36 1 blend
+          0 32 -44 -16 30 2 blend
+          0 -56 26 1 blend
+          rrcurveto
+          0 -56 -36 -46 -54 24 17 36 35 4 blend
+          0 rrcurveto
+          -70 44 1 blend
+          0 -42 62 14 -40 2 blend
+          0 104 -32 1 blend
+          rrcurveto
+          0 142 68 54 60 -66 -52 2 8 4 blend
+          0 rrcurveto
+          28 -1 1 blend
+          0 22 -10 18 -12 -3 -2 2 -3 4 blend
+          rrcurveto
+          14 26 34 50 2 blend
+          rlineto
+          -22 14 -22 8 -36 -2 7 -16 16 -25 5 blend
+          0 rrcurveto
+          -80 -43 1 blend
+          0 -80 -58 16 -33 2 blend
+          0 -166 51 1 blend
+          rrcurveto
+          0 -122 58 -68 82 -2 3 -16 29 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00188">
+          1 vsindex
+          142 -30 1 blend
+          0 rmoveto
+          30 102 1 blend
+          0 rlineto
+          8 140 26 104 100 128 -2 -10 -10 -20 -14 -18 6 blend
+          rrcurveto
+          0 18 48 1 blend
+          rlineto
+          -256 -46 1 blend
+          0 rlineto
+          0 -26 -78 1 blend
+          rlineto
+          222 -58 1 blend
+          0 rlineto
+          -88 -114 24 14 2 blend
+          -32 -104 -10 -146 34 4 30 3 blend
+          rrcurveto
+        </CharString>
+        <CharString name="glyph00189">
+          1 vsindex
+          178 12 1 blend
+          -12 rmoveto
+          72 18 1 blend
+          0 56 48 8 2 2 blend
+          0 64 -2 1 blend
+          rrcurveto
+          0 46 -26 28 -48 24 4 -6 8 10 -4 5 blend
+          rrcurveto
+          0 4 rlineto
+          22 12 1 blend
+          18 38 30 -14 2 2 blend
+          0 52 -18 1 blend
+          rrcurveto
+          0 60 -50 8 -12 2 blend
+          40 -64 -16 1 blend
+          0 rrcurveto
+          -62 -16 1 blend
+          0 -48 -42 -16 2 2 blend
+          0 -58 -10 1 blend
+          rrcurveto
+          0 -42 2 1 blend
+          24 -24 -4 1 blend
+          34 -22 -2 1 blend
+          rrcurveto
+          0 -4 rlineto
+          -40 -22 6 2 2 blend
+          -36 -40 5 1 blend
+          0 -52 9 1 blend
+          rrcurveto
+          0 -58 50 -4 14 2 blend
+          -50 78 12 1 blend
+          0 rrcurveto
+          28 222 -14 34 2 blend
+          rmoveto
+          -60 18 -48 26 34 -6 28 -16 4 blend
+          0 48 -24 1 blend
+          rrcurveto
+          0 42 36 30 44 -26 -22 -18 -27 4 blend
+          0 rrcurveto
+          46 -27 1 blend
+          0 38 -28 -24 16 2 blend
+          0 -42 20 1 blend
+          rrcurveto
+          0 -34 -18 -32 -38 -28 22 12 18 26 14 5 blend
+          rrcurveto
+          -28 -196 14 22 2 blend
+          rmoveto
+          -60 36 1 blend
+          0 -38 42 20 -24 2 blend
+          0 42 -18 1 blend
+          rrcurveto
+          0 40 24 34 46 26 -22 -14 -16 -30 -14 5 blend
+          rrcurveto
+          64 -24 62 -14 -30 6 -38 6 4 blend
+          0 -62 38 1 blend
+          rrcurveto
+          0 -46 -44 -38 -54 24 26 20 30 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00190">
+          1 vsindex
+          144 17 1 blend
+          -12 rmoveto
+          80 43 1 blend
+          0 80 58 -16 33 2 blend
+          0 166 -51 1 blend
+          rrcurveto
+          0 122 -58 68 -82 2 -3 16 -29 4 blend
+          0 rrcurveto
+          -70 -10 1 blend
+          0 -52 -56 -10 -4 2 blend
+          0 -72 -8 1 blend
+          rrcurveto
+          0 -72 42 -54 80 -4 6 8 -6 4 blend
+          0 rrcurveto
+          44 -10 1 blend
+          0 38 18 34 34 -6 -4 -13 -7 4 blend
+          rrcurveto
+          0 35 -5 34 2 blend
+          rlineto
+          -42 -47 -32 -14 -40 26 29 13 4 23 5 blend
+          0 rrcurveto
+          -62 36 1 blend
+          0 -32 44 16 -30 2 blend
+          0 56 -26 1 blend
+          rrcurveto
+          0 56 36 46 54 -24 -17 -36 -35 4 blend
+          0 rrcurveto
+          70 -44 1 blend
+          0 42 -62 -14 40 2 blend
+          0 -104 32 1 blend
+          rrcurveto
+          0 -142 -68 -54 -60 66 52 -2 -8 4 blend
+          0 rrcurveto
+          -28 1 1 blend
+          0 -22 10 -18 12 3 2 -2 3 4 blend
+          rrcurveto
+          -14 -26 -34 -50 2 blend
+          rlineto
+          22 -14 22 -8 36 2 -7 16 -16 25 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00191">
+          1 vsindex
+          152 -70 2 -24 2 blend
+          rmoveto
+          18 14 74 22 2 blend
+          rlineto
+          -56 78 -18 84 14 4 -6 -2 4 blend
+          0 88 2 1 blend
+          rrcurveto
+          0 88 18 84 56 76 2 6 -2 -14 6 5 blend
+          rrcurveto
+          -18 14 -74 22 2 blend
+          rlineto
+          -56 -76 -30 -80 -2 -14 -4 2 4 blend
+          0 -106 -16 1 blend
+          rrcurveto
+          0 -108 30 -80 56 -76 -14 4 2 2 -14 5 blend
+          rrcurveto
+        </CharString>
+        <CharString name="glyph00192">
+          1 vsindex
+          62 -70 64 -24 2 blend
+          rmoveto
+          54 76 30 80 4 14 4 -2 4 blend
+          0 108 14 1 blend
+          rrcurveto
+          0 106 -30 80 -54 76 16 -4 -2 -4 14 5 blend
+          rrcurveto
+          -20 -14 -72 -22 2 blend
+          rlineto
+          56 -76 18 -84 -14 -6 6 2 4 blend
+          0 -88 -2 1 blend
+          rrcurveto
+          0 -88 -18 -84 -56 -78 -2 -6 2 14 -4 5 blend
+          rrcurveto
+          20 -14 72 -22 2 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00193">
+          1 vsindex
+          76 34 1 blend
+          -8 rmoveto
+          18 22 1 blend
+          0 14 12 16 18 2 blend
+          0 22 18 1 blend
+          rrcurveto
+          0 22 -14 12 -18 18 -16 20 -22 4 blend
+          0 rrcurveto
+          -18 -22 1 blend
+          0 -14 -12 -16 -20 2 blend
+          0 -22 -18 1 blend
+          rrcurveto
+          0 -22 14 -12 18 -18 16 -18 22 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00194">
+          1 vsindex
+          46 -104 8 -32 2 blend
+          rmoveto
+          42 20 30 44 46 4 18 14 4 blend
+          0 46 36 1 blend
+          rrcurveto
+          0 36 -16 18 -24 32 -12 20 -26 4 blend
+          0 rrcurveto
+          -16 -24 1 blend
+          0 -16 -12 -16 -16 2 blend
+          0 -22 -16 1 blend
+          rrcurveto
+          0 -20 16 -8 16 -22 17 -16 20 4 blend
+          0 rrcurveto
+          8 7 1 blend
+          0 10 2 6 4 6 4 3 blend
+          8 rrcurveto
+          -24 32 -10 30 2 blend
+          rlineto
+          10 -38 -12 -38 2 blend
+          rlineto
+          0 1 1 blend
+          -40 -22 -30 -32 -14 -6 9 -23 -3 4 blend
+          rrcurveto
+          12 -22 12 -40 2 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00195">
+          1 vsindex
+          180 258 10 -10 2 blend
+          rmoveto
+          86 10 1 blend
+          0 52 74 20 4 2 blend
+          0 134 -4 1 blend
+          rrcurveto
+          0 132 -52 74 -86 -2 -20 2 -10 4 blend
+          0 rrcurveto
+          -86 -10 1 blend
+          0 -52 -74 -20 -2 2 blend
+          0 -132 2 1 blend
+          rrcurveto
+          0 -134 52 -74 86 4 20 -4 10 4 blend
+          0 rrcurveto
+          0 26 68 1 blend
+          rmoveto
+          -66 40 1 blend
+          0 -42 68 18 -42 2 blend
+          0 114 -26 1 blend
+          rrcurveto
+          0 114 42 66 66 -26 -18 -42 -40 4 blend
+          0 rrcurveto
+          66 -40 1 blend
+          0 42 -66 -18 42 2 blend
+          0 -114 26 1 blend
+          rrcurveto
+          0 -114 -42 -68 -66 26 18 42 40 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00196">
+          1 vsindex
+          178 270 -16 -10 2 blend
+          rmoveto
+          28 98 1 blend
+          0 rlineto
+          0 390 rlineto
+          -26 -72 1 blend
+          0 rlineto
+          -22 -18 -26 -14 -6 2 3 blend
+          -12 -36 -22 1 blend
+          -8 rrcurveto
+          0 -22 -54 1 blend
+          rlineto
+          82 8 1 blend
+          0 rlineto
+          0 -330 60 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00197">
+          1 vsindex
+          58 270 -16 -10 2 blend
+          rmoveto
+          250 48 1 blend
+          0 rlineto
+          0 26 78 1 blend
+          rlineto
+          -202 102 1 blend
+          0 rlineto
+          106 104 72 66 -62 -52 -28 -13 4 blend
+          0 84 -25 1 blend
+          rrcurveto
+          0 82 -48 40 -70 2 -12 10 -20 4 blend
+          0 rrcurveto
+          -48 -14 1 blend
+          0 -46 -34 -22 -38 -4 8 -22 -18 4 blend
+          rrcurveto
+          20 -18 50 -46 2 blend
+          rlineto
+          22 34 34 30 38 -6 -14 -14 -14 4 blend
+          0 rrcurveto
+          54 -22 1 blend
+          0 36 -38 -18 18 2 blend
+          0 -60 26 1 blend
+          rrcurveto
+          0 -68 -58 -60 -138 -130 24 -16 -4 46 58 5 blend
+          rrcurveto
+          0 -20 -46 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00198">
+          1 vsindex
+          176 258 12 -10 2 blend
+          rmoveto
+          72 10 1 blend
+          0 56 42 18 8 2 blend
+          0 72 rrcurveto
+          0 56 -46 34 -48 8 -12 18 -2 10 10 5 blend
+          rrcurveto
+          44 16 34 34 -10 6 -16 -8 4 blend
+          0 50 -10 1 blend
+          rrcurveto
+          0 64 -52 38 -64 4 -14 4 -10 4 blend
+          0 rrcurveto
+          -48 -16 1 blend
+          0 -40 -28 -26 -34 8 -20 -14 3 blend
+          rrcurveto
+          20 -18 50 -44 2 blend
+          rlineto
+          26 32 34 22 32 -10 -12 -16 -6 -8 5 blend
+          0 rrcurveto
+          54 -30 1 blend
+          0 34 -32 -18 20 2 blend
+          0 -46 24 1 blend
+          rrcurveto
+          0 -46 -46 -42 -82 16 19 32 41 4 blend
+          0 rrcurveto
+          0 -24 -46 1 blend
+          rlineto
+          88 -31 1 blend
+          0 56 -30 -31 16 2 blend
+          0 -54 24 1 blend
+          rrcurveto
+          0 -56 -44 -32 -52 32 23 18 25 4 blend
+          0 rrcurveto
+          -46 16 1 blend
+          0 -42 28 20 -16 2 blend
+          -24 38 -6 1 blend
+          rrcurveto
+          -24 -18 -50 -40 2 blend
+          rlineto
+          26 -38 48 -36 60 10 -16 10 10 10 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00199">
+          1 vsindex
+          224 270 -12 -10 2 blend
+          rmoveto
+          28 82 1 blend
+          0 rlineto
+          0 390 rlineto
+          -22 -136 1 blend
+          0 rlineto
+          -182 -256 50 8 2 blend
+          rlineto
+          0 -16 -46 1 blend
+          rlineto
+          262 86 1 blend
+          0 rlineto
+          0 26 54 1 blend
+          rlineto
+          -222 -14 1 blend
+          0 rlineto
+          78 112 -44 -38 2 blend
+          rlineto
+          58 84 -22 -8 2 blend
+          rlineto
+          4 0 rlineto
+          -4 -102 -2 -18 2 blend
+          rlineto
+          0 -238 48 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00200">
+          1 vsindex
+          180 258 8 -10 2 blend
+          rmoveto
+          72 20 1 blend
+          0 58 52 6 7 2 blend
+          0 82 -5 1 blend
+          rrcurveto
+          0 88 -56 46 -72 -10 -3 2 4 4 blend
+          0 rrcurveto
+          -32 26 1 blend
+          0 -24 -10 -20 -12 7 10 4 9 4 blend
+          rrcurveto
+          14 128 -10 -89 2 blend
+          rlineto
+          168 -21 1 blend
+          0 rlineto
+          0 28 76 1 blend
+          rlineto
+          -194 -51 1 blend
+          0 rlineto
+          -20 -184 4 -12 2 blend
+          rlineto
+          20 -14 31 -22 2 blend
+          rlineto
+          22 18 26 20 38 -3 -2 -12 -16 -19 5 blend
+          0 rrcurveto
+          60 -33 1 blend
+          0 40 -42 -16 26 2 blend
+          0 -66 34 1 blend
+          rrcurveto
+          0 -64 -42 -44 -56 39 22 21 28 4 blend
+          0 rrcurveto
+          -54 24 1 blend
+          0 -36 28 -26 38 14 -16 2 -6 4 blend
+          rrcurveto
+          -24 -18 -50 -40 2 blend
+          rlineto
+          28 -38 42 -36 68 8 -16 16 10 2 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00201">
+          1 vsindex
+          192 258 12 -10 2 blend
+          rmoveto
+          70 10 1 blend
+          0 52 56 10 4 2 blend
+          0 72 8 1 blend
+          rrcurveto
+          0 72 -42 54 -80 4 -6 -8 6 4 blend
+          0 rrcurveto
+          -44 10 1 blend
+          0 -38 -18 -34 -34 6 4 13 7 4 blend
+          rrcurveto
+          0 -35 5 -34 2 blend
+          rlineto
+          42 47 32 14 40 -26 -29 -13 -4 -23 5 blend
+          0 rrcurveto
+          62 -36 1 blend
+          0 32 -44 -16 30 2 blend
+          0 -56 26 1 blend
+          rrcurveto
+          0 -56 -36 -46 -54 24 17 36 35 4 blend
+          0 rrcurveto
+          -70 44 1 blend
+          0 -42 62 14 -40 2 blend
+          0 104 -32 1 blend
+          rrcurveto
+          0 142 68 54 60 -66 -52 2 8 4 blend
+          0 rrcurveto
+          28 -1 1 blend
+          0 22 -10 18 -12 -3 -2 2 -3 4 blend
+          rrcurveto
+          14 26 34 50 2 blend
+          rlineto
+          -22 14 -22 8 -36 -2 7 -16 16 -25 5 blend
+          0 rrcurveto
+          -80 -43 1 blend
+          0 -80 -58 16 -33 2 blend
+          0 -166 51 1 blend
+          rrcurveto
+          0 -122 58 -68 82 -2 3 -16 29 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00202">
+          1 vsindex
+          142 270 -30 -10 2 blend
+          rmoveto
+          30 102 1 blend
+          0 rlineto
+          8 140 26 104 100 128 -2 -10 -10 -20 -14 -18 6 blend
+          rrcurveto
+          0 18 48 1 blend
+          rlineto
+          -256 -46 1 blend
+          0 rlineto
+          0 -26 -78 1 blend
+          rlineto
+          222 -58 1 blend
+          0 rlineto
+          -88 -114 24 14 2 blend
+          -32 -104 -10 -146 34 4 30 3 blend
+          rrcurveto
+        </CharString>
+        <CharString name="glyph00203">
+          1 vsindex
+          178 258 12 -10 2 blend
+          rmoveto
+          72 18 1 blend
+          0 56 48 8 2 2 blend
+          0 64 -2 1 blend
+          rrcurveto
+          0 46 -26 28 -48 24 4 -6 8 10 -4 5 blend
+          rrcurveto
+          0 4 rlineto
+          22 12 1 blend
+          18 38 30 -14 2 2 blend
+          0 52 -18 1 blend
+          rrcurveto
+          0 60 -50 8 -12 2 blend
+          40 -64 -16 1 blend
+          0 rrcurveto
+          -62 -16 1 blend
+          0 -48 -42 -16 2 2 blend
+          0 -58 -10 1 blend
+          rrcurveto
+          0 -42 2 1 blend
+          24 -24 -4 1 blend
+          34 -22 -2 1 blend
+          rrcurveto
+          0 -4 rlineto
+          -40 -22 6 2 2 blend
+          -36 -40 5 1 blend
+          0 -52 9 1 blend
+          rrcurveto
+          0 -58 50 -4 14 2 blend
+          -50 78 12 1 blend
+          0 rrcurveto
+          28 222 -14 34 2 blend
+          rmoveto
+          -60 18 -48 26 34 -6 28 -16 4 blend
+          0 48 -24 1 blend
+          rrcurveto
+          0 42 36 30 44 -26 -22 -18 -27 4 blend
+          0 rrcurveto
+          46 -27 1 blend
+          0 38 -28 -24 16 2 blend
+          0 -42 20 1 blend
+          rrcurveto
+          0 -34 -18 -32 -38 -28 22 12 18 26 14 5 blend
+          rrcurveto
+          -28 -196 14 22 2 blend
+          rmoveto
+          -60 36 1 blend
+          0 -38 42 20 -24 2 blend
+          0 42 -18 1 blend
+          rrcurveto
+          0 40 24 34 46 26 -22 -14 -16 -30 -14 5 blend
+          rrcurveto
+          64 -24 62 -14 -30 6 -38 6 4 blend
+          0 -62 38 1 blend
+          rrcurveto
+          0 -46 -44 -38 -54 24 26 20 30 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00204">
+          1 vsindex
+          144 258 17 -10 2 blend
+          rmoveto
+          80 43 1 blend
+          0 80 58 -16 33 2 blend
+          0 166 -51 1 blend
+          rrcurveto
+          0 122 -58 68 -82 2 -3 16 -29 4 blend
+          0 rrcurveto
+          -70 -10 1 blend
+          0 -52 -56 -10 -4 2 blend
+          0 -72 -8 1 blend
+          rrcurveto
+          0 -72 42 -54 80 -4 6 8 -6 4 blend
+          0 rrcurveto
+          44 -10 1 blend
+          0 38 18 34 34 -6 -4 -13 -7 4 blend
+          rrcurveto
+          0 35 -5 34 2 blend
+          rlineto
+          -42 -47 -32 -14 -40 26 29 13 4 23 5 blend
+          0 rrcurveto
+          -62 36 1 blend
+          0 -32 44 16 -30 2 blend
+          0 56 -26 1 blend
+          rrcurveto
+          0 56 36 46 54 -24 -17 -36 -35 4 blend
+          0 rrcurveto
+          70 -44 1 blend
+          0 42 -62 -14 40 2 blend
+          0 -104 32 1 blend
+          rrcurveto
+          0 -142 -68 -54 -60 66 52 -2 -8 4 blend
+          0 rrcurveto
+          -28 1 1 blend
+          0 -22 10 -18 12 3 2 -2 3 4 blend
+          rrcurveto
+          -14 -26 -34 -50 2 blend
+          rlineto
+          22 -14 22 -8 36 2 -7 16 -16 25 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00205">
+          1 vsindex
+          152 200 2 -34 2 blend
+          rmoveto
+          18 14 74 22 2 blend
+          rlineto
+          -56 78 -18 84 14 4 -6 -2 4 blend
+          0 88 2 1 blend
+          rrcurveto
+          0 88 18 84 56 76 2 6 -2 -14 6 5 blend
+          rrcurveto
+          -18 14 -74 22 2 blend
+          rlineto
+          -56 -76 -30 -80 -2 -14 -4 2 4 blend
+          0 -106 -16 1 blend
+          rrcurveto
+          0 -108 30 -80 56 -76 -14 4 2 2 -14 5 blend
+          rrcurveto
+        </CharString>
+        <CharString name="glyph00206">
+          1 vsindex
+          62 200 64 -34 2 blend
+          rmoveto
+          54 76 30 80 4 14 4 -2 4 blend
+          0 108 14 1 blend
+          rrcurveto
+          0 106 -30 80 -54 76 16 -4 -2 -4 14 5 blend
+          rrcurveto
+          -20 -14 -72 -22 2 blend
+          rlineto
+          56 -76 18 -84 -14 -6 6 2 4 blend
+          0 -88 -2 1 blend
+          rrcurveto
+          0 -88 -18 -84 -56 -78 -2 -6 2 14 -4 5 blend
+          rrcurveto
+          20 -14 72 -22 2 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00207">
+          1 vsindex
+          76 262 34 -10 2 blend
+          rmoveto
+          18 22 1 blend
+          0 14 12 16 18 2 blend
+          0 22 18 1 blend
+          rrcurveto
+          0 22 -14 12 -18 18 -16 20 -22 4 blend
+          0 rrcurveto
+          -18 -22 1 blend
+          0 -14 -12 -16 -20 2 blend
+          0 -22 -18 1 blend
+          rrcurveto
+          0 -22 14 -12 18 -18 16 -18 22 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00208">
+          1 vsindex
+          46 166 8 -42 2 blend
+          rmoveto
+          42 20 30 44 46 4 18 14 4 blend
+          0 46 36 1 blend
+          rrcurveto
+          0 36 -16 18 -24 32 -12 20 -26 4 blend
+          0 rrcurveto
+          -16 -24 1 blend
+          0 -16 -12 -16 -16 2 blend
+          0 -22 -16 1 blend
+          rrcurveto
+          0 -20 16 -8 16 -22 17 -16 20 4 blend
+          0 rrcurveto
+          8 7 1 blend
+          0 10 2 6 4 6 4 3 blend
+          8 rrcurveto
+          -24 32 -10 30 2 blend
+          rlineto
+          10 -38 -12 -38 2 blend
+          rlineto
+          0 1 1 blend
+          -40 -22 -30 -32 -14 -6 9 -23 -3 4 blend
+          rrcurveto
+          12 -22 12 -40 2 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00211">
+          1 vsindex
+          3 410 -10 -42 2 blend
+          rmoveto
+          29 94 1 blend
+          0 rlineto
+          90 255 -42 -45 2 blend
+          rlineto
+          18 52 15 44 16 53 -9 -12 -2 7 -7 -10 6 blend
+          rrcurveto
+          2 0 rlineto
+          16 -51 15 -45 18 -53 -5 9 -3 -7 -9 13 6 blend
+          rrcurveto
+          88 -255 -40 45 2 blend
+          rlineto
+          31 97 1 blend
+          0 rlineto
+          -154 21 1 blend
+          432 rlineto
+          -29 -117 1 blend
+          0 rlineto
+          -155 22 1 blend
+          -432 rlineto
+          71 149 25 -59 2 blend
+          rmoveto
+          195 21 1 blend
+          0 rlineto
+          0 25 66 1 blend
+          rlineto
+          -195 -21 1 blend
+          0 rlineto
+          0 -25 -66 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00212">
+          1 vsindex
+          63 410 -16 -42 2 blend
+          rmoveto
+          126 49 1 blend
+          0 rlineto
+          99 -6 1 blend
+          0 64 42 14 -2 2 blend
+          0 84 5 1 blend
+          rrcurveto
+          0 60 -40 35 -65 10 -4 10 -3 4 2 5 blend
+          rrcurveto
+          0 3 -1 1 blend
+          rlineto
+          51 12 27 36 4 -6 6 3 blend
+          0 45 -8 1 blend
+          rrcurveto
+          0 72 -56 33 -88 12 -19 -11 -3 4 blend
+          0 rrcurveto
+          -118 -43 1 blend
+          0 rlineto
+          0 -432 rlineto
+          29 242 91 21 2 blend
+          rmoveto
+          0 166 -88 1 blend
+          rlineto
+          81 -44 1 blend
+          0 rlineto
+          81 -44 1 blend
+          0 42 -24 -26 13 2 blend
+          0 -56 32 1 blend
+          rrcurveto
+          0 -58 -36 -28 -91 34 19 9 55 4 blend
+          0 rrcurveto
+          -77 40 1 blend
+          0 rlineto
+          0 -218 46 1 blend
+          rmoveto
+          0 194 -104 1 blend
+          rlineto
+          89 -43 1 blend
+          0 rlineto
+          90 -46 1 blend
+          0 52 -30 -33 17 2 blend
+          0 -63 34 1 blend
+          rrcurveto
+          0 -73 -54 -28 -88 43 35 10 44 4 blend
+          0 rrcurveto
+          -89 43 1 blend
+          0 rlineto
+        </CharString>
+        <CharString name="glyph00213">
+          1 vsindex
+          218 402 18 -42 2 blend
+          rmoveto
+          56 3 1 blend
+          0 40 24 32 37 11 -3 6 8 4 blend
+          rrcurveto
+          -17 18 -48 53 2 blend
+          rlineto
+          -31 -34 -34 -19 -45 12 13 10 5 12 5 blend
+          0 rrcurveto
+          -95 40 1 blend
+          0 -59 78 23 -34 2 blend
+          0 122 -45 1 blend
+          rrcurveto
+          0 119 60 78 97 -44 -17 -32 -46 4 blend
+          0 rrcurveto
+          39 -12 1 blend
+          0 32 -18 24 -27 -14 8 -2 9 4 blend
+          rrcurveto
+          18 19 47 54 2 blend
+          rlineto
+          -24 27 -39 24 -51 -5 6 -9 2 -6 5 blend
+          0 rrcurveto
+          -111 -2 1 blend
+          0 -76 -87 -26 2 2 blend
+          0 -136 -8 1 blend
+          rrcurveto
+          0 -138 76 -87 108 -8 19 14 4 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00214">
+          1 vsindex
+          63 410 -16 -42 2 blend
+          rmoveto
+          102 35 1 blend
+          0 rlineto
+          134 -6 1 blend
+          0 64 87 28 -22 2 blend
+          0 131 24 1 blend
+          rrcurveto
+          0 129 -64 85 -134 23 -28 -25 -1 4 blend
+          0 rrcurveto
+          -102 -28 1 blend
+          0 rlineto
+          0 -432 rlineto
+          29 25 91 70 2 blend
+          rmoveto
+          0 382 -140 1 blend
+          rlineto
+          70 -64 1 blend
+          0 rlineto
+          118 -56 1 blend
+          0 52 -76 -6 59 2 blend
+          0 -113 11 1 blend
+          rrcurveto
+          0 -114 -51 -79 -116 15 5 55 54 4 blend
+          0 rrcurveto
+          -73 67 1 blend
+          0 rlineto
+        </CharString>
+        <CharString name="glyph00215">
+          1 vsindex
+          63 410 -16 -42 2 blend
+          rmoveto
+          245 47 1 blend
+          0 rlineto
+          0 25 74 1 blend
+          rlineto
+          -216 44 1 blend
+          0 rlineto
+          0 193 -121 1 blend
+          rlineto
+          177 -35 1 blend
+          0 rlineto
+          0 25 74 1 blend
+          rlineto
+          -177 35 1 blend
+          0 rlineto
+          0 164 -101 1 blend
+          rlineto
+          210 -44 1 blend
+          0 rlineto
+          0 25 74 1 blend
+          rlineto
+          -239 -47 1 blend
+          0 rlineto
+          0 -432 rlineto
+        </CharString>
+        <CharString name="glyph00216">
+          1 vsindex
+          63 410 -16 -42 2 blend
+          rmoveto
+          29 91 1 blend
+          0 rlineto
+          0 209 -54 1 blend
+          rlineto
+          177 -32 1 blend
+          0 rlineto
+          0 25 74 1 blend
+          rlineto
+          -177 32 1 blend
+          0 rlineto
+          0 173 -94 1 blend
+          rlineto
+          209 -40 1 blend
+          0 rlineto
+          0 25 74 1 blend
+          rlineto
+          -238 -51 1 blend
+          0 rlineto
+          0 -432 rlineto
+        </CharString>
+        <CharString name="glyph00217">
+          1 vsindex
+          222 402 28 -42 2 blend
+          rmoveto
+          57 5 1 blend
+          0 45 20 26 9 4 8 3 blend
+          28 rrcurveto
+          0 172 38 1 blend
+          rlineto
+          -132 -34 1 blend
+          0 rlineto
+          0 -25 -71 1 blend
+          rlineto
+          105 -43 1 blend
+          0 rlineto
+          0 -136 78 1 blend
+          rlineto
+          -21 -20 -38 -13 -40 13 16 26 11 27 5 blend
+          0 rrcurveto
+          -100 24 1 blend
+          0 -59 78 24 -33 2 blend
+          0 122 -43 1 blend
+          rrcurveto
+          0 119 62 78 101 -43 -19 -34 -44 4 blend
+          0 rrcurveto
+          48 -12 1 blend
+          0 31 -21 22 -24 -12 11 -1 6 4 blend
+          rrcurveto
+          17 19 47 55 2 blend
+          rlineto
+          -23 24 -37 27 -58 -11 6 -7 -1 -4 5 blend
+          0 rrcurveto
+          -116 -4 1 blend
+          0 -78 -87 -24 5 2 blend
+          0 -136 -10 1 blend
+          rrcurveto
+          0 -138 76 -87 112 -8 20 13 12 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00218">
+          1 vsindex
+          63 410 -16 -42 2 blend
+          rmoveto
+          29 91 1 blend
+          0 rlineto
+          0 218 -48 1 blend
+          rlineto
+          236 -110 1 blend
+          0 rlineto
+          0 -218 48 1 blend
+          rlineto
+          29 91 1 blend
+          0 rlineto
+          0 432 rlineto
+          -29 -91 1 blend
+          0 rlineto
+          0 -189 30 1 blend
+          rlineto
+          -236 110 1 blend
+          0 rlineto
+          0 189 -30 1 blend
+          rlineto
+          -29 -91 1 blend
+          0 rlineto
+          0 -432 rlineto
+        </CharString>
+        <CharString name="glyph00219">
+          1 vsindex
+          63 410 -16 -42 2 blend
+          rmoveto
+          29 91 1 blend
+          0 rlineto
+          0 432 rlineto
+          -29 -91 1 blend
+          0 rlineto
+          0 -432 rlineto
+        </CharString>
+        <CharString name="glyph00220">
+          1 vsindex
+          131 402 24 -42 2 blend
+          rmoveto
+          79 27 1 blend
+          0 31 55 16 19 2 blend
+          0 70 17 1 blend
+          rrcurveto
+          0 315 -36 1 blend
+          rlineto
+          -29 -91 1 blend
+          0 rlineto
+          0 -312 43 1 blend
+          rlineto
+          0 -70 -27 -32 -54 14 11 19 24 4 blend
+          0 rrcurveto
+          -36 16 1 blend
+          0 -26 15 -22 36 5 -2 8 -7 4 blend
+          rrcurveto
+          -22 -14 -59 -46 2 blend
+          rlineto
+          22 -39 35 -24 49 11 -18 11 -3 21 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00221">
+          1 vsindex
+          63 410 -16 -42 2 blend
+          rmoveto
+          29 91 1 blend
+          0 rlineto
+          0 150 -40 1 blend
+          rlineto
+          90 101 -49 -45 2 blend
+          rlineto
+          146 -251 -52 85 2 blend
+          rlineto
+          33 98 1 blend
+          0 rlineto
+          -159 273 3 -15 2 blend
+          rlineto
+          140 159 -10 15 2 blend
+          rlineto
+          -35 -96 1 blend
+          0 rlineto
+          -213 -241 107 85 2 blend
+          rlineto
+          -2 -1 1 blend
+          0 rlineto
+          0 241 -85 1 blend
+          rlineto
+          -29 -91 1 blend
+          0 rlineto
+          0 -432 rlineto
+        </CharString>
+        <CharString name="glyph00222">
+          1 vsindex
+          63 410 -16 -42 2 blend
+          rmoveto
+          231 54 1 blend
+          0 rlineto
+          0 25 74 1 blend
+          rlineto
+          -202 37 1 blend
+          0 rlineto
+          0 407 -74 1 blend
+          rlineto
+          -29 -91 1 blend
+          0 rlineto
+          0 -432 rlineto
+        </CharString>
+        <CharString name="glyph00223">
+          63 410 -10 -16 -25 -42 2 blend
+          rmoveto
+          27 52 83 1 blend
+          0 rlineto
+          0 285 -98 -163 1 blend
+          rlineto
+          0 34 -2 45 -2 36 7 11 -2 -8 6 24 -4 -3 10 4 5 blend
+          rrcurveto
+          3 -1 -1 1 blend
+          0 rlineto
+          35 -94 -3 2 -10 -6 2 blend
+          rlineto
+          95 -261 -27 -36 79 121 2 blend
+          rlineto
+          27 25 16 1 blend
+          0 rlineto
+          94 261 -26 -35 -79 -121 2 blend
+          rlineto
+          34 94 -2 4 10 6 2 blend
+          rlineto
+          2 0 1 1 blend
+          0 rlineto
+          -1 -36 -2 -45 -5 -5 -10 -4 -3 -8 -6 -24 4 blend
+          0 -34 -7 -11 1 blend
+          rrcurveto
+          0 -285 98 163 1 blend
+          rlineto
+          28 53 84 1 blend
+          0 rlineto
+          0 432 rlineto
+          -42 -54 -83 1 blend
+          0 rlineto
+          -90 -253 14 26 46 78 2 blend
+          rlineto
+          -34 -96 12 11 14 27 2 blend
+          rlineto
+          -3 0 rlineto
+          -35 96 12 11 -14 -27 2 blend
+          rlineto
+          -91 253 11 21 -46 -78 2 blend
+          rlineto
+          -43 -52 -80 1 blend
+          0 rlineto
+          0 -432 rlineto
+        </CharString>
+        <CharString name="glyph00224">
+          63 410 -10 -16 -25 -42 2 blend
+          rmoveto
+          27 51 85 1 blend
+          0 rlineto
+          0 271 -91 -151 1 blend
+          rlineto
+          0 41 -2 39 -1 41 7 11 -1 -5 12 24 -5 -5 9 9 5 blend
+          rrcurveto
+          2 1 1 1 blend
+          0 rlineto
+          51 -85 -6 -10 -15 -11 2 blend
+          rlineto
+          185 -307 -61 -94 78 118 2 blend
+          rlineto
+          31 61 94 1 blend
+          0 rlineto
+          0 432 rlineto
+          -27 -51 -85 1 blend
+          0 rlineto
+          0 -267 90 150 1 blend
+          rlineto
+          0 -42 2 -42 2 -41 -7 -12 0 5 -13 -24 5 4 -7 -7 5 blend
+          rrcurveto
+          -3 0 rlineto
+          -50 85 6 9 15 14 2 blend
+          rlineto
+          -185 307 61 94 -78 -121 2 blend
+          rlineto
+          -32 -61 -93 1 blend
+          0 rlineto
+          0 -432 rlineto
+        </CharString>
+        <CharString name="glyph00225">
+          1 vsindex
+          214 402 20 -42 2 blend
+          rmoveto
+          106 14 1 blend
+          0 75 88 11 -3 2 blend
+          0 138 3 1 blend
+          rrcurveto
+          0 136 -75 86 -106 6 -11 -6 -14 4 blend
+          0 rrcurveto
+          -104 -18 1 blend
+          0 -76 -85 -8 5 2 blend
+          0 -137 -5 1 blend
+          rrcurveto
+          0 -138 76 -88 104 -3 8 3 18 4 blend
+          0 rrcurveto
+          0 26 76 1 blend
+          rmoveto
+          -89 37 1 blend
+          0 -60 79 30 -31 2 blend
+          0 121 -45 1 blend
+          rrcurveto
+          0 120 60 77 89 -42 -30 -35 -37 4 blend
+          0 rrcurveto
+          91 -41 1 blend
+          0 59 -77 -27 35 2 blend
+          0 -120 42 1 blend
+          rrcurveto
+          0 -121 -59 -79 -91 45 27 31 41 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00226">
+          1 vsindex
+          63 410 -16 -42 2 blend
+          rmoveto
+          29 91 1 blend
+          0 rlineto
+          0 186 -51 1 blend
+          rlineto
+          90 -36 1 blend
+          0 rlineto
+          97 -7 1 blend
+          0 59 41 26 6 2 blend
+          0 85 22 1 blend
+          rrcurveto
+          0 88 -58 32 -98 20 -24 3 5 4 blend
+          0 rrcurveto
+          -119 -55 1 blend
+          0 rlineto
+          0 -432 rlineto
+          29 211 91 17 2 blend
+          rmoveto
+          0 196 -86 1 blend
+          rlineto
+          83 -37 1 blend
+          0 rlineto
+          89 -46 1 blend
+          0 44 -22 -21 8 2 blend
+          0 -73 38 1 blend
+          rrcurveto
+          0 -72 -44 -29 -89 35 23 5 44 4 blend
+          0 rrcurveto
+          -83 37 1 blend
+          0 rlineto
+        </CharString>
+        <CharString name="glyph00227">
+          1 vsindex
+          214 402 17 -42 2 blend
+          rmoveto
+          105 17 1 blend
+          0 75 89 9 -5 2 blend
+          0 138 3 1 blend
+          rrcurveto
+          0 135 -75 86 -105 7 -9 -5 -17 4 blend
+          0 rrcurveto
+          -104 -19 1 blend
+          0 -76 -85 -6 5 2 blend
+          0 -136 -7 1 blend
+          rrcurveto
+          0 -138 76 -89 104 -3 6 5 19 4 blend
+          0 rrcurveto
+          0 26 72 1 blend
+          rmoveto
+          -89 37 1 blend
+          0 -60 80 30 -32 2 blend
+          0 121 -42 1 blend
+          rrcurveto
+          0 119 60 77 89 -42 -30 -34 -37 4 blend
+          0 rrcurveto
+          90 -39 1 blend
+          0 59 -77 -27 34 2 blend
+          0 -119 42 1 blend
+          rrcurveto
+          0 -121 -59 -80 -90 42 27 32 39 4 blend
+          0 rrcurveto
+          127 -119 23 -93 2 blend
+          rmoveto
+          22 17 1 blend
+          0 21 4 11 3 8 3 7 7 4 blend
+          rrcurveto
+          -7 25 -14 60 2 blend
+          rlineto
+          -11 -2 -13 -3 -3 -4 3 blend
+          -3 -20 0 rrcurveto
+          -58 21 1 blend
+          0 -41 26 -18 49 -5 -19 2 -11 4 blend
+          rrcurveto
+          -32 -1 -89 -12 2 blend
+          rlineto
+          20 -58 50 -43 76 12 -17 21 -8 27 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00228">
+          1 vsindex
+          63 410 -16 -42 2 blend
+          rmoveto
+          29 91 1 blend
+          0 rlineto
+          0 199 -56 1 blend
+          rlineto
+          95 -46 1 blend
+          0 rlineto
+          87 7 1 blend
+          0 57 41 25 7 2 blend
+          0 79 23 1 blend
+          rrcurveto
+          0 81 -57 26 -25 2 blend
+          32 -87 -7 1 blend
+          0 rrcurveto
+          -124 -45 1 blend
+          0 rlineto
+          0 -432 rlineto
+          29 224 91 12 2 blend
+          rmoveto
+          0 183 -81 1 blend
+          rlineto
+          87 -46 1 blend
+          0 rlineto
+          79 -35 1 blend
+          0 43 -23 -20 9 2 blend
+          0 -65 30 1 blend
+          rrcurveto
+          0 -65 -43 -30 -79 32 20 10 35 4 blend
+          0 rrcurveto
+          -87 46 1 blend
+          0 rlineto
+          213 -224 -97 -12 2 blend
+          rmoveto
+          34 100 1 blend
+          0 rlineto
+          -130 216 -12 37 2 blend
+          rlineto
+          -28 -8 -53 -71 2 blend
+          rlineto
+          124 -208 -35 34 2 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00229">
+          1 vsindex
+          177 402 13 -42 2 blend
+          rmoveto
+          84 25 1 blend
+          0 55 50 6 16 2 blend
+          0 69 11 1 blend
+          rrcurveto
+          0 63 -42 26 -50 22 -9 20 4 -12 4 5 blend
+          rrcurveto
+          -68 30 14 -7 2 blend
+          rlineto
+          -31 13 -43 21 -7 3 17 -14 4 blend
+          0 50 -30 1 blend
+          rrcurveto
+          0 48 39 31 58 -31 -27 -20 -30 4 blend
+          0 rrcurveto
+          45 -11 1 blend
+          0 34 -18 26 -27 -7 4 4 7 4 blend
+          rrcurveto
+          17 19 43 55 2 blend
+          rlineto
+          -27 28 -42 23 -53 -14 11 -14 -4 4 5 blend
+          0 rrcurveto
+          -72 -27 1 blend
+          0 -55 -43 -12 -19 2 blend
+          0 -62 -11 1 blend
+          rrcurveto
+          0 -64 51 -27 38 -17 3 -16 -7 16 -6 5 blend
+          rrcurveto
+          68 -30 -14 7 2 blend
+          rlineto
+          43 -19 35 -17 -7 4 -13 10 4 blend
+          0 -55 35 1 blend
+          rrcurveto
+          0 -53 -43 -35 -67 37 33 21 35 4 blend
+          0 rrcurveto
+          -51 17 1 blend
+          0 -46 21 2 -7 2 blend
+          -32 38 -12 1 blend
+          rrcurveto
+          -19 -20 -43 -58 2 blend
+          rlineto
+          35 -38 49 -27 64 13 -4 13 7 -8 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00230">
+          1 vsindex
+          156 410 -23 -42 2 blend
+          rmoveto
+          29 91 1 blend
+          0 rlineto
+          0 407 -74 1 blend
+          rlineto
+          139 -24 1 blend
+          0 rlineto
+          0 25 74 1 blend
+          rlineto
+          -307 -45 1 blend
+          0 rlineto
+          0 -25 -74 1 blend
+          rlineto
+          139 -22 1 blend
+          0 rlineto
+          0 -407 74 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00231">
+          1 vsindex
+          209 402 21 -42 2 blend
+          rmoveto
+          74 50 1 blend
+          0 73 39 -17 31 2 blend
+          0 134 16 1 blend
+          rrcurveto
+          0 267 -47 1 blend
+          rlineto
+          -27 -89 1 blend
+          0 rlineto
+          0 -263 28 1 blend
+          rlineto
+          0 -116 -57 -35 -63 40 37 8 19 4 blend
+          0 rrcurveto
+          -62 15 1 blend
+          0 -56 35 38 -8 2 blend
+          0 116 -40 1 blend
+          rrcurveto
+          0 263 -28 1 blend
+          rlineto
+          -29 -91 1 blend
+          0 rlineto
+          0 -267 47 1 blend
+          rlineto
+          0 -134 73 -39 74 -16 -20 -31 58 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00232">
+          1 vsindex
+          146 410 -23 -42 2 blend
+          rmoveto
+          31 114 1 blend
+          0 rlineto
+          143 -14 1 blend
+          432 rlineto
+          -30 -92 1 blend
+          0 rlineto
+          -81 -252 37 67 2 blend
+          rlineto
+          -17 -53 -10 -40 -18 -52 6 8 1 -4 6 4 6 blend
+          rrcurveto
+          -3 1 1 blend
+          0 rlineto
+          -18 52 -12 40 -17 53 6 -4 3 4 6 -8 6 blend
+          rrcurveto
+          -82 252 37 -67 2 blend
+          rlineto
+          -31 -96 1 blend
+          0 rlineto
+          145 -15 1 blend
+          -432 rlineto
+        </CharString>
+        <CharString name="glyph00233">
+          117 410 -20 -34 -25 -42 2 blend
+          rmoveto
+          32 77 118 1 blend
+          0 rlineto
+          79 298 -33 -50 -79 -131 2 blend
+          rlineto
+          9 33 7 30 8 34 -2 -3 0 -1 -2 -2 3 6 -4 -3 -2 -3 6 blend
+          rrcurveto
+          3 -1 -1 1 blend
+          0 rlineto
+          8 -34 6 -30 9 -33 -4 -4 2 3 1 0 -3 -6 -2 -3 0 1 6 blend
+          rrcurveto
+          81 -298 -33 -48 79 131 2 blend
+          rlineto
+          31 78 121 1 blend
+          0 rlineto
+          100 -18 -29 1 blend
+          432 rlineto
+          -29 -52 -85 1 blend
+          0 rlineto
+          -56 -254 18 33 41 69 2 blend
+          rlineto
+          -11 -48 -8 -47 -10 -46 4 6 2 5 3 4 13 1 6 5 -12 -1 6 blend
+          rrcurveto
+          -3 -1 1 1 blend
+          0 rlineto
+          -12 46 -10 47 -13 48 4 4 12 1 2 2 -13 0 3 5 -2 -6 6 blend
+          rrcurveto
+          -69 254 17 27 -41 -69 2 blend
+          rlineto
+          -30 -48 -70 1 blend
+          0 rlineto
+          -69 -254 19 29 41 69 2 blend
+          rlineto
+          -13 -48 -10 -47 -11 -46 2 4 2 4 3 4 13 2 3 3 -12 -1 6 blend
+          rrcurveto
+          -3 -1 0 1 blend
+          0 rlineto
+          -9 46 -9 47 -11 48 3 3 12 1 5 4 -13 -3 3 6 -2 -3 6 blend
+          rrcurveto
+          -56 254 20 34 -41 -69 2 blend
+          rlineto
+          -31 -57 -92 1 blend
+          0 rlineto
+          100 -13 -23 1 blend
+          -432 rlineto
+        </CharString>
+        <CharString name="glyph00234">
+          1 vsindex
+          9 410 -2 -42 2 blend
+          rmoveto
+          30 98 1 blend
+          0 rlineto
+          77 134 -47 -59 2 blend
+          rlineto
+          12 21 12 21 14 26 -3 2 -1 1 -4 1 6 blend
+          rrcurveto
+          3 -1 1 blend
+          0 rlineto
+          16 -26 13 -21 12 -21 -5 -1 -3 -1 -2 -2 6 blend
+          rrcurveto
+          76 -134 -44 59 2 blend
+          rlineto
+          31 103 1 blend
+          0 rlineto
+          -132 223 15 -6 2 blend
+          rlineto
+          123 209 -12 6 2 blend
+          rlineto
+          -30 -99 1 blend
+          0 rlineto
+          -73 -128 50 62 2 blend
+          rlineto
+          -11 4 1 blend
+          -20 -9 -15 -13 -23 -9 3 -7 3 blend
+          rrcurveto
+          -3 0 rlineto
+          -14 23 -9 15 -12 2 7 -3 9 4 5 blend
+          20 rrcurveto
+          -72 128 45 -62 2 blend
+          rlineto
+          -32 -102 1 blend
+          0 rlineto
+          123 -208 -11 -2 2 blend
+          rlineto
+          -132 -224 13 2 2 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00235">
+          1 vsindex
+          131 410 -5 -42 2 blend
+          rmoveto
+          29 91 1 blend
+          0 rlineto
+          0 176 -28 1 blend
+          rlineto
+          132 256 -1 28 2 blend
+          rlineto
+          -30 -95 1 blend
+          0 rlineto
+          -67 -136 37 50 2 blend
+          rlineto
+          -14 -32 -16 -29 -17 -32 2 -1 5 -2 6 -2 6 blend
+          rrcurveto
+          -3 1 1 blend
+          0 rlineto
+          -17 32 -15 29 -15 32 5 2 5 2 2 1 6 blend
+          rrcurveto
+          -68 136 38 -50 2 blend
+          rlineto
+          -31 -97 1 blend
+          0 rlineto
+          132 -256 1 -28 2 blend
+          rlineto
+          0 -176 28 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00236">
+          1 vsindex
+          31 410 -10 -42 2 blend
+          rmoveto
+          293 32 1 blend
+          0 rlineto
+          0 25 74 1 blend
+          rlineto
+          -257 80 1 blend
+          0 rlineto
+          254 390 -78 -129 2 blend
+          rlineto
+          0 17 55 1 blend
+          rlineto
+          -268 -39 1 blend
+          0 rlineto
+          0 -25 -74 1 blend
+          rlineto
+          232 -73 1 blend
+          0 rlineto
+          -254 -390 78 129 2 blend
+          rlineto
+          0 -17 -55 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00237">
+          140 402 -7 -12 -25 -42 2 blend
+          rmoveto
+          44 -5 -8 1 blend
+          0 36 24 28 -4 -6 -5 -8 -2 -4 3 blend
+          24 rrcurveto
+          4 0 rlineto
+          6 -40 2 4 5 8 2 blend
+          rlineto
+          22 45 74 1 blend
+          0 rlineto
+          0 202 -10 -16 1 blend
+          rlineto
+          0 72 -22 50 -76 21 34 -21 -34 -2 -2 -6 -10 4 blend
+          0 rrcurveto
+          -52 0 -48 -26 -24 -16 -1 -2 6 10 -14 -24 -7 -12 4 blend
+          rrcurveto
+          12 -22 18 30 -33 -56 2 blend
+          rlineto
+          22 16 46 22 42 8 13 1 2 -12 -19 -7 -12 -11 -18 5 blend
+          0 rrcurveto
+          58 -18 -31 1 blend
+          0 14 -44 0 -54 21 35 2 3 19 31 3 blend
+          rrcurveto
+          -144 -14 -64 -34 8 16 2 2 7 10 -2 -4 4 blend
+          0 -70 -2 0 1 blend
+          rrcurveto
+          0 -58 40 -32 56 2 4 -1 -2 -9 -16 5 8 4 blend
+          0 rrcurveto
+          6 26 21 35 38 64 2 blend
+          rmoveto
+          -44 15 25 1 blend
+          0 -28 20 11 18 -7 -12 2 blend
+          0 46 -20 -32 1 blend
+          rrcurveto
+          0 48 46 32 132 14 -20 -30 -18 -30 -10 -14 -48 -80 -4 -8 5 blend
+          rrcurveto
+          0 -108 42 64 1 blend
+          rlineto
+          -38 -36 -36 -16 -32 15 26 14 24 16 26 5 8 9 15 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00238">
+          1 vsindex
+          186 402 42 -42 2 blend
+          rmoveto
+          76 -6 1 blend
+          0 64 4 1 blend
+          64 0 108 8 1 blend
+          rrcurveto
+          0 98 -42 62 -88 2 -10 6 10 4 blend
+          0 rrcurveto
+          -42 13 1 blend
+          0 -34 -24 -34 -28 4 11 11 7 4 blend
+          rrcurveto
+          2 64 2 -17 2 blend
+          rlineto
+          0 138 -31 1 blend
+          rlineto
+          -28 -92 1 blend
+          0 rlineto
+          0 -474 14 1 blend
+          rlineto
+          22 70 1 blend
+          0 rlineto
+          4 30 6 6 2 blend
+          rlineto
+          4 0 rlineto
+          30 -24 36 -8 -6 -4 3 blend
+          -14 30 0 rrcurveto
+          2 26 -32 68 2 blend
+          rmoveto
+          -28 14 1 blend
+          0 -38 12 -34 30 26 -8 20 -20 4 blend
+          rrcurveto
+          0 184 -62 1 blend
+          rlineto
+          36 34 38 20 32 -22 -18 -26 -14 -16 5 blend
+          0 rrcurveto
+          72 -44 1 blend
+          0 30 -56 -14 36 2 blend
+          0 -78 24 1 blend
+          rrcurveto
+          0 -88 -46 -58 -62 26 24 36 38 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00239">
+          1 vsindex
+          182 402 6 -42 2 blend
+          rmoveto
+          48 6 1 blend
+          0 28 18 24 20 12 2 -2 -2 4 blend
+          rrcurveto
+          -14 20 -34 56 2 blend
+          rlineto
+          -22 -18 -26 -14 -38 10 8 12 4 12 5 blend
+          0 rrcurveto
+          -70 34 1 blend
+          0 -48 58 24 -26 2 blend
+          0 82 -34 1 blend
+          rrcurveto
+          0 82 50 58 66 -34 -24 -26 -30 4 blend
+          0 rrcurveto
+          38 -24 1 blend
+          0 18 -10 24 -20 -4 4 -12 10 4 blend
+          rrcurveto
+          16 20 38 56 2 blend
+          rlineto
+          -22 18 -28 6 -2 -10 3 blend
+          18 -44 -8 1 blend
+          0 rrcurveto
+          -78 -14 1 blend
+          0 -70 -60 -10 -6 2 blend
+          0 -106 -2 1 blend
+          rrcurveto
+          0 -106 62 -60 86 -4 8 -4 10 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00240">
+          1 vsindex
+          176 402 -16 -42 2 blend
+          rmoveto
+          40 -8 1 blend
+          0 28 22 28 24 2 -6 -6 -2 4 blend
+          rrcurveto
+          4 -2 1 blend
+          0 rlineto
+          6 -38 2 8 2 blend
+          rlineto
+          22 76 1 blend
+          0 rlineto
+          0 474 -14 1 blend
+          rlineto
+          -28 -92 1 blend
+          0 rlineto
+          0 -130 28 1 blend
+          rlineto
+          2 -58 4 6 2 blend
+          rlineto
+          -32 24 -30 14 -4 4 3 blend
+          14 -36 2 1 blend
+          0 rrcurveto
+          -76 12 1 blend
+          0 -66 -62 -6 -2 2 blend
+          0 -98 -6 1 blend
+          rrcurveto
+          0 -110 52 -62 86 -4 1 -4 -3 4 blend
+          0 rrcurveto
+          2 26 32 68 2 blend
+          rmoveto
+          -76 46 1 blend
+          0 -34 58 16 -36 2 blend
+          0 88 -24 1 blend
+          rrcurveto
+          0 76 50 58 60 -24 -28 -36 -36 4 blend
+          0 rrcurveto
+          30 -16 1 blend
+          0 34 -12 34 -30 -22 8 -20 18 4 blend
+          rrcurveto
+          0 -186 66 1 blend
+          rlineto
+          -36 -32 -30 -20 -32 26 14 18 14 16 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00241">
+          180 402 10 16 -26 -42 2 blend
+          rmoveto
+          48 -6 -11 1 blend
+          0 32 18 26 16 8 15 -4 -4 8 12 8 10 4 blend
+          rrcurveto
+          -14 22 -14 -24 28 46 2 blend
+          rlineto
+          -22 -16 -32 -14 -36 0 -2 2 2 4 10 6 10 8 14 5 blend
+          0 rrcurveto
+          -74 25 38 1 blend
+          0 -46 56 0 80 9 16 -28 -46 -6 -10 -28 -38 4 blend
+          rrcurveto
+          234 -29 -46 1 blend
+          0 rlineto
+          2 16 0 4 1 2 -2 -2 2 2 8 6 4 blend
+          0 10 8 10 1 blend
+          rrcurveto
+          0 48 -22 92 -102 24 42 -15 -26 -12 -20 1 4 4 blend
+          0 rrcurveto
+          -78 -5 -8 1 blend
+          0 -64 -64 -7 -12 -2 -4 2 blend
+          0 -102 -2 -4 1 blend
+          rrcurveto
+          0 -108 66 -58 82 6 10 -6 -8 10 16 3 blend
+          0 rrcurveto
+          -118 188 36 56 16 20 2 blend
+          rmoveto
+          8 72 42 46 62 -2 -2 -28 -36 -14 -22 -18 -32 -22 -37 5 blend
+          0 rrcurveto
+          72 -26 -39 1 blend
+          0 24 -64 -8 -12 26 42 2 blend
+          0 -54 20 26 1 blend
+          rrcurveto
+          -208 72 112 1 blend
+          0 rlineto
+        </CharString>
+        <CharString name="glyph00242">
+          1 vsindex
+          68 410 -10 -42 2 blend
+          rmoveto
+          28 92 1 blend
+          0 rlineto
+          0 386 -50 1 blend
+          rlineto
+          0 40 16 30 34 -5 -2 -17 -14 4 blend
+          0 rrcurveto
+          18 -6 1 blend
+          0 12 -4 10 -4 2 -2 2 3 blend
+          rrcurveto
+          8 24 14 60 2 blend
+          rlineto
+          -18 8 -12 2 -18 2 -2 -14 4 -12 5 blend
+          0 rrcurveto
+          -50 -52 1 blend
+          0 -28 -38 -6 -32 2 blend
+          0 -62 -12 1 blend
+          rrcurveto
+          0 -382 50 1 blend
+          rlineto
+          -46 292 2 -52 2 blend
+          rmoveto
+          150 69 1 blend
+          0 rlineto
+          0 24 68 1 blend
+          rlineto
+          -104 -64 1 blend
+          0 rlineto
+          -46 -2 -5 -2 2 blend
+          rlineto
+          0 -22 -66 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00243">
+          1 vsindex
+          166 258 -6 -26 2 blend
+          rmoveto
+          94 28 1 blend
+          0 58 52 16 -2 2 blend
+          0 54 18 1 blend
+          rrcurveto
+          0 52 -32 22 -73 9 -14 3 -13 4 blend
+          0 rrcurveto
+          -69 19 1 blend
+          0 rlineto
+          -46 12 1 blend
+          0 -16 16 4 -12 2 blend
+          0 24 -10 1 blend
+          rrcurveto
+          0 20 12 14 14 10 -12 -10 -10 -8 -4 5 blend
+          rrcurveto
+          16 -10 20 -4 18 6 -10 4 -8 4 blend
+          0 rrcurveto
+          63 11 1 blend
+          0 51 48 11 -16 2 blend
+          0 66 12 1 blend
+          rrcurveto
+          0 30 -14 30 -20 16 -18 12 -17 18 -9 5 blend
+          rrcurveto
+          72 -26 1 blend
+          0 rlineto
+          0 26 60 1 blend
+          rlineto
+          -103 -21 1 blend
+          0 rlineto
+          -14 -2 1 blend
+          6 -14 4 -21 -6 -2 3 3 blend
+          0 rrcurveto
+          -64 -11 1 blend
+          0 -50 -46 -20 7 2 blend
+          0 -66 -17 1 blend
+          rrcurveto
+          0 -38 20 1 1 blend
+          -31 21 -17 4 2 2 blend
+          rrcurveto
+          0 -4 rlineto
+          -15 -10 -20 -20 -9 -6 7 -4 4 blend
+          0 -26 4 1 blend
+          rrcurveto
+          0 -24 -4 1 blend
+          12 -18 16 -10 2 2 -2 3 blend
+          rrcurveto
+          0 -4 rlineto
+          -30 -20 6 1 blend
+          -16 -26 6 1 blend
+          0 -28 rrcurveto
+          0 -54 48 -34 82 -6 16 12 -6 4 blend
+          0 rrcurveto
+          -4 276 16 34 2 blend
+          rmoveto
+          -50 30 1 blend
+          0 -36 36 22 -22 2 blend
+          0 52 -22 1 blend
+          rrcurveto
+          0 54 36 32 50 -24 -22 -18 -30 4 blend
+          0 rrcurveto
+          46 -26 1 blend
+          0 40 -33 -27 19 2 blend
+          0 -53 23 1 blend
+          rrcurveto
+          0 -52 -40 -36 -46 22 27 22 26 4 blend
+          0 rrcurveto
+          8 -250 12 1 blend
+          rmoveto
+          -68 30 1 blend
+          0 -38 24 12 -14 2 blend
+          0 41 -21 1 blend
+          rrcurveto
+          0 23 14 22 28 18 -15 -9 -15 -21 -11 5 blend
+          rrcurveto
+          14 -4 18 -2 1 blend
+          0 8 8 1 blend
+          0 rrcurveto
+          68 -42 1 blend
+          0 rlineto
+          48 -20 1 blend
+          0 28 -12 -14 8 2 blend
+          0 -34 19 1 blend
+          rrcurveto
+          0 -40 -48 -38 -72 23 22 26 36 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00244">
+          1 vsindex
+          60 410 -22 -42 2 blend
+          rmoveto
+          28 92 1 blend
+          0 rlineto
+          0 238 -23 1 blend
+          rlineto
+          42 42 34 18 30 -26 -27 -22 -8 -12 5 blend
+          0 rrcurveto
+          64 -36 1 blend
+          0 14 -40 -10 24 2 blend
+          0 -60 24 1 blend
+          rrcurveto
+          0 -198 10 1 blend
+          rlineto
+          28 92 1 blend
+          0 rlineto
+          0 204 -2 1 blend
+          rlineto
+          0 70 -24 50 -76 14 -6 4 1 4 blend
+          0 rrcurveto
+          -42 -3 1 blend
+          0 -40 -26 -30 -32 6 2 8 10 4 blend
+          rrcurveto
+          0 72 8 -14 2 blend
+          rlineto
+          0 136 -28 1 blend
+          rlineto
+          -28 -92 1 blend
+          0 rlineto
+          0 -474 14 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00245">
+          1 vsindex
+          60 410 -22 -42 2 blend
+          rmoveto
+          28 92 1 blend
+          0 rlineto
+          0 316 16 1 blend
+          rlineto
+          -28 -92 1 blend
+          0 rlineto
+          0 -316 -16 1 blend
+          rlineto
+          16 392 44 -22 2 blend
+          rmoveto
+          16 22 1 blend
+          0 12 12 16 12 2 blend
+          0 16 18 1 blend
+          rrcurveto
+          0 16 -12 12 -16 18 -16 12 -22 4 blend
+          0 rrcurveto
+          -16 -23 1 blend
+          0 -12 -12 -15 -12 2 blend
+          0 -16 -18 1 blend
+          rrcurveto
+          0 -16 12 -12 16 -18 15 -12 23 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00246">
+          1 vsindex
+          20 258 8 -22 2 blend
+          rmoveto
+          46 56 1 blend
+          0 24 28 6 42 2 blend
+          0 70 4 1 blend
+          rrcurveto
+          0 370 -50 1 blend
+          rlineto
+          -28 -92 1 blend
+          0 rlineto
+          0 -374 50 1 blend
+          rlineto
+          0 -40 -8 -26 -36 4 1 14 13 4 blend
+          0 rrcurveto
+          -14 3 1 blend
+          0 -6 -3 1 blend
+          2 -10 4 4 -2 2 blend
+          rrcurveto
+          -8 -26 -12 -62 2 blend
+          rlineto
+          16 -6 8 -2 16 -2 2 10 -2 16 5 blend
+          0 rrcurveto
+          58 544 14 -42 2 blend
+          rmoveto
+          16 22 1 blend
+          0 12 12 16 12 2 blend
+          0 16 18 1 blend
+          rrcurveto
+          0 16 -12 12 -16 18 -16 12 -22 4 blend
+          0 rrcurveto
+          -16 -23 1 blend
+          0 -12 -12 -15 -12 2 blend
+          0 -16 -18 1 blend
+          rrcurveto
+          0 -16 12 -12 16 -18 15 -12 23 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00247">
+          1 vsindex
+          60 410 -22 -42 2 blend
+          rmoveto
+          28 92 1 blend
+          0 rlineto
+          0 82 -2 1 blend
+          rlineto
+          72 86 -44 -52 2 blend
+          rlineto
+          110 -168 -44 54 2 blend
+          rlineto
+          34 94 1 blend
+          0 rlineto
+          -124 -4 1 blend
+          190 rlineto
+          106 126 16 16 2 blend
+          rlineto
+          -36 -92 1 blend
+          0 rlineto
+          -158 -188 74 74 2 blend
+          rlineto
+          -4 0 rlineto
+          0 346 -104 1 blend
+          rlineto
+          -28 -92 1 blend
+          0 rlineto
+          0 -474 14 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00248">
+          1 vsindex
+          102 402 42 -42 2 blend
+          rmoveto
+          10 18 1 blend
+          0 6 2 6 2 10 2 8 4 4 blend
+          rrcurveto
+          -6 24 -8 62 2 blend
+          rlineto
+          -6 -2 -4 2 1 blend
+          0 -4 0 rrcurveto
+          -10 0 -6 6 -2 2 2 blend
+          0 16 6 1 blend
+          rrcurveto
+          0 434 -90 1 blend
+          rlineto
+          -28 -92 1 blend
+          0 rlineto
+          0 -428 88 1 blend
+          rlineto
+          0 -36 12 -18 30 -40 14 -34 50 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00249">
+          1 vsindex
+          60 410 -22 -42 2 blend
+          rmoveto
+          28 92 1 blend
+          0 rlineto
+          0 238 -22 1 blend
+          rlineto
+          40 42 28 18 30 -24 -26 -14 -10 -18 5 blend
+          0 rrcurveto
+          58 -32 1 blend
+          0 16 -40 -8 24 2 blend
+          0 -60 24 1 blend
+          rrcurveto
+          0 -198 10 1 blend
+          rlineto
+          28 92 1 blend
+          0 rlineto
+          0 238 -22 1 blend
+          rlineto
+          40 42 28 18 30 -24 -26 -14 -10 -18 5 blend
+          0 rrcurveto
+          58 -32 1 blend
+          0 16 -40 -8 24 2 blend
+          0 -60 24 1 blend
+          rrcurveto
+          0 -198 10 1 blend
+          rlineto
+          28 92 1 blend
+          0 rlineto
+          0 204 -2 1 blend
+          rlineto
+          0 70 -26 50 -70 14 -8 4 -4 4 blend
+          0 rrcurveto
+          -42 -4 1 blend
+          0 -38 -30 -32 -34 8 4 5 6 4 blend
+          rrcurveto
+          -12 44 -32 -7 -10 3 3 blend
+          20 -44 -1 1 blend
+          0 rrcurveto
+          -42 -4 1 blend
+          0 -32 4 1 blend
+          -24 -28 -32 2 6 2 blend
+          rrcurveto
+          -4 2 1 blend
+          0 rlineto
+          -4 48 -5 -6 2 blend
+          rlineto
+          -22 -75 1 blend
+          0 rlineto
+          0 -316 -16 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00250">
+          1 vsindex
+          60 410 -22 -42 2 blend
+          rmoveto
+          28 92 1 blend
+          0 rlineto
+          0 238 -23 1 blend
+          rlineto
+          42 42 34 18 32 -26 -27 -22 -8 -14 5 blend
+          0 rrcurveto
+          62 -34 1 blend
+          0 14 -40 -10 24 2 blend
+          0 -60 24 1 blend
+          rrcurveto
+          0 -198 10 1 blend
+          rlineto
+          28 92 1 blend
+          0 rlineto
+          0 204 -2 1 blend
+          rlineto
+          0 70 -24 50 -76 14 -6 4 1 4 blend
+          0 rrcurveto
+          -42 -3 1 blend
+          0 -38 4 1 blend
+          -24 -30 -32 4 6 2 blend
+          rrcurveto
+          -4 2 1 blend
+          0 rlineto
+          -4 48 -6 -6 2 blend
+          rlineto
+          -22 -74 1 blend
+          0 rlineto
+          0 -316 -16 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00251">
+          1 vsindex
+          178 402 10 -42 2 blend
+          rmoveto
+          80 6 1 blend
+          0 64 62 16 2 2 blend
+          0 104 5 1 blend
+          rrcurveto
+          0 106 -64 60 -80 4 -16 5 -6 4 blend
+          0 rrcurveto
+          -80 -6 1 blend
+          0 -64 -60 -16 -5 2 blend
+          0 -106 -4 1 blend
+          rrcurveto
+          0 -104 64 -62 80 -5 16 -2 6 4 blend
+          0 rrcurveto
+          0 26 68 1 blend
+          rmoveto
+          -68 35 1 blend
+          0 -46 58 35 -27 2 blend
+          0 82 -34 1 blend
+          rrcurveto
+          0 84 46 56 68 -35 -35 -24 -35 4 blend
+          0 rrcurveto
+          68 -35 1 blend
+          0 46 -56 -35 24 2 blend
+          0 -84 35 1 blend
+          rrcurveto
+          0 -82 -46 -58 -68 34 35 27 35 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00252">
+          1 vsindex
+          60 270 -22 -34 2 blend
+          rmoveto
+          28 92 1 blend
+          0 rlineto
+          0 112 -22 1 blend
+          rlineto
+          -2 59 -4 9 2 blend
+          rlineto
+          30 -25 40 -14 30 -8 3 -14 2 -2 5 blend
+          0 rrcurveto
+          76 -6 1 blend
+          0 64 4 1 blend
+          64 0 108 8 1 blend
+          rrcurveto
+          0 98 -42 62 -88 2 -10 6 10 4 blend
+          0 rrcurveto
+          -42 10 1 blend
+          0 -34 -24 -28 -24 -4 6 6 2 4 blend
+          rrcurveto
+          -4 2 1 blend
+          0 rlineto
+          -6 40 -2 -8 2 blend
+          rlineto
+          -22 -74 1 blend
+          0 rlineto
+          0 -456 -8 1 blend
+          rlineto
+          128 158 32 60 2 blend
+          rmoveto
+          -28 14 1 blend
+          0 -38 12 -34 30 26 -8 20 -20 4 blend
+          rrcurveto
+          0 184 -62 1 blend
+          rlineto
+          36 34 38 20 32 -22 -18 -26 -14 -16 5 blend
+          0 rrcurveto
+          72 -44 1 blend
+          0 30 -56 -14 36 2 blend
+          0 -78 24 1 blend
+          rrcurveto
+          0 -88 -46 -58 -62 26 24 36 38 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00253">
+          1 vsindex
+          276 270 -44 -34 2 blend
+          rmoveto
+          28 92 1 blend
+          0 rlineto
+          0 456 8 1 blend
+          rlineto
+          -22 -70 1 blend
+          0 rlineto
+          -4 -30 -6 -6 2 blend
+          rlineto
+          -4 2 1 blend
+          0 rlineto
+          -26 24 -32 1 6 5 3 blend
+          14 -36 4 1 blend
+          0 rrcurveto
+          -76 8 1 blend
+          0 -66 -62 -6 -4 2 blend
+          0 -104 -4 1 blend
+          rrcurveto
+          0 -104 52 -62 86 -4 2 -4 -2 4 blend
+          0 rrcurveto
+          40 -14 1 blend
+          0 34 18 28 26 -2 -4 -10 -6 4 blend
+          rrcurveto
+          -2 -62 -4 10 2 blend
+          rlineto
+          0 -114 8 1 blend
+          rlineto
+          -98 158 60 62 2 blend
+          rmoveto
+          -76 46 1 blend
+          0 -34 58 16 -36 2 blend
+          0 82 -24 1 blend
+          rrcurveto
+          0 82 50 58 60 -26 -26 -38 -38 4 blend
+          0 rrcurveto
+          30 -16 1 blend
+          0 34 -12 34 -30 -20 6 -22 20 4 blend
+          rrcurveto
+          0 -192 74 1 blend
+          rlineto
+          -34 -30 -32 -16 -32 22 12 22 12 16 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00254">
+          1 vsindex
+          60 410 -22 -42 2 blend
+          rmoveto
+          30 90 1 blend
+          0 rlineto
+          0 216 -34 1 blend
+          rlineto
+          26 58 33 20 31 -10 -18 -5 -6 -7 5 blend
+          0 rrcurveto
+          10 4 1 blend
+          0 12 -2 6 2 -2 4 3 blend
+          -2 rrcurveto
+          8 28 12 74 2 blend
+          rlineto
+          -8 -1 1 blend
+          4 -14 2 -12 1 2 -10 3 blend
+          0 rrcurveto
+          -38 6 1 blend
+          0 -28 -24 -24 -40 -8 4 -2 -6 4 blend
+          rrcurveto
+          -4 2 1 blend
+          0 rlineto
+          -6 56 -3 2 2 blend
+          rlineto
+          -22 -75 1 blend
+          0 rlineto
+          0 -316 -16 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00255">
+          1 vsindex
+          144 402 -1 -42 2 blend
+          rmoveto
+          60 35 1 blend
+          0 44 38 6 10 2 blend
+          0 54 9 1 blend
+          rrcurveto
+          0 60 -54 14 -50 20 -1 8 12 12 -6 5 blend
+          rrcurveto
+          -40 16 -36 12 8 -4 4 -6 4 blend
+          0 38 -22 1 blend
+          rrcurveto
+          0 26 22 28 46 -14 -12 -22 -28 4 blend
+          0 rrcurveto
+          36 -16 1 blend
+          0 18 -10 6 -2 2 blend
+          24 -18 2 1 blend
+          rrcurveto
+          18 22 34 48 2 blend
+          rlineto
+          -24 18 -32 14 -40 -6 4 -6 8 -16 5 blend
+          0 rrcurveto
+          -64 -16 1 blend
+          0 -34 -42 -20 -2 2 blend
+          0 -40 -25 1 blend
+          rrcurveto
+          0 -56 54 -20 48 -18 1 -10 -8 -8 2 5 blend
+          rrcurveto
+          38 -4 1 blend
+          -14 40 -16 -10 10 2 blend
+          0 -38 22 1 blend
+          rrcurveto
+          0 -34 -28 -28 -46 22 18 22 24 4 blend
+          0 rrcurveto
+          -44 22 1 blend
+          0 -32 18 -28 4 -8 -4 3 blend
+          22 rrcurveto
+          -18 -22 -32 -52 2 blend
+          rlineto
+          30 -24 42 -20 50 5 -2 9 2 -7 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00256">
+          1 vsindex
+          150 402 28 -42 2 blend
+          rmoveto
+          14 24 1 blend
+          0 24 6 16 4 1 blend
+          6 rrcurveto
+          -8 24 -12 60 2 blend
+          rlineto
+          -14 -6 -14 -4 -14 4 2 6 4 4 5 blend
+          0 rrcurveto
+          -42 22 1 blend
+          0 -14 28 -4 -16 2 blend
+          0 42 -6 1 blend
+          rrcurveto
+          0 202 -94 1 blend
+          rlineto
+          96 -22 1 blend
+          0 rlineto
+          0 26 66 1 blend
+          rlineto
+          -96 22 1 blend
+          0 rlineto
+          0 104 -20 1 blend
+          rlineto
+          -24 -76 1 blend
+          0 rlineto
+          -4 -104 -10 20 2 blend
+          rlineto
+          -51 -2 1 -2 2 blend
+          rlineto
+          0 -24 -64 1 blend
+          rlineto
+          51 -7 1 blend
+          0 rlineto
+          0 -200 90 1 blend
+          rlineto
+          0 -58 18 -40 62 -24 18 -16 26 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00257">
+          1 vsindex
+          160 402 -20 -42 2 blend
+          rmoveto
+          42 4 1 blend
+          0 38 24 30 32 -4 2 -8 -10 4 blend
+          rrcurveto
+          4 -2 1 blend
+          0 rlineto
+          4 -48 8 8 2 blend
+          rlineto
+          22 74 1 blend
+          0 rlineto
+          0 316 16 1 blend
+          rlineto
+          -28 -92 1 blend
+          0 rlineto
+          0 -238 22 1 blend
+          rlineto
+          -42 -42 -34 -18 -32 28 26 20 10 16 5 blend
+          0 rrcurveto
+          -62 32 1 blend
+          0 -14 40 10 -26 2 blend
+          0 60 -24 1 blend
+          rrcurveto
+          0 198 -8 1 blend
+          rlineto
+          -28 -92 1 blend
+          0 rlineto
+          0 -204 -1 1 blend
+          rlineto
+          0 -70 24 -50 76 -12 9 -3 -3 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00258">
+          1 vsindex
+          128 410 -12 -42 2 blend
+          rmoveto
+          36 102 1 blend
+          0 rlineto
+          122 316 -16 16 2 blend
+          rlineto
+          -30 -84 1 blend
+          0 rlineto
+          -72 -196 38 54 2 blend
+          rlineto
+          -36 -92 12 -12 2 blend
+          rlineto
+          -4 2 1 blend
+          0 rlineto
+          -34 92 8 12 2 blend
+          rlineto
+          -72 196 38 -54 2 blend
+          rlineto
+          -30 -88 1 blend
+          0 rlineto
+          120 -316 -12 -16 2 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00259">
+          1 vsindex
+          110 410 -14 -42 2 blend
+          rmoveto
+          38 98 1 blend
+          0 rlineto
+          56 194 -34 -82 2 blend
+          rlineto
+          24 92 -10 -2 2 blend
+          rlineto
+          2 0 rlineto
+          26 -92 -12 2 2 blend
+          rlineto
+          54 -194 -30 82 2 blend
+          rlineto
+          38 100 1 blend
+          0 rlineto
+          94 316 -19 16 2 blend
+          rlineto
+          -30 -79 1 blend
+          0 rlineto
+          -54 -204 30 68 2 blend
+          rlineto
+          -26 -86 13 -16 2 blend
+          rlineto
+          -4 1 1 blend
+          0 rlineto
+          -24 86 6 16 2 blend
+          rlineto
+          -58 204 22 -68 2 blend
+          rlineto
+          -34 -60 1 blend
+          0 rlineto
+          -56 -204 22 68 2 blend
+          rlineto
+          -24 -86 7 -16 2 blend
+          rlineto
+          -4 1 1 blend
+          0 rlineto
+          -24 86 12 16 2 blend
+          rlineto
+          -56 204 32 -68 2 blend
+          rlineto
+          -32 -86 1 blend
+          0 rlineto
+          94 -316 -14 -16 2 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00260">
+          1 vsindex
+          8 410 -42 1 blend
+          rmoveto
+          32 92 1 blend
+          0 rlineto
+          54 84 -36 -40 2 blend
+          rlineto
+          40 58 -18 -8 2 blend
+          rlineto
+          4 0 rlineto
+          38 -58 -8 8 2 blend
+          rlineto
+          54 -84 -30 40 2 blend
+          rlineto
+          34 92 1 blend
+          0 rlineto
+          -108 164 8 -6 2 blend
+          rlineto
+          100 152 -4 22 2 blend
+          rlineto
+          -32 -92 1 blend
+          0 rlineto
+          -50 -78 34 32 2 blend
+          rlineto
+          -32 -52 14 2 2 blend
+          rlineto
+          -4 0 rlineto
+          -34 52 8 -2 2 blend
+          rlineto
+          -52 78 30 -32 2 blend
+          rlineto
+          -34 -94 1 blend
+          0 rlineto
+          102 -150 -6 -10 2 blend
+          rlineto
+          -112 -166 10 -6 2 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00261">
+          1 vsindex
+          50 268 40 -20 2 blend
+          rmoveto
+          58 28 1 blend
+          0 34 54 18 54 2 -16 18 36 4 blend
+          rrcurveto
+          124 350 -14 -26 2 blend
+          rlineto
+          -30 -84 1 blend
+          0 rlineto
+          -66 -196 36 72 2 blend
+          rlineto
+          -10 -30 -12 2 -2 4 3 blend
+          -30 -10 4 1 blend
+          -32 rrcurveto
+          -4 0 rlineto
+          -12 32 -14 34 4 2 10 -8 4 blend
+          -10 26 8 1 blend
+          rrcurveto
+          -78 196 40 -72 2 blend
+          rlineto
+          -30 -90 1 blend
+          0 rlineto
+          132 -321 -4 3 2 blend
+          rlineto
+          -8 -25 4 13 2 blend
+          rlineto
+          -16 -50 -28 -34 -38 10 32 12 20 8 5 blend
+          0 rrcurveto
+          -9 3 1 blend
+          0 -9 2 -8 5 -2 -4 3 blend
+          4 rrcurveto
+          -8 -28 -12 -60 2 blend
+          rlineto
+          10 6 1 blend
+          -4 12 2 1 blend
+          -2 12 10 1 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00262">
+          1 vsindex
+          18 410 8 -42 2 blend
+          rmoveto
+          236 42 1 blend
+          0 rlineto
+          0 26 66 1 blend
+          rlineto
+          -198 69 1 blend
+          0 rlineto
+          192 272 -67 -96 2 blend
+          rlineto
+          0 18 46 1 blend
+          rlineto
+          -208 -50 1 blend
+          0 rlineto
+          0 -26 -66 1 blend
+          rlineto
+          170 -60 1 blend
+          0 rlineto
+          -192 -274 66 98 2 blend
+          rlineto
+          0 -16 -48 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00263">
+          1 vsindex
+          212 778 -4 -32 2 blend
+          rmoveto
+          18 16 36 40 2 blend
+          rlineto
+          -112 112 -30 20 2 blend
+          rlineto
+          -20 -18 -50 -60 2 blend
+          rlineto
+          114 44 1 blend
+          -110 rlineto
+          -32 -378 20 -8 2 blend
+          rmoveto
+          48 -11 1 blend
+          0 32 18 26 16 15 -4 12 10 4 blend
+          rrcurveto
+          -14 22 -24 46 2 blend
+          rlineto
+          -22 -16 -32 -14 -36 -2 2 10 10 14 5 blend
+          0 rrcurveto
+          -74 38 1 blend
+          0 -46 56 0 80 16 -46 -10 -38 4 blend
+          rrcurveto
+          234 -46 1 blend
+          0 rlineto
+          2 16 0 4 2 -2 2 6 4 blend
+          0 10 10 1 blend
+          rrcurveto
+          0 48 -22 92 -102 42 -26 -20 4 4 blend
+          0 rrcurveto
+          -78 -8 1 blend
+          0 -64 -64 -12 -4 2 blend
+          0 -102 -4 1 blend
+          rrcurveto
+          0 -108 66 -58 82 10 -8 16 3 blend
+          0 rrcurveto
+          -118 188 56 20 2 blend
+          rmoveto
+          8 72 42 46 62 -2 -36 -22 -32 -37 5 blend
+          0 rrcurveto
+          72 -39 1 blend
+          0 24 -64 -12 42 2 blend
+          0 -54 26 1 blend
+          rrcurveto
+          -208 112 1 blend
+          0 rlineto
+        </CharString>
+        <CharString name="glyph00264">
+          1 vsindex
+          132 778 20 -32 2 blend
+          rmoveto
+          114 44 1 blend
+          110 rlineto
+          -20 18 -50 60 2 blend
+          rlineto
+          -112 -112 -30 -20 2 blend
+          rlineto
+          18 -16 36 -40 2 blend
+          rlineto
+          48 -376 -4 -10 2 blend
+          rmoveto
+          48 -11 1 blend
+          0 32 18 26 16 15 -4 12 10 4 blend
+          rrcurveto
+          -14 22 -24 46 2 blend
+          rlineto
+          -22 -16 -32 -14 -36 -2 2 10 10 14 5 blend
+          0 rrcurveto
+          -74 38 1 blend
+          0 -46 56 0 80 16 -46 -10 -38 4 blend
+          rrcurveto
+          234 -46 1 blend
+          0 rlineto
+          2 16 0 4 2 -2 2 6 4 blend
+          0 10 10 1 blend
+          rrcurveto
+          0 48 -22 92 -102 42 -26 -20 4 4 blend
+          0 rrcurveto
+          -78 -8 1 blend
+          0 -64 -64 -12 -4 2 blend
+          0 -102 -4 1 blend
+          rrcurveto
+          0 -108 66 -58 82 10 -8 16 3 blend
+          0 rrcurveto
+          -118 188 56 20 2 blend
+          rmoveto
+          8 72 42 46 62 -2 -36 -22 -32 -37 5 blend
+          0 rrcurveto
+          72 -39 1 blend
+          0 24 -64 -12 42 2 blend
+          0 -54 26 1 blend
+          rrcurveto
+          -208 112 1 blend
+          0 rlineto
+        </CharString>
+        <CharString name="glyph00265">
+          1 vsindex
+          76 402 34 -42 2 blend
+          rmoveto
+          18 22 1 blend
+          0 14 12 16 18 2 blend
+          0 22 18 1 blend
+          rrcurveto
+          0 22 -14 12 -18 18 -16 20 -22 4 blend
+          0 rrcurveto
+          -18 -22 1 blend
+          0 -14 -12 -16 -20 2 blend
+          0 -22 -18 1 blend
+          rrcurveto
+          0 -22 14 -12 18 -18 16 -18 22 4 blend
+          0 rrcurveto
+          0 240 -40 1 blend
+          rmoveto
+          18 22 1 blend
+          0 14 12 16 18 2 blend
+          0 22 18 1 blend
+          rrcurveto
+          0 22 -14 12 -18 18 -16 20 -22 4 blend
+          0 rrcurveto
+          -18 -22 1 blend
+          0 -14 -12 -16 -20 2 blend
+          0 -22 -18 1 blend
+          rrcurveto
+          0 -22 14 -12 18 -18 16 -18 22 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="glyph00266">
+          1 vsindex
+          40 562 4 -36 2 blend
+          rmoveto
+          147 23 1 blend
+          0 rlineto
+          0 24 58 1 blend
+          rlineto
+          -147 -23 1 blend
+          0 rlineto
+          0 -24 -58 1 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00272">
+          1 vsindex
+          -164 -8 1 blend
+          -12 rmoveto
+          32 64 1 blend
+          0 rlineto
+          370 684 -22 -10 2 blend
+          rlineto
+          -32 -64 1 blend
+          0 rlineto
+          -370 -684 22 10 2 blend
+          rlineto
+        </CharString>
+        <CharString name="glyph00293">
+        </CharString>
+        <CharString name="grave">
+          1 vsindex
+          310 574 10 -2 2 blend
+          rmoveto
+          18 16 66 68 2 blend
+          rlineto
+          -142 154 -76 34 2 blend
+          rlineto
+          -24 -20 -72 -94 2 blend
+          rlineto
+          148 -150 82 -8 2 blend
+          rlineto
+        </CharString>
+        <CharString name="greater">
+          1 vsindex
+          34 152 -58 1 blend
+          rmoveto
+          404 162 68 18 2 blend
+          rlineto
+          0 36 80 1 blend
+          rlineto
+          -404 162 -68 18 2 blend
+          rlineto
+          0 -32 -108 1 blend
+          rlineto
+          240 -94 -78 44 2 blend
+          rlineto
+          132 -52 4 6 2 blend
+          rlineto
+          0 -4 rlineto
+          -132 -52 -4 6 2 blend
+          rlineto
+          -240 -94 78 44 2 blend
+          rlineto
+          0 -32 -108 1 blend
+          rlineto
+        </CharString>
+        <CharString name="guillemotleft">
+          1 vsindex
+          180 74 4 -22 2 blend
+          rmoveto
+          20 16 42 34 2 blend
+          rlineto
+          -124 162 16 -12 2 blend
+          rlineto
+          124 160 -16 -10 2 blend
+          rlineto
+          -20 18 -42 32 2 blend
+          rlineto
+          -138 -164 4 24 2 blend
+          rlineto
+          0 -28 -92 1 blend
+          rlineto
+          138 -164 -4 24 2 blend
+          rlineto
+          134 66 1 blend
+          0 rmoveto
+          20 16 42 34 2 blend
+          rlineto
+          -124 162 16 -12 2 blend
+          rlineto
+          124 160 -16 -10 2 blend
+          rlineto
+          -20 18 -42 32 2 blend
+          rlineto
+          -138 -164 4 24 2 blend
+          rlineto
+          0 -28 -92 1 blend
+          rlineto
+          138 -164 -4 24 2 blend
+          rlineto
+        </CharString>
+        <CharString name="guillemotright">
+          1 vsindex
+          74 74 42 -22 2 blend
+          rmoveto
+          138 164 -4 -24 2 blend
+          rlineto
+          0 28 92 1 blend
+          rlineto
+          -138 164 4 -24 2 blend
+          rlineto
+          -20 -18 -42 -32 2 blend
+          rlineto
+          124 -160 -16 10 2 blend
+          rlineto
+          -124 -162 16 12 2 blend
+          rlineto
+          20 -16 42 -34 2 blend
+          rlineto
+          134 66 1 blend
+          0 rmoveto
+          138 164 -4 -24 2 blend
+          rlineto
+          0 28 92 1 blend
+          rlineto
+          -138 164 4 -24 2 blend
+          rlineto
+          -20 -18 -42 -32 2 blend
+          rlineto
+          124 -160 -16 10 2 blend
+          rlineto
+          -124 -162 16 12 2 blend
+          rlineto
+          20 -16 42 -34 2 blend
+          rlineto
+        </CharString>
+        <CharString name="h">
+          1 vsindex
+          96 -38 1 blend
+          0 rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 366 -38 1 blend
+          rlineto
+          62 64 44 32 60 -36 -40 -26 -18 -28 5 blend
+          0 rrcurveto
+          82 -48 1 blend
+          0 34 -52 -18 36 2 blend
+          0 -106 42 1 blend
+          rrcurveto
+          0 -304 18 1 blend
+          rlineto
+          30 142 1 blend
+          0 rlineto
+          0 308 rlineto
+          0 124 -46 58 -98 22 -12 2 blend
+          0 rrcurveto
+          -66 -2 1 blend
+          0 -50 -38 -52 -52 2 4 18 22 4 blend
+          rrcurveto
+          0 108 8 -22 2 blend
+          rlineto
+          0 214 -52 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -722 26 1 blend
+          rlineto
+        </CharString>
+        <CharString name="hyphen">
+          1 vsindex
+          40 234 4 -40 2 blend
+          rmoveto
+          216 36 1 blend
+          0 rlineto
+          0 30 90 1 blend
+          rlineto
+          -216 -36 1 blend
+          0 rlineto
+          0 -30 -90 1 blend
+          rlineto
+        </CharString>
+        <CharString name="i">
+          1 vsindex
+          96 -38 1 blend
+          0 rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 478 22 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -478 -22 1 blend
+          rlineto
+          16 600 70 -38 2 blend
+          rmoveto
+          18 38 1 blend
+          0 14 14 24 20 2 blend
+          0 22 30 1 blend
+          rrcurveto
+          0 20 -14 14 -18 32 -24 20 -38 4 blend
+          0 rrcurveto
+          -18 -38 1 blend
+          0 -14 -14 -24 -20 2 blend
+          0 -20 -32 1 blend
+          rrcurveto
+          0 -22 14 -14 18 -30 24 -20 38 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="iacute">
+          1 vsindex
+          96 -38 1 blend
+          0 rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 478 22 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -478 -22 1 blend
+          rlineto
+          -28 574 74 -2 2 blend
+          rmoveto
+          148 150 82 8 2 blend
+          rlineto
+          -24 20 -72 94 2 blend
+          rlineto
+          -142 -154 -76 -34 2 blend
+          rlineto
+          18 -16 66 -68 2 blend
+          rlineto
+        </CharString>
+        <CharString name="icircumflex">
+          1 vsindex
+          96 -38 1 blend
+          0 rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 478 22 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -478 -22 1 blend
+          rlineto
+          -98 574 54 -16 2 blend
+          rmoveto
+          112 130 16 -46 2 blend
+          rlineto
+          4 0 rlineto
+          112 -130 16 46 2 blend
+          rlineto
+          18 16 46 44 2 blend
+          rlineto
+          -118 146 12 -18 2 blend
+          rlineto
+          -28 -148 1 blend
+          0 rlineto
+          -118 -146 12 18 2 blend
+          rlineto
+          18 -16 46 -44 2 blend
+          rlineto
+        </CharString>
+        <CharString name="idieresis">
+          1 vsindex
+          96 -38 1 blend
+          0 rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 478 22 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -478 -22 1 blend
+          rlineto
+          -70 602 42 -40 2 blend
+          rmoveto
+          18 29 1 blend
+          0 14 14 19 21 2 blend
+          0 18 27 1 blend
+          rrcurveto
+          0 18 -14 14 -18 27 -19 21 -29 4 blend
+          0 rrcurveto
+          -18 -29 1 blend
+          0 -14 -14 -19 -21 2 blend
+          0 -18 -27 1 blend
+          rrcurveto
+          0 -18 14 -14 18 -27 19 -21 29 4 blend
+          0 rrcurveto
+          172 56 1 blend
+          0 rmoveto
+          18 29 1 blend
+          0 14 14 19 21 2 blend
+          0 18 27 1 blend
+          rrcurveto
+          0 18 -14 14 -18 27 -19 21 -29 4 blend
+          0 rrcurveto
+          -18 -29 1 blend
+          0 -14 -14 -19 -21 2 blend
+          0 -18 -27 1 blend
+          rrcurveto
+          0 -18 14 -14 18 -27 19 -21 29 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="igrave">
+          1 vsindex
+          96 -38 1 blend
+          0 rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 478 22 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -478 -22 1 blend
+          rlineto
+          60 574 66 -2 2 blend
+          rmoveto
+          18 16 66 68 2 blend
+          rlineto
+          -142 154 -76 34 2 blend
+          rlineto
+          -24 -20 -72 -94 2 blend
+          rlineto
+          148 -150 82 -8 2 blend
+          rlineto
+        </CharString>
+        <CharString name="j">
+          1 vsindex
+          28 -234 10 46 2 blend
+          rmoveto
+          66 84 1 blend
+          0 32 40 12 62 2 blend
+          0 92 20 1 blend
+          rrcurveto
+          0 580 -106 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -576 96 1 blend
+          rlineto
+          0 -62 -10 -46 -56 8 -4 26 20 4 blend
+          0 rrcurveto
+          -18 6 1 blend
+          0 -22 6 -12 12 -4 -2 3 blend
+          4 rrcurveto
+          -8 -24 -22 -102 2 blend
+          rlineto
+          14 8 1 blend
+          -8 26 -6 18 28 1 blend
+          0 rrcurveto
+          82 834 26 -84 2 blend
+          rmoveto
+          18 38 1 blend
+          0 14 14 24 20 2 blend
+          0 22 30 1 blend
+          rrcurveto
+          0 20 -14 14 -18 32 -24 20 -38 4 blend
+          0 rrcurveto
+          -18 -38 1 blend
+          0 -14 -14 -24 -20 2 blend
+          0 -20 -32 1 blend
+          rrcurveto
+          0 -22 14 -14 18 -30 24 -20 38 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="k">
+          1 vsindex
+          96 -38 1 blend
+          0 rmoveto
+          30 140 1 blend
+          0 rlineto
+          0 132 -10 1 blend
+          rlineto
+          114 134 -64 -78 2 blend
+          rlineto
+          166 -266 -66 88 2 blend
+          rlineto
+          34 152 1 blend
+          0 rlineto
+          -182 -4 1 blend
+          290 rlineto
+          154 188 22 22 2 blend
+          rlineto
+          -36 -152 1 blend
+          0 rlineto
+          -248 -304 114 132 2 blend
+          rlineto
+          -2 -2 1 blend
+          0 rlineto
+          0 548 -180 1 blend
+          rlineto
+          -30 -140 1 blend
+          0 rlineto
+          0 -722 26 1 blend
+          rlineto
+        </CharString>
+        <CharString name="l">
+          1 vsindex
+          144 68 1 blend
+          -12 rmoveto
+          10 28 1 blend
+          0 8 2 8 4 20 4 10 4 4 blend
+          rrcurveto
+          -6 24 -14 102 2 blend
+          rlineto
+          -8 -2 -4 0 -4 -2 1 blend
+          0 rrcurveto
+          -14 2 1 blend
+          0 -8 8 -8 2 2 blend
+          0 22 12 1 blend
+          rrcurveto
+          0 676 -150 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -670 150 1 blend
+          rlineto
+          0 -46 18 -18 30 -66 20 -58 86 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="less">
+          1 vsindex
+          438 152 68 -58 2 blend
+          rmoveto
+          0 32 108 1 blend
+          rlineto
+          -240 94 78 -44 2 blend
+          rlineto
+          -132 52 -4 -6 2 blend
+          rlineto
+          0 4 rlineto
+          132 52 4 -6 2 blend
+          rlineto
+          240 94 -78 -44 2 blend
+          rlineto
+          0 32 108 1 blend
+          rlineto
+          -404 -162 -68 -18 2 blend
+          rlineto
+          0 -36 -80 1 blend
+          rlineto
+          404 -162 68 -18 2 blend
+          rlineto
+        </CharString>
+        <CharString name="logicalnot">
+          1 vsindex
+          406 112 -24 -22 2 blend
+          rmoveto
+          32 92 1 blend
+          0 rlineto
+          0 232 68 1 blend
+          rlineto
+          -404 -68 1 blend
+          0 rlineto
+          0 -28 -92 1 blend
+          rlineto
+          372 -24 1 blend
+          0 rlineto
+          0 -204 24 1 blend
+          rlineto
+        </CharString>
+        <CharString name="m">
+          1 vsindex
+          96 -38 1 blend
+          0 rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 366 -38 1 blend
+          rlineto
+          56 64 50 32 46 -30 -38 -26 -20 -26 5 blend
+          0 rrcurveto
+          78 -44 1 blend
+          0 36 -52 -20 36 2 blend
+          0 -106 42 1 blend
+          rrcurveto
+          0 -304 18 1 blend
+          rlineto
+          30 142 1 blend
+          0 rlineto
+          0 366 -38 1 blend
+          rlineto
+          56 64 48 32 48 -30 -38 -24 -20 -28 5 blend
+          0 rrcurveto
+          78 -44 1 blend
+          0 36 -52 -20 36 2 blend
+          0 -106 42 1 blend
+          rrcurveto
+          0 -304 18 1 blend
+          rlineto
+          30 142 1 blend
+          0 rlineto
+          0 308 rlineto
+          0 124 -48 58 -94 22 -16 2 blend
+          0 rrcurveto
+          -54 -14 1 blend
+          0 -54 9 1 blend
+          -38 -56 -62 15 20 2 blend
+          rrcurveto
+          -16 60 -38 40 -78 -11 -8 -5 -12 10 5 blend
+          0 rrcurveto
+          -52 -16 1 blend
+          0 -56 -38 -44 -50 14 4 4 11 4 blend
+          rrcurveto
+          -2 -2 1 blend
+          0 rlineto
+          -4 76 -8 -15 2 blend
+          rlineto
+          -26 -114 1 blend
+          0 rlineto
+          0 -478 -22 1 blend
+          rlineto
+        </CharString>
+        <CharString name="macron">
+          1 vsindex
+          146 608 -20 -20 2 blend
+          rmoveto
+          240 68 1 blend
+          0 rlineto
+          0 28 80 1 blend
+          rlineto
+          -240 -68 1 blend
+          0 rlineto
+          0 -28 -80 1 blend
+          rlineto
+        </CharString>
+        <CharString name="mu">
+          1 vsindex
+          96 -180 -38 4 2 blend
+          rmoveto
+          30 144 1 blend
+          0 rlineto
+          -4 82 0 38 0 114 -4 -16 -2 15 -2 -49 6 blend
+          rrcurveto
+          28 -54 40 -12 52 -14 42 -22 10 -34 5 blend
+          0 rrcurveto
+          60 -20 1 blend
+          0 54 32 44 72 -20 -6 -24 -26 4 blend
+          rrcurveto
+          2 2 1 blend
+          0 rlineto
+          -2 -74 12 -30 44 22 24 38 2 30 5 blend
+          0 rrcurveto
+          15 33 1 blend
+          0 12 4 9 4 14 4 15 6 4 blend
+          rrcurveto
+          -6 26 -14 100 2 blend
+          rlineto
+          -12 2 1 blend
+          -4 -7 -7 1 blend
+          -2 -9 1 1 blend
+          0 rrcurveto
+          -16 -14 1 blend
+          0 -12 12 -6 -2 2 blend
+          0 24 10 1 blend
+          rrcurveto
+          0 144 1 138 1 144 -74 7 12 3 -34 5 blend
+          rrcurveto
+          -30 -144 1 blend
+          0 rlineto
+          0 -344 32 1 blend
+          rlineto
+          -61 -105 -51 -13 -52 43 69 31 -5 22 5 blend
+          0 rrcurveto
+          -80 46 1 blend
+          0 -32 60 16 -44 2 blend
+          0 98 -34 1 blend
+          rrcurveto
+          0 304 -18 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -658 -18 1 blend
+          rlineto
+        </CharString>
+        <CharString name="multiply">
+          1 vsindex
+          72 138 60 -32 2 blend
+          rmoveto
+          164 172 -26 -34 2 blend
+          rlineto
+          164 -172 -26 34 2 blend
+          rlineto
+          20 22 65 63 2 blend
+          rlineto
+          -164 170 26 -32 2 blend
+          rlineto
+          164 170 -26 -32 2 blend
+          rlineto
+          -20 22 -65 63 2 blend
+          rlineto
+          -164 -172 26 34 2 blend
+          rlineto
+          -164 172 26 -34 2 blend
+          rlineto
+          -20 -22 -65 -63 2 blend
+          rlineto
+          164 -170 -26 32 2 blend
+          rlineto
+          -164 -170 26 32 2 blend
+          rlineto
+          20 -22 65 -63 2 blend
+          rlineto
+        </CharString>
+        <CharString name="n">
+          1 vsindex
+          96 -38 1 blend
+          0 rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 366 -38 1 blend
+          rlineto
+          62 64 44 32 60 -36 -40 -26 -18 -28 5 blend
+          0 rrcurveto
+          82 -48 1 blend
+          0 34 -52 -18 36 2 blend
+          0 -106 42 1 blend
+          rrcurveto
+          0 -304 18 1 blend
+          rlineto
+          30 142 1 blend
+          0 rlineto
+          0 308 rlineto
+          0 124 -46 58 -98 22 -12 2 blend
+          0 rrcurveto
+          -66 -2 1 blend
+          0 -50 -38 -50 -50 4 10 12 3 blend
+          rrcurveto
+          -2 -2 1 blend
+          0 rlineto
+          -4 76 -8 -16 2 blend
+          rlineto
+          -26 -114 1 blend
+          0 rlineto
+          0 -478 -22 1 blend
+          rlineto
+        </CharString>
+        <CharString name="nine">
+          1 vsindex
+          186 52 1 blend
+          -12 rmoveto
+          122 14 1 blend
+          0 110 92 16 18 2 blend
+          0 272 -42 1 blend
+          rrcurveto
+          0 190 -76 110 -128 40 -50 -22 6 4 blend
+          0 rrcurveto
+          -92 -28 1 blend
+          0 -78 -84 -22 4 2 blend
+          0 -114 -22 1 blend
+          rrcurveto
+          0 -128 64 -70 112 -8 20 10 -4 4 blend
+          0 rrcurveto
+          64 -27 1 blend
+          0 60 38 46 58 -1 -12 -16 -12 4 blend
+          rrcurveto
+          0 40 -8 68 2 blend
+          rlineto
+          -56 -78 -64 -30 -48 33 34 33 14 18 5 blend
+          0 rrcurveto
+          -104 68 1 blend
+          0 -42 74 8 -59 2 blend
+          0 96 -35 1 blend
+          rrcurveto
+          0 94 58 76 78 -27 -26 -55 -42 4 blend
+          0 rrcurveto
+          122 -83 1 blend
+          0 52 -116 -3 84 2 blend
+          0 -156 -2 1 blend
+          rrcurveto
+          0 -250 -92 -86 -106 98 42 36 38 4 blend
+          0 rrcurveto
+          -42 6 1 blend
+          0 -39 18 -29 36 -1 4 9 -14 4 blend
+          rrcurveto
+          -20 -22 -70 -80 2 blend
+          rlineto
+          31 -36 41 -24 56 11 -6 25 -14 34 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="ntilde">
+          1 vsindex
+          96 -38 1 blend
+          0 rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 366 -38 1 blend
+          rlineto
+          62 64 44 32 60 -36 -40 -26 -18 -28 5 blend
+          0 rrcurveto
+          82 -48 1 blend
+          0 34 -52 -18 36 2 blend
+          0 -106 42 1 blend
+          rrcurveto
+          0 -304 18 1 blend
+          rlineto
+          30 142 1 blend
+          0 rlineto
+          0 308 rlineto
+          0 124 -46 58 -98 22 -12 2 blend
+          0 rrcurveto
+          -66 -2 1 blend
+          0 -50 -38 -50 -50 4 10 12 3 blend
+          rrcurveto
+          -2 -2 1 blend
+          0 rlineto
+          -4 76 -8 -16 2 blend
+          rlineto
+          -26 -114 1 blend
+          0 rlineto
+          0 -478 -22 1 blend
+          rlineto
+          261 580 65 -8 2 blend
+          rmoveto
+          63 17 1 blend
+          0 16 66 4 56 34 -21 -2 57 4 blend
+          rrcurveto
+          -26 2 -80 4 2 blend
+          rlineto
+          -2 -52 -16 -46 -37 -2 16 6 36 21 5 blend
+          0 rrcurveto
+          -59 33 1 blend
+          0 -20 100 -76 -18 -44 16 3 blend
+          0 rrcurveto
+          -64 -16 1 blend
+          0 -16 -65 -4 -57 -34 20 2 -56 4 blend
+          rrcurveto
+          26 -2 80 -4 2 blend
+          rlineto
+          2 54 16 44 38 2 -18 -6 -34 -22 5 blend
+          0 rrcurveto
+          58 -32 1 blend
+          0 20 -100 77 18 44 -17 3 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="numbersign">
+          94 -10 -10 1 blend
+          0 rmoveto
+          28 52 70 1 blend
+          0 rlineto
+          26 218 -2 -4 -28 -38 2 blend
+          rlineto
+          156 -51 -64 1 blend
+          0 rlineto
+          -26 -218 3 4 28 38 2 blend
+          rlineto
+          28 52 70 1 blend
+          0 rlineto
+          26 218 -3 -4 -28 -38 2 blend
+          rlineto
+          90 3 6 1 blend
+          0 rlineto
+          0 28 58 80 1 blend
+          rlineto
+          -86 2 2 1 blend
+          0 rlineto
+          22 178 -6 -10 -58 -82 2 blend
+          rlineto
+          84 4 8 1 blend
+          0 rlineto
+          0 28 58 80 1 blend
+          rlineto
+          -82 3 4 1 blend
+          0 rlineto
+          26 198 -3 -8 -30 -40 2 blend
+          rlineto
+          -28 -52 -68 1 blend
+          0 rlineto
+          -26 -198 3 6 30 40 2 blend
+          rlineto
+          -156 51 64 1 blend
+          0 rlineto
+          26 198 -4 -8 -30 -40 2 blend
+          rlineto
+          -28 -52 -68 1 blend
+          0 rlineto
+          -26 -198 4 6 30 40 2 blend
+          rlineto
+          -92 2 2 1 blend
+          0 rlineto
+          0 -28 -58 -80 1 blend
+          rlineto
+          90 -10 -14 1 blend
+          0 rlineto
+          -22 -178 6 10 58 82 2 blend
+          rlineto
+          -88 4 4 1 blend
+          0 rlineto
+          0 -28 -58 -80 1 blend
+          rlineto
+          84 -8 -12 1 blend
+          0 rlineto
+          -26 -218 2 4 28 38 2 blend
+          rlineto
+          58 246 54 74 30 42 2 blend
+          rmoveto
+          22 178 -6 -10 -58 -82 2 blend
+          rlineto
+          156 -50 -64 1 blend
+          0 rlineto
+          -22 -178 6 10 58 82 2 blend
+          rlineto
+          -156 50 64 1 blend
+          0 rlineto
+        </CharString>
+        <CharString name="o">
+          1 vsindex
+          266 14 1 blend
+          -12 rmoveto
+          114 14 1 blend
+          0 98 92 22 4 2 blend
+          0 158 8 1 blend
+          rrcurveto
+          0 160 -98 92 -114 6 -22 4 -14 4 blend
+          0 rrcurveto
+          -114 -14 1 blend
+          0 -98 -92 -22 -4 2 blend
+          0 -160 -6 1 blend
+          rrcurveto
+          0 -158 98 -92 114 -8 22 -4 14 4 blend
+          0 rrcurveto
+          0 28 110 1 blend
+          rmoveto
+          -102 50 1 blend
+          0 -78 90 58 -42 2 blend
+          0 132 -56 1 blend
+          rrcurveto
+          0 132 78 92 102 -56 -58 -44 -50 4 blend
+          0 rrcurveto
+          102 -50 1 blend
+          0 78 -92 -58 44 2 blend
+          0 -132 56 1 blend
+          rrcurveto
+          0 -132 -78 -90 -102 56 58 42 50 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="oacute">
+          1 vsindex
+          266 14 1 blend
+          -12 rmoveto
+          114 14 1 blend
+          0 98 92 22 4 2 blend
+          0 158 8 1 blend
+          rrcurveto
+          0 160 -98 92 -114 6 -22 4 -14 4 blend
+          0 rrcurveto
+          -114 -14 1 blend
+          0 -98 -92 -22 -4 2 blend
+          0 -160 -6 1 blend
+          rrcurveto
+          0 -158 98 -92 114 -8 22 -4 14 4 blend
+          0 rrcurveto
+          0 28 110 1 blend
+          rmoveto
+          -102 50 1 blend
+          0 -78 90 58 -42 2 blend
+          0 132 -56 1 blend
+          rrcurveto
+          0 132 78 92 102 -56 -58 -44 -50 4 blend
+          0 rrcurveto
+          102 -50 1 blend
+          0 78 -92 -58 44 2 blend
+          0 -132 56 1 blend
+          rrcurveto
+          0 -132 -78 -90 -102 56 58 42 50 4 blend
+          0 rrcurveto
+          -44 558 4 -112 2 blend
+          rmoveto
+          148 150 82 8 2 blend
+          rlineto
+          -24 20 -72 94 2 blend
+          rlineto
+          -142 -154 -76 -34 2 blend
+          rlineto
+          18 -16 66 -68 2 blend
+          rlineto
+        </CharString>
+        <CharString name="ocircumflex">
+          1 vsindex
+          266 14 1 blend
+          -12 rmoveto
+          114 14 1 blend
+          0 98 92 22 4 2 blend
+          0 158 8 1 blend
+          rrcurveto
+          0 160 -98 92 -114 6 -22 4 -14 4 blend
+          0 rrcurveto
+          -114 -14 1 blend
+          0 -98 -92 -22 -4 2 blend
+          0 -160 -6 1 blend
+          rrcurveto
+          0 -158 98 -92 114 -8 22 -4 14 4 blend
+          0 rrcurveto
+          0 28 110 1 blend
+          rmoveto
+          -102 50 1 blend
+          0 -78 90 58 -42 2 blend
+          0 132 -56 1 blend
+          rrcurveto
+          0 132 78 92 102 -56 -58 -44 -50 4 blend
+          0 rrcurveto
+          102 -50 1 blend
+          0 78 -92 -58 44 2 blend
+          0 -132 56 1 blend
+          rrcurveto
+          0 -132 -78 -90 -102 56 58 42 50 4 blend
+          0 rrcurveto
+          -114 558 -16 -126 2 blend
+          rmoveto
+          112 130 16 -46 2 blend
+          rlineto
+          4 0 rlineto
+          112 -130 16 46 2 blend
+          rlineto
+          18 16 46 44 2 blend
+          rlineto
+          -118 146 12 -18 2 blend
+          rlineto
+          -28 -148 1 blend
+          0 rlineto
+          -118 -146 12 18 2 blend
+          rlineto
+          18 -16 46 -44 2 blend
+          rlineto
+        </CharString>
+        <CharString name="odieresis">
+          1 vsindex
+          266 14 1 blend
+          -12 rmoveto
+          114 14 1 blend
+          0 98 92 22 4 2 blend
+          0 158 8 1 blend
+          rrcurveto
+          0 160 -98 92 -114 6 -22 4 -14 4 blend
+          0 rrcurveto
+          -114 -14 1 blend
+          0 -98 -92 -22 -4 2 blend
+          0 -160 -6 1 blend
+          rrcurveto
+          0 -158 98 -92 114 -8 22 -4 14 4 blend
+          0 rrcurveto
+          0 28 110 1 blend
+          rmoveto
+          -102 50 1 blend
+          0 -78 90 58 -42 2 blend
+          0 132 -56 1 blend
+          rrcurveto
+          0 132 78 92 102 -56 -58 -44 -50 4 blend
+          0 rrcurveto
+          102 -50 1 blend
+          0 78 -92 -58 44 2 blend
+          0 -132 56 1 blend
+          rrcurveto
+          0 -132 -78 -90 -102 56 58 42 50 4 blend
+          0 rrcurveto
+          -86 586 -28 -150 2 blend
+          rmoveto
+          18 29 1 blend
+          0 14 14 19 21 2 blend
+          0 18 27 1 blend
+          rrcurveto
+          0 18 -14 14 -18 27 -19 21 -29 4 blend
+          0 rrcurveto
+          -18 -29 1 blend
+          0 -14 -14 -19 -21 2 blend
+          0 -18 -27 1 blend
+          rrcurveto
+          0 -18 14 -14 18 -27 19 -21 29 4 blend
+          0 rrcurveto
+          172 56 1 blend
+          0 rmoveto
+          18 29 1 blend
+          0 14 14 19 21 2 blend
+          0 18 27 1 blend
+          rrcurveto
+          0 18 -14 14 -18 27 -19 21 -29 4 blend
+          0 rrcurveto
+          -18 -29 1 blend
+          0 -14 -14 -19 -21 2 blend
+          0 -18 -27 1 blend
+          rrcurveto
+          0 -18 14 -14 18 -27 19 -21 29 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="ograve">
+          1 vsindex
+          266 14 1 blend
+          -12 rmoveto
+          114 14 1 blend
+          0 98 92 22 4 2 blend
+          0 158 8 1 blend
+          rrcurveto
+          0 160 -98 92 -114 6 -22 4 -14 4 blend
+          0 rrcurveto
+          -114 -14 1 blend
+          0 -98 -92 -22 -4 2 blend
+          0 -160 -6 1 blend
+          rrcurveto
+          0 -158 98 -92 114 -8 22 -4 14 4 blend
+          0 rrcurveto
+          0 28 110 1 blend
+          rmoveto
+          -102 50 1 blend
+          0 -78 90 58 -42 2 blend
+          0 132 -56 1 blend
+          rrcurveto
+          0 132 78 92 102 -56 -58 -44 -50 4 blend
+          0 rrcurveto
+          102 -50 1 blend
+          0 78 -92 -58 44 2 blend
+          0 -132 56 1 blend
+          rrcurveto
+          0 -132 -78 -90 -102 56 58 42 50 4 blend
+          0 rrcurveto
+          44 558 -4 -112 2 blend
+          rmoveto
+          18 16 66 68 2 blend
+          rlineto
+          -142 154 -76 34 2 blend
+          rlineto
+          -24 -20 -72 -94 2 blend
+          rlineto
+          148 -150 82 -8 2 blend
+          rlineto
+        </CharString>
+        <CharString name="one">
+          1 vsindex
+          86 -20 1 blend
+          0 rmoveto
+          324 98 1 blend
+          0 rlineto
+          0 28 110 1 blend
+          rlineto
+          -142 28 1 blend
+          0 rlineto
+          0 612 -116 1 blend
+          rlineto
+          -26 -100 1 blend
+          0 rlineto
+          -28 -16 -40 -14 -50 -8 -20 -14 -6 -4 -22 -6 6 blend
+          rrcurveto
+          0 -22 -84 1 blend
+          rlineto
+          114 6 1 blend
+          0 rlineto
+          0 -552 224 1 blend
+          rlineto
+          -152 16 1 blend
+          0 rlineto
+          0 -28 -110 1 blend
+          rlineto
+        </CharString>
+        <CharString name="onehalf">
+          1 vsindex
+          158 270 -28 -10 2 blend
+          rmoveto
+          28 98 1 blend
+          0 rlineto
+          0 390 rlineto
+          -26 -72 1 blend
+          0 rlineto
+          -22 -18 -26 -14 -6 2 3 blend
+          -12 -36 -22 1 blend
+          -8 rrcurveto
+          0 -22 -54 1 blend
+          rlineto
+          82 8 1 blend
+          0 rlineto
+          0 -330 60 1 blend
+          rlineto
+          -6 -282 50 10 2 blend
+          rmoveto
+          32 64 1 blend
+          0 rlineto
+          370 684 -22 -10 2 blend
+          rlineto
+          -32 -64 1 blend
+          0 rlineto
+          -370 -684 22 10 2 blend
+          rlineto
+          324 24 1 blend
+          12 rmoveto
+          250 48 1 blend
+          0 rlineto
+          0 26 78 1 blend
+          rlineto
+          -202 102 1 blend
+          0 rlineto
+          106 104 72 66 -62 -52 -28 -13 4 blend
+          0 84 -25 1 blend
+          rrcurveto
+          0 82 -48 40 -70 2 -12 10 -20 4 blend
+          0 rrcurveto
+          -48 -14 1 blend
+          0 -46 -34 -22 -38 -4 8 -22 -18 4 blend
+          rrcurveto
+          20 -18 50 -46 2 blend
+          rlineto
+          22 34 34 30 38 -6 -14 -14 -14 4 blend
+          0 rrcurveto
+          54 -22 1 blend
+          0 36 -38 -18 18 2 blend
+          0 -60 26 1 blend
+          rrcurveto
+          0 -68 -58 -60 -138 -130 24 -16 -4 46 58 5 blend
+          rrcurveto
+          0 -20 -46 1 blend
+          rlineto
+        </CharString>
+        <CharString name="onequarter">
+          1 vsindex
+          158 270 -28 -10 2 blend
+          rmoveto
+          28 98 1 blend
+          0 rlineto
+          0 390 rlineto
+          -26 -72 1 blend
+          0 rlineto
+          -22 -18 -26 -14 -6 2 3 blend
+          -12 -36 -22 1 blend
+          -8 rrcurveto
+          0 -22 -54 1 blend
+          rlineto
+          82 8 1 blend
+          0 rlineto
+          0 -330 60 1 blend
+          rlineto
+          18 -282 40 10 2 blend
+          rmoveto
+          32 64 1 blend
+          0 rlineto
+          370 684 -22 -10 2 blend
+          rlineto
+          -32 -64 1 blend
+          0 rlineto
+          -370 -684 22 10 2 blend
+          rlineto
+          446 18 1 blend
+          12 rmoveto
+          28 82 1 blend
+          0 rlineto
+          0 390 rlineto
+          -22 -136 1 blend
+          0 rlineto
+          -182 -256 50 8 2 blend
+          rlineto
+          0 -16 -46 1 blend
+          rlineto
+          262 86 1 blend
+          0 rlineto
+          0 26 54 1 blend
+          rlineto
+          -222 -14 1 blend
+          0 rlineto
+          78 112 -44 -38 2 blend
+          rlineto
+          58 84 -22 -8 2 blend
+          rlineto
+          4 0 rlineto
+          -4 -102 -2 -18 2 blend
+          rlineto
+          0 -238 48 1 blend
+          rlineto
+        </CharString>
+        <CharString name="ordfeminine">
+          1 vsindex
+          140 402 -12 -42 2 blend
+          rmoveto
+          44 -8 1 blend
+          0 36 24 28 -6 -8 -4 3 blend
+          24 rrcurveto
+          4 0 rlineto
+          6 -40 4 8 2 blend
+          rlineto
+          22 74 1 blend
+          0 rlineto
+          0 202 -16 1 blend
+          rlineto
+          0 72 -22 50 -76 34 -34 -2 -10 4 blend
+          0 rrcurveto
+          -52 0 -48 -26 -24 -16 -2 10 -24 -12 4 blend
+          rrcurveto
+          12 -22 30 -56 2 blend
+          rlineto
+          22 16 46 22 42 13 2 -19 -12 -18 5 blend
+          0 rrcurveto
+          58 -31 1 blend
+          0 14 -44 0 -54 35 3 31 3 blend
+          rrcurveto
+          -144 -14 -64 -34 16 2 10 -4 4 blend
+          0 -70 rrcurveto
+          0 -58 40 -32 56 4 -2 -16 8 4 blend
+          0 rrcurveto
+          6 26 35 64 2 blend
+          rmoveto
+          -44 25 1 blend
+          0 -28 20 18 -12 2 blend
+          0 46 -32 1 blend
+          rrcurveto
+          0 48 46 32 132 14 -30 -30 -14 -80 -8 5 blend
+          rrcurveto
+          0 -108 64 1 blend
+          rlineto
+          -38 -36 -36 -16 -32 26 24 26 8 15 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="ordmasculine">
+          1 vsindex
+          178 402 10 -42 2 blend
+          rmoveto
+          80 6 1 blend
+          0 64 62 16 2 2 blend
+          0 104 5 1 blend
+          rrcurveto
+          0 106 -64 60 -80 4 -16 5 -6 4 blend
+          0 rrcurveto
+          -80 -6 1 blend
+          0 -64 -60 -16 -5 2 blend
+          0 -106 -4 1 blend
+          rrcurveto
+          0 -104 64 -62 80 -5 16 -2 6 4 blend
+          0 rrcurveto
+          0 26 68 1 blend
+          rmoveto
+          -68 35 1 blend
+          0 -46 58 35 -27 2 blend
+          0 82 -34 1 blend
+          rrcurveto
+          0 84 46 56 68 -35 -35 -24 -35 4 blend
+          0 rrcurveto
+          68 -35 1 blend
+          0 46 -56 -35 24 2 blend
+          0 -84 35 1 blend
+          rrcurveto
+          0 -82 -46 -58 -68 34 35 27 35 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="oslash">
+          266 8 14 1 blend
+          -12 rmoveto
+          114 9 14 1 blend
+          0 98 92 13 22 2 4 2 blend
+          0 158 5 8 1 blend
+          rrcurveto
+          0 160 -98 92 -114 4 6 -13 -22 2 4 -9 -14 4 blend
+          0 rrcurveto
+          -114 -8 -14 1 blend
+          0 -98 -92 -13 -22 -2 -4 2 blend
+          0 -160 -4 -6 1 blend
+          rrcurveto
+          0 -158 98 -92 114 -5 -8 13 22 -2 -4 8 14 4 blend
+          0 rrcurveto
+          0 28 62 104 1 blend
+          rmoveto
+          -102 29 48 1 blend
+          0 -78 90 30 50 -28 -48 2 blend
+          0 132 -21 -34 1 blend
+          rrcurveto
+          0 132 78 92 102 -36 -60 -29 -48 -26 -44 -30 -50 4 blend
+          0 rrcurveto
+          102 -28 -48 1 blend
+          0 78 -92 -30 -50 30 50 2 blend
+          0 -132 20 34 1 blend
+          rrcurveto
+          0 -132 -78 -90 -102 36 60 28 48 25 42 30 50 4 blend
+          0 rrcurveto
+          -198 -38 22 26 -74 -108 2 blend
+          rmoveto
+          418 502 -2 -12 6 4 2 blend
+          rlineto
+          -22 18 -40 -40 34 30 2 blend
+          rlineto
+          -418 -502 2 12 -6 -4 2 blend
+          rlineto
+          22 -18 40 40 -34 -30 2 blend
+          rlineto
+        </CharString>
+        <CharString name="otilde">
+          1 vsindex
+          266 14 1 blend
+          -12 rmoveto
+          114 14 1 blend
+          0 98 92 22 4 2 blend
+          0 158 8 1 blend
+          rrcurveto
+          0 160 -98 92 -114 6 -22 4 -14 4 blend
+          0 rrcurveto
+          -114 -14 1 blend
+          0 -98 -92 -22 -4 2 blend
+          0 -160 -6 1 blend
+          rrcurveto
+          0 -158 98 -92 114 -8 22 -4 14 4 blend
+          0 rrcurveto
+          0 28 110 1 blend
+          rmoveto
+          -102 50 1 blend
+          0 -78 90 58 -42 2 blend
+          0 132 -56 1 blend
+          rrcurveto
+          0 132 78 92 102 -56 -58 -44 -50 4 blend
+          0 rrcurveto
+          102 -50 1 blend
+          0 78 -92 -58 44 2 blend
+          0 -132 56 1 blend
+          rrcurveto
+          0 -132 -78 -90 -102 56 58 42 50 4 blend
+          0 rrcurveto
+          77 564 -13 -118 2 blend
+          rmoveto
+          63 17 1 blend
+          0 16 66 4 56 34 -21 -2 57 4 blend
+          rrcurveto
+          -26 2 -80 4 2 blend
+          rlineto
+          -2 -52 -16 -46 -37 -2 16 6 36 21 5 blend
+          0 rrcurveto
+          -59 33 1 blend
+          0 -20 100 -76 -18 -44 16 3 blend
+          0 rrcurveto
+          -64 -16 1 blend
+          0 -16 -65 -4 -57 -34 20 2 -56 4 blend
+          rrcurveto
+          26 -2 80 -4 2 blend
+          rlineto
+          2 54 16 44 38 2 -18 -6 -34 -22 5 blend
+          0 rrcurveto
+          58 -32 1 blend
+          0 20 -100 77 18 44 -17 3 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="p">
+          1 vsindex
+          96 -222 -38 46 2 blend
+          rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 180 -42 1 blend
+          rlineto
+          0 90 -6 -14 2 blend
+          rlineto
+          52 -38 50 -22 46 -20 6 -12 4 -4 5 blend
+          0 rrcurveto
+          114 -8 1 blend
+          0 98 96 4 2 2 blend
+          0 162 10 1 blend
+          rrcurveto
+          0 148 -62 96 -130 6 -14 4 12 4 blend
+          0 rrcurveto
+          -60 10 1 blend
+          0 -58 -36 -48 -38 9 12 11 4 4 blend
+          rrcurveto
+          -2 -2 1 blend
+          0 rlineto
+          -4 62 -8 -16 2 blend
+          rlineto
+          -26 -114 1 blend
+          0 rlineto
+          0 -700 24 1 blend
+          rlineto
+          180 238 56 66 2 blend
+          rmoveto
+          -38 16 1 blend
+          0 -54 18 -58 48 32 -12 38 -30 4 blend
+          rrcurveto
+          0 296 -112 1 blend
+          rlineto
+          62 54 54 30 50 -40 -28 -34 -20 -24 5 blend
+          0 rrcurveto
+          118 -72 1 blend
+          0 44 -94 -20 60 2 blend
+          0 -122 40 1 blend
+          rrcurveto
+          0 -134 -74 -96 -104 38 40 64 64 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="paragraph">
+          1 vsindex
+          370 28 1 blend
+          -80 rmoveto
+          32 140 1 blend
+          0 rlineto
+          0 740 -10 1 blend
+          rlineto
+          -32 -140 1 blend
+          0 rlineto
+          0 -740 10 1 blend
+          rlineto
+          -80 330 -20 -64 2 blend
+          rmoveto
+          26 18 1 blend
+          0 rlineto
+          0 410 54 1 blend
+          rlineto
+          -44 0 rlineto
+          -136 -4 1 blend
+          0 -94 -58 -26 4 2 blend
+          0 -148 -24 1 blend
+          rrcurveto
+          0 -148 100 -56 148 -7 20 -27 -8 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="parenleft">
+          1 vsindex
+          222 -174 -22 -6 2 blend
+          rmoveto
+          18 12 90 32 2 blend
+          rlineto
+          -80 126 -42 154 8 4 12 -8 4 blend
+          0 160 -22 1 blend
+          rrcurveto
+          0 160 42 154 80 126 -22 -12 -8 -8 4 5 blend
+          rrcurveto
+          -18 12 -90 32 2 blend
+          rlineto
+          -82 -132 -50 -2 -6 2 3 blend
+          -144 0 -176 rrcurveto
+          0 -176 50 -2 1 blend
+          -144 82 -132 2 -6 2 blend
+          rrcurveto
+        </CharString>
+        <CharString name="parenright">
+          1 vsindex
+          48 -174 112 -6 2 blend
+          rmoveto
+          82 132 50 2 6 -2 3 blend
+          144 0 176 rrcurveto
+          0 176 -50 2 1 blend
+          144 -82 132 -2 6 2 blend
+          rrcurveto
+          -18 -12 -90 -32 2 blend
+          rlineto
+          80 -126 42 -154 -8 -4 -12 8 4 blend
+          0 -160 22 1 blend
+          rrcurveto
+          0 -160 -42 -154 -80 -126 22 12 8 8 -4 5 blend
+          rrcurveto
+          18 -12 90 -32 2 blend
+          rlineto
+        </CharString>
+        <CharString name="percent">
+          1 vsindex
+          180 258 10 -10 2 blend
+          rmoveto
+          86 10 1 blend
+          0 52 74 20 4 2 blend
+          0 134 -4 1 blend
+          rrcurveto
+          0 132 -52 74 -86 -2 -20 2 -10 4 blend
+          0 rrcurveto
+          -86 -10 1 blend
+          0 -52 -74 -20 -2 2 blend
+          0 -132 2 1 blend
+          rrcurveto
+          0 -134 52 -74 86 4 20 -4 10 4 blend
+          0 rrcurveto
+          0 26 68 1 blend
+          rmoveto
+          -66 40 1 blend
+          0 -42 68 18 -42 2 blend
+          0 114 -26 1 blend
+          rrcurveto
+          0 114 42 66 66 -26 -18 -42 -40 4 blend
+          0 rrcurveto
+          66 -40 1 blend
+          0 42 -66 -18 42 2 blend
+          0 -114 26 1 blend
+          rrcurveto
+          0 -114 -42 -68 -66 26 18 42 40 4 blend
+          0 rrcurveto
+          16 -296 8 -58 2 blend
+          rmoveto
+          32 64 1 blend
+          0 rlineto
+          370 684 -22 -10 2 blend
+          rlineto
+          -32 -64 1 blend
+          0 rlineto
+          -370 -684 22 10 2 blend
+          rlineto
+          422 44 1 blend
+          0 rmoveto
+          86 10 1 blend
+          0 52 74 20 4 2 blend
+          0 134 -4 1 blend
+          rrcurveto
+          0 132 -52 74 -86 -2 -20 2 -10 4 blend
+          0 rrcurveto
+          -86 -10 1 blend
+          0 -52 -74 -20 -2 2 blend
+          0 -132 2 1 blend
+          rrcurveto
+          0 -134 52 -74 86 4 20 -4 10 4 blend
+          0 rrcurveto
+          0 26 68 1 blend
+          rmoveto
+          -66 40 1 blend
+          0 -42 68 18 -42 2 blend
+          0 114 -26 1 blend
+          rrcurveto
+          0 114 42 66 66 -26 -18 -42 -40 4 blend
+          0 rrcurveto
+          66 -40 1 blend
+          0 42 -66 -18 42 2 blend
+          0 -114 26 1 blend
+          rrcurveto
+          0 -114 -42 -68 -66 26 18 42 40 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="period">
+          1 vsindex
+          104 56 1 blend
+          -12 rmoveto
+          18 40 1 blend
+          0 18 14 24 32 2 blend
+          0 24 34 1 blend
+          rrcurveto
+          0 26 -18 14 -18 32 -24 32 -40 4 blend
+          0 rrcurveto
+          -18 -40 1 blend
+          0 -18 -14 -24 -32 2 blend
+          0 -26 -32 1 blend
+          rrcurveto
+          0 -24 18 -14 18 -34 24 -32 40 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="periodcentered">
+          1 vsindex
+          104 284 56 -68 2 blend
+          rmoveto
+          18 40 1 blend
+          0 18 14 24 32 2 blend
+          0 24 34 1 blend
+          rrcurveto
+          0 26 -18 14 -18 32 -24 32 -40 4 blend
+          0 rrcurveto
+          -18 -40 1 blend
+          0 -18 -14 -24 -32 2 blend
+          0 -26 -32 1 blend
+          rrcurveto
+          0 -24 18 -14 18 -34 24 -32 40 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="plus">
+          1 vsindex
+          220 112 -12 -22 2 blend
+          rmoveto
+          32 92 1 blend
+          0 rlineto
+          0 204 -24 1 blend
+          rlineto
+          186 -12 1 blend
+          0 rlineto
+          0 28 92 1 blend
+          rlineto
+          -186 12 1 blend
+          0 rlineto
+          0 204 -24 1 blend
+          rlineto
+          -32 -92 1 blend
+          0 rlineto
+          0 -204 24 1 blend
+          rlineto
+          -186 12 1 blend
+          0 rlineto
+          0 -28 -92 1 blend
+          rlineto
+          186 -12 1 blend
+          0 rlineto
+          0 -204 24 1 blend
+          rlineto
+        </CharString>
+        <CharString name="plusminus">
+          1 vsindex
+          220 102 -12 68 2 blend
+          rmoveto
+          32 92 1 blend
+          0 rlineto
+          0 210 -90 1 blend
+          rlineto
+          186 -12 1 blend
+          0 rlineto
+          0 28 92 1 blend
+          rlineto
+          -186 12 1 blend
+          0 rlineto
+          0 208 -48 1 blend
+          rlineto
+          -32 -92 1 blend
+          0 rlineto
+          0 -208 48 1 blend
+          rlineto
+          -186 12 1 blend
+          0 rlineto
+          0 -28 -92 1 blend
+          rlineto
+          186 -12 1 blend
+          0 rlineto
+          0 -210 90 1 blend
+          rlineto
+          -186 -102 12 -68 2 blend
+          rmoveto
+          404 68 1 blend
+          0 rlineto
+          0 28 92 1 blend
+          rlineto
+          -404 -68 1 blend
+          0 rlineto
+          0 -28 -92 1 blend
+          rlineto
+        </CharString>
+        <CharString name="q">
+          1 vsindex
+          414 -222 -64 46 2 blend
+          rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 700 -24 1 blend
+          rlineto
+          -26 -108 1 blend
+          0 rlineto
+          -4 -44 -10 -6 2 blend
+          rlineto
+          -2 -2 1 blend
+          0 rlineto
+          -46 34 -40 22 -58 8 10 1 -4 5 5 blend
+          0 rrcurveto
+          -116 14 1 blend
+          0 -98 -4 1 blend
+          -98 0 -154 -10 1 blend
+          rrcurveto
+          0 -162 78 -88 120 2 -12 4 3 blend
+          0 rrcurveto
+          66 -26 1 blend
+          0 54 36 44 42 -8 -16 -14 -12 4 blend
+          rrcurveto
+          -2 -98 -4 27 2 blend
+          rlineto
+          0 -190 47 1 blend
+          rlineto
+          -160 238 96 66 2 blend
+          rmoveto
+          -108 62 1 blend
+          0 -60 90 32 -56 2 blend
+          0 132 -42 1 blend
+          rrcurveto
+          0 124 78 100 102 -36 -44 -68 -66 4 blend
+          0 rrcurveto
+          50 -28 1 blend
+          0 44 -18 54 -48 -18 12 -34 30 4 blend
+          rrcurveto
+          0 -296 112 1 blend
+          rlineto
+          -54 -54 -50 -30 -56 36 26 30 22 30 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="question">
+          1 vsindex
+          164 172 -12 72 2 blend
+          rmoveto
+          28 122 1 blend
+          0 rlineto
+          -20 157 170 65 10 -47 -24 -33 4 blend
+          0 138 -18 1 blend
+          rrcurveto
+          0 82 -54 68 -96 44 -34 -18 -14 4 blend
+          0 rrcurveto
+          -68 -12 1 blend
+          0 -50 -34 -38 -42 -19 -4 -11 -14 4 blend
+          rrcurveto
+          20 -18 74 -68 2 blend
+          rlineto
+          34 42 50 24 50 -8 -18 -28 -6 -16 5 blend
+          0 rrcurveto
+          84 -54 1 blend
+          0 36 -60 -10 46 2 blend
+          0 -64 28 1 blend
+          rrcurveto
+          0 -130 -168 -58 22 -170 66 26 2 -2 40 5 blend
+          rrcurveto
+          18 -184 56 -72 2 blend
+          rmoveto
+          18 40 1 blend
+          0 18 14 24 32 2 blend
+          0 24 34 1 blend
+          rrcurveto
+          0 26 -18 14 -18 32 -24 32 -40 4 blend
+          0 rrcurveto
+          -18 -40 1 blend
+          0 -18 -14 -24 -32 2 blend
+          0 -26 -32 1 blend
+          rrcurveto
+          0 -24 18 -14 18 -34 24 -32 40 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="questiondown">
+          1 vsindex
+          202 -204 36 22 2 blend
+          rmoveto
+          68 12 1 blend
+          0 50 34 38 42 18 4 12 14 4 blend
+          rrcurveto
+          -20 18 -74 68 2 blend
+          rlineto
+          -34 -42 -50 -24 -50 8 18 28 6 16 5 blend
+          0 rrcurveto
+          -84 54 1 blend
+          0 -36 60 10 -46 2 blend
+          0 64 -28 1 blend
+          rrcurveto
+          0 130 168 58 -22 170 -66 -26 -2 2 -40 5 blend
+          rrcurveto
+          -28 -122 1 blend
+          0 rlineto
+          20 -157 -170 -65 -10 47 24 33 4 blend
+          0 -138 18 1 blend
+          rrcurveto
+          0 -82 54 -68 96 -44 34 18 14 4 blend
+          0 rrcurveto
+          10 616 4 -130 2 blend
+          rmoveto
+          18 40 1 blend
+          0 18 14 24 32 2 blend
+          0 26 32 1 blend
+          rrcurveto
+          0 24 -18 14 -18 34 -24 32 -40 4 blend
+          0 rrcurveto
+          -18 -40 1 blend
+          0 -18 -14 -24 -32 2 blend
+          0 -24 -34 1 blend
+          rrcurveto
+          0 -26 18 -14 18 -32 24 -32 40 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="quotedbl">
+          1 vsindex
+          90 494 24 -170 2 blend
+          rmoveto
+          26 66 1 blend
+          0 rlineto
+          6 140 28 72 2 blend
+          rlineto
+          0 60 6 88 2 blend
+          rlineto
+          -38 -134 1 blend
+          0 rlineto
+          0 -60 6 -88 2 blend
+          rlineto
+          6 -140 28 -72 2 blend
+          rlineto
+          128 132 1 blend
+          0 rmoveto
+          26 66 1 blend
+          0 rlineto
+          6 140 28 72 2 blend
+          rlineto
+          0 60 6 88 2 blend
+          rlineto
+          -38 -134 1 blend
+          0 rlineto
+          0 -60 6 -88 2 blend
+          rlineto
+          6 -140 28 -72 2 blend
+          rlineto
+        </CharString>
+        <CharString name="quotesingle">
+          1 vsindex
+          90 494 24 -170 2 blend
+          rmoveto
+          26 66 1 blend
+          0 rlineto
+          6 140 28 72 2 blend
+          rlineto
+          0 60 6 88 2 blend
+          rlineto
+          -38 -134 1 blend
+          0 rlineto
+          0 -60 6 -88 2 blend
+          rlineto
+          6 -140 28 -72 2 blend
+          rlineto
+        </CharString>
+        <CharString name="r">
+          1 vsindex
+          96 -38 1 blend
+          0 rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 332 -54 1 blend
+          rlineto
+          38 94 52 34 44 -14 -32 -8 -12 -8 5 blend
+          0 rrcurveto
+          18 4 1 blend
+          0 10 2 1 blend
+          -2 12 6 1 blend
+          -4 rrcurveto
+          10 26 22 120 2 blend
+          rlineto
+          -16 8 -14 2 -16 2 -2 -3 2 -15 5 blend
+          0 rrcurveto
+          -58 9 1 blend
+          0 -46 -44 -32 -58 -10 14 -5 -10 4 blend
+          rrcurveto
+          -2 -2 1 blend
+          0 rlineto
+          -4 90 -8 -4 2 blend
+          rlineto
+          -26 -114 1 blend
+          0 rlineto
+          0 -478 -22 1 blend
+          rlineto
+        </CharString>
+        <CharString name="registered">
+          1 vsindex
+          196 326 42 -18 2 blend
+          rmoveto
+          98 14 1 blend
+          0 82 76 8 10 2 blend
+          0 116 2 1 blend
+          rrcurveto
+          0 116 -82 78 -98 2 -8 8 -14 4 blend
+          0 rrcurveto
+          -98 -14 1 blend
+          0 -82 -78 -8 -8 2 blend
+          0 -116 -2 1 blend
+          rrcurveto
+          0 -116 82 -76 98 -2 8 -10 14 4 blend
+          0 rrcurveto
+          0 26 28 1 blend
+          rmoveto
+          -84 0 -68 70 10 -12 2 blend
+          0 96 -4 1 blend
+          rrcurveto
+          0 96 68 72 -4 -10 -14 3 blend
+          84 0 rrcurveto
+          84 0 68 -72 -10 14 2 blend
+          0 -96 4 1 blend
+          rrcurveto
+          0 -96 -68 -70 4 10 12 3 blend
+          -84 0 rrcurveto
+          -66 66 -18 -12 2 blend
+          rmoveto
+          28 36 1 blend
+          0 rlineto
+          0 78 -22 1 blend
+          rlineto
+          50 -26 1 blend
+          0 rlineto
+          40 -78 -12 22 2 blend
+          rlineto
+          34 32 1 blend
+          0 rlineto
+          -50 88 10 -14 2 blend
+          rlineto
+          22 6 18 24 2 6 -8 -4 4 blend
+          0 26 -4 1 blend
+          rrcurveto
+          0 50 -38 14 -38 -6 4 8 -10 4 blend
+          0 rrcurveto
+          -66 -28 1 blend
+          0 rlineto
+          0 -208 14 1 blend
+          rlineto
+          28 104 36 -5 2 blend
+          rmoveto
+          0 78 -30 1 blend
+          rlineto
+          34 -16 1 blend
+          0 rlineto
+          38 -22 1 blend
+          0 12 -16 -2 6 2 blend
+          0 -24 11 1 blend
+          rrcurveto
+          0 -28 -22 -10 -32 16 14 -3 14 4 blend
+          0 rrcurveto
+          -30 12 1 blend
+          0 rlineto
+        </CharString>
+        <CharString name="s">
+          1 vsindex
+          208 4 1 blend
+          -12 rmoveto
+          100 40 1 blend
+          0 56 62 18 10 2 blend
+          0 70 24 1 blend
+          rrcurveto
+          0 94 -84 23 -14 28 25 3 blend
+          -76 29 -5 1 blend
+          rrcurveto
+          -58 22 -54 22 -6 -2 30 -12 4 blend
+          0 58 -36 1 blend
+          rrcurveto
+          0 47 36 47 80 -29 -22 -37 -50 4 blend
+          0 rrcurveto
+          50 -18 1 blend
+          0 34 -17 32 -23 3 8 5 -4 4 blend
+          rrcurveto
+          18 20 54 76 2 blend
+          rlineto
+          -34 28 -46 20 -52 -10 10 -18 8 -24 5 blend
+          0 rrcurveto
+          -98 -20 1 blend
+          0 -52 -58 -28 -6 2 blend
+          0 -66 -32 1 blend
+          rrcurveto
+          0 -82 78 -28 74 6 -20 -20 -4 4 blend
+          -26 rrcurveto
+          56 -3 1 blend
+          -20 64 -28 -25 18 2 blend
+          0 -64 38 1 blend
+          rrcurveto
+          0 -54 -42 -48 -80 34 28 38 44 4 blend
+          0 rrcurveto
+          -76 42 1 blend
+          0 -42 24 -40 34 -4 -14 -6 2 4 blend
+          rrcurveto
+          -18 -20 -54 -76 2 blend
+          rlineto
+          40 -40 58 12 -10 20 3 blend
+          -26 76 -12 1 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="section">
+          1 vsindex
+          232 -48 10 -44 2 blend
+          rmoveto
+          70 67 1 blend
+          0 66 50 1 22 2 blend
+          0 70 24 1 blend
+          rrcurveto
+          0 168 -286 -40 6 18 30 3 blend
+          0 158 -64 1 blend
+          rrcurveto
+          0 56 36 28 50 28 -27 -17 -5 -9 -16 5 blend
+          rrcurveto
+          -12 24 -74 46 2 blend
+          rlineto
+          -56 -28 -48 -38 -16 4 2 -26 4 blend
+          0 -72 14 1 blend
+          rrcurveto
+          0 -182 286 40 -8 -28 -40 3 blend
+          0 -144 80 1 blend
+          rrcurveto
+          0 -48 -42 -42 -64 28 28 30 28 4 blend
+          0 rrcurveto
+          -64 30 1 blend
+          0 -36 22 -34 32 -2 -6 2 2 4 blend
+          rrcurveto
+          -22 -22 -76 -64 2 blend
+          rlineto
+          38 -34 50 -26 68 8 -28 32 -2 6 5 blend
+          0 rrcurveto
+          76 192 82 36 2 blend
+          rmoveto
+          62 30 50 31 8 4 -14 19 4 blend
+          0 79 -15 1 blend
+          rrcurveto
+          0 186 -282 -39 -6 14 55 3 blend
+          0 139 -83 1 blend
+          rrcurveto
+          0 40 28 42 72 -18 -13 -34 -43 4 blend
+          0 rrcurveto
+          52 -21 1 blend
+          0 32 -20 32 -26 8 -1 -1 -1 4 blend
+          rrcurveto
+          18 22 60 84 2 blend
+          rlineto
+          -36 30 -46 22 -52 -6 3 -20 13 -30 5 blend
+          0 rrcurveto
+          -90 -27 1 blend
+          0 -40 -60 -31 -4 2 blend
+          0 -52 -46 1 blend
+          rrcurveto
+          0 -162 282 38 -14 -4 -24 3 blend
+          0 -162 64 1 blend
+          rrcurveto
+          0 -63 -36 -23 -60 -26 32 18 2 18 12 5 blend
+          rrcurveto
+          14 -26 84 -42 2 blend
+          rlineto
+        </CharString>
+        <CharString name="semicolon">
+          1 vsindex
+          104 378 56 -80 2 blend
+          rmoveto
+          18 40 1 blend
+          0 18 14 24 32 2 blend
+          0 24 34 1 blend
+          rrcurveto
+          0 26 -18 14 -18 32 -24 32 -40 4 blend
+          0 rrcurveto
+          -18 -40 1 blend
+          0 -18 -14 -24 -32 2 blend
+          0 -26 -32 1 blend
+          rrcurveto
+          0 -24 18 -14 18 -34 24 -32 40 4 blend
+          0 rrcurveto
+          -44 -528 -36 26 2 blend
+          rmoveto
+          52 32 40 54 78 4 28 36 4 blend
+          0 68 50 1 blend
+          rrcurveto
+          0 38 -18 24 -26 60 -22 34 -48 4 blend
+          0 rrcurveto
+          -18 -40 1 blend
+          0 -18 -12 -28 -26 2 blend
+          0 -24 -32 1 blend
+          rrcurveto
+          0 -24 16 -12 20 -36 32 -22 32 4 blend
+          0 rrcurveto
+          12 10 1 blend
+          0 12 2 8 14 8 5 8 -2 4 blend
+          rrcurveto
+          -34 42 -17 49 2 blend
+          rlineto
+          14 -54 -14 -54 2 blend
+          rlineto
+          0 -58 -30 -42 -42 -24 1 8 -11 -6 -39 -2 6 blend
+          rrcurveto
+          12 -24 22 -66 2 blend
+          rlineto
+        </CharString>
+        <CharString name="seven">
+          1 vsindex
+          188 -46 1 blend
+          0 rmoveto
+          34 138 1 blend
+          0 rlineto
+          10 250 42 166 156 206 2 -3 -20 -59 -6 -32 6 blend
+          rrcurveto
+          0 18 88 1 blend
+          rlineto
+          -386 -68 1 blend
+          0 rlineto
+          0 -28 -116 1 blend
+          rlineto
+          346 -74 1 blend
+          0 rlineto
+          -134 -182 -58 -166 -10 -264 12 16 18 42 -2 64 6 blend
+          rrcurveto
+        </CharString>
+        <CharString name="six">
+          1 vsindex
+          258 28 1 blend
+          -12 rmoveto
+          92 28 1 blend
+          0 78 84 22 -4 2 blend
+          0 114 22 1 blend
+          rrcurveto
+          0 128 -64 70 -112 8 -20 -10 4 4 blend
+          0 rrcurveto
+          -64 27 1 blend
+          0 -60 -38 -46 -58 1 12 16 12 4 blend
+          rrcurveto
+          0 -40 8 -68 2 blend
+          rlineto
+          56 78 64 30 48 -33 -34 -33 -14 -18 5 blend
+          0 rrcurveto
+          104 -68 1 blend
+          0 42 -74 -8 59 2 blend
+          0 -96 35 1 blend
+          rrcurveto
+          0 -94 -58 -76 -78 27 26 55 42 4 blend
+          0 rrcurveto
+          -122 83 1 blend
+          0 -52 116 3 -84 2 blend
+          0 156 2 1 blend
+          rrcurveto
+          0 250 92 86 106 -98 -41 -36 -39 4 blend
+          0 rrcurveto
+          42 -6 1 blend
+          0 39 -18 29 -36 1 -4 -9 14 4 blend
+          rrcurveto
+          20 22 70 80 2 blend
+          rlineto
+          -32 36 -40 24 -56 -10 6 -26 14 -34 5 blend
+          0 rrcurveto
+          -122 -14 1 blend
+          0 -110 -92 -16 -18 2 blend
+          0 -272 42 1 blend
+          rrcurveto
+          0 -190 76 -110 128 -40 50 22 -6 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="slash">
+          1 vsindex
+          8 6 1 blend
+          -160 rmoveto
+          30 80 1 blend
+          0 rlineto
+          320 -144 1 blend
+          870 rlineto
+          -30 -80 1 blend
+          0 rlineto
+          -320 144 1 blend
+          -870 rlineto
+        </CharString>
+        <CharString name="space">
+        </CharString>
+        <CharString name="sterling">
+          1 vsindex
+          58 -12 1 blend
+          0 rmoveto
+          360 108 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -300 50 1 blend
+          0 rlineto
+          0 4 rlineto
+          48 46 28 52 -20 -12 -18 -25 4 blend
+          0 88 -49 1 blend
+          rrcurveto
+          0 106 -50 74 -44 22 -17 3 blend
+          0 90 -35 1 blend
+          rrcurveto
+          0 74 44 62 86 -16 -12 -34 -38 4 blend
+          0 rrcurveto
+          57 -29 1 blend
+          0 37 -22 28 -38 -15 12 -6 12 4 blend
+          rrcurveto
+          20 16 68 70 2 blend
+          rlineto
+          -28 42 -46 30 -66 -12 10 -12 6 -18 5 blend
+          0 rrcurveto
+          -102 -24 1 blend
+          0 -62 -64 -34 -18 2 blend
+          0 -102 -30 1 blend
+          rrcurveto
+          0 -92 52 -82 37 -10 14 3 blend
+          0 -94 35 1 blend
+          rrcurveto
+          0 -78 -30 -78 -76 -44 8 -20 28 20 20 5 blend
+          rrcurveto
+          0 -18 -88 1 blend
+          rlineto
+          -4 296 10 -30 2 blend
+          rmoveto
+          292 80 1 blend
+          0 rlineto
+          0 28 76 1 blend
+          rlineto
+          -226 -78 1 blend
+          0 rlineto
+          -66 -2 -2 -4 2 blend
+          rlineto
+          0 -26 -72 1 blend
+          rlineto
+        </CharString>
+        <CharString name="t">
+          218 28 46 1 blend
+          -12 rmoveto
+          22 17 30 1 blend
+          0 28 8 26 14 6 12 1 2 1 0 -5 -4 4 blend
+          rrcurveto
+          -12 22 -8 -14 63 98 2 blend
+          rlineto
+          -24 -12 -20 -4 -18 10 12 6 8 0 4 -1 2 1 2 5 blend
+          0 rrcurveto
+          -70 23 38 1 blend
+          0 -14 44 -8 -14 -16 -26 2 blend
+          0 62 -4 -7 1 blend
+          rrcurveto
+          0 328 -94 -157 1 blend
+          rlineto
+          142 -17 -28 1 blend
+          0 rlineto
+          0 28 63 106 1 blend
+          rlineto
+          -142 17 28 1 blend
+          0 rlineto
+          0 160 -26 -10 1 blend
+          rlineto
+          -26 -70 -116 1 blend
+          0 rlineto
+          -4 -160 -10 -16 26 10 2 blend
+          rlineto
+          -76 -4 -1 -2 1 blend
+          rlineto
+          0 -24 -62 -104 1 blend
+          rlineto
+          76 -6 -10 1 blend
+          0 rlineto
+          0 -324 90 150 1 blend
+          rlineto
+          0 -82 24 -56 88 -24 -40 18 30 -16 -26 26 42 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="thorn">
+          1 vsindex
+          96 -222 -38 46 2 blend
+          rmoveto
+          30 142 1 blend
+          0 rlineto
+          0 180 -42 1 blend
+          rlineto
+          0 90 -4 -20 2 blend
+          rlineto
+          52 -38 50 -22 46 -22 10 -18 6 2 5 blend
+          0 rrcurveto
+          114 -8 1 blend
+          0 98 96 4 2 2 blend
+          0 162 10 1 blend
+          rrcurveto
+          0 148 -62 96 -130 6 -18 4 6 4 blend
+          0 rrcurveto
+          -60 18 1 blend
+          0 -58 -36 -50 -38 17 20 19 10 4 blend
+          rrcurveto
+          0 94 4 -28 2 blend
+          rlineto
+          0 212 -50 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -944 72 1 blend
+          rlineto
+          180 238 56 66 2 blend
+          rmoveto
+          -38 16 1 blend
+          0 -54 18 -58 48 32 -12 38 -30 4 blend
+          rrcurveto
+          0 296 -112 1 blend
+          rlineto
+          62 54 54 30 50 -40 -28 -34 -20 -24 5 blend
+          0 rrcurveto
+          118 -72 1 blend
+          0 44 -94 -20 60 2 blend
+          0 -122 40 1 blend
+          rrcurveto
+          0 -134 -74 -96 -104 38 40 64 64 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="three">
+          1 vsindex
+          230 16 1 blend
+          -12 rmoveto
+          108 24 1 blend
+          0 82 70 32 -4 2 blend
+          0 110 10 1 blend
+          rrcurveto
+          0 92 -68 60 -80 16 -12 18 -10 8 6 5 blend
+          rrcurveto
+          0 4 rlineto
+          70 23 54 51 -2 7 -20 -5 4 blend
+          0 86 -25 1 blend
+          rrcurveto
+          0 96 -74 56 -94 19 -16 8 -46 4 blend
+          0 rrcurveto
+          -74 -4 1 blend
+          0 -54 -36 -42 -42 -12 6 -20 -10 4 blend
+          rrcurveto
+          20 -22 66 -82 2 blend
+          rlineto
+          36 40 54 32 60 4 -6 -24 -14 -18 5 blend
+          0 rrcurveto
+          82 -39 1 blend
+          0 54 -50 -31 30 2 blend
+          0 -76 38 1 blend
+          rrcurveto
+          0 -80 -54 -66 -152 36 22 38 46 4 blend
+          0 rrcurveto
+          0 -30 -90 1 blend
+          rlineto
+          162 -29 1 blend
+          0 68 -64 -43 36 2 blend
+          0 -92 44 1 blend
+          rrcurveto
+          0 -90 -66 -60 -90 50 30 40 34 4 blend
+          0 rrcurveto
+          -92 47 1 blend
+          0 -52 42 -38 42 6 -18 -1 -6 4 blend
+          rrcurveto
+          -20 -22 -58 -86 2 blend
+          rlineto
+          40 -42 58 -48 102 8 -14 17 14 1 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="threequarters">
+          1 vsindex
+          176 258 8 -10 2 blend
+          rmoveto
+          72 10 1 blend
+          0 56 42 18 8 2 blend
+          0 72 rrcurveto
+          0 56 -46 34 -48 8 -12 18 -2 10 10 5 blend
+          rrcurveto
+          44 16 34 34 -10 6 -16 -8 4 blend
+          0 50 -10 1 blend
+          rrcurveto
+          0 64 -52 38 -64 4 -14 4 -10 4 blend
+          0 rrcurveto
+          -48 -16 1 blend
+          0 -40 -28 -26 -34 8 -20 -14 3 blend
+          rrcurveto
+          20 -18 50 -44 2 blend
+          rlineto
+          26 32 34 22 32 -10 -12 -16 -6 -8 5 blend
+          0 rrcurveto
+          54 -30 1 blend
+          0 34 -32 -18 20 2 blend
+          0 -46 24 1 blend
+          rrcurveto
+          0 -46 -46 -42 -82 16 19 32 41 4 blend
+          0 rrcurveto
+          0 -24 -46 1 blend
+          rlineto
+          88 -31 1 blend
+          0 56 -30 -31 16 2 blend
+          0 -54 24 1 blend
+          rrcurveto
+          0 -56 -44 -32 -52 32 23 18 25 4 blend
+          0 rrcurveto
+          -46 16 1 blend
+          0 -42 28 20 -16 2 blend
+          -24 38 -6 1 blend
+          rrcurveto
+          -24 -18 -50 -40 2 blend
+          rlineto
+          26 -38 48 -36 60 10 -16 10 10 10 5 blend
+          0 rrcurveto
+          50 -270 -30 10 2 blend
+          rmoveto
+          32 64 1 blend
+          0 rlineto
+          370 684 -22 -10 2 blend
+          rlineto
+          -32 -64 1 blend
+          0 rlineto
+          -370 -684 22 10 2 blend
+          rlineto
+          416 38 1 blend
+          12 rmoveto
+          28 82 1 blend
+          0 rlineto
+          0 390 rlineto
+          -22 -136 1 blend
+          0 rlineto
+          -182 -256 50 8 2 blend
+          rlineto
+          0 -16 -46 1 blend
+          rlineto
+          262 86 1 blend
+          0 rlineto
+          0 26 54 1 blend
+          rlineto
+          -222 -14 1 blend
+          0 rlineto
+          78 112 -44 -38 2 blend
+          rlineto
+          58 84 -22 -8 2 blend
+          rlineto
+          4 0 rlineto
+          -4 -102 -2 -18 2 blend
+          rlineto
+          0 -238 48 1 blend
+          rlineto
+        </CharString>
+        <CharString name="two">
+          1 vsindex
+          42 -6 1 blend
+          0 rmoveto
+          384 76 1 blend
+          0 rlineto
+          0 28 116 1 blend
+          rlineto
+          -232 110 1 blend
+          0 rlineto
+          -36 8 1 blend
+          0 -36 -2 -36 -2 -10 -2 4 -2 4 blend
+          rrcurveto
+          190 198 118 124 -94 -106 -16 -24 4 blend
+          0 130 -18 1 blend
+          rrcurveto
+          0 106 -64 70 -112 18 -26 12 -16 4 blend
+          0 rrcurveto
+          -76 -16 1 blend
+          0 -56 -42 -46 -52 -4 8 -18 -20 4 blend
+          rrcurveto
+          22 -20 66 -68 2 blend
+          rlineto
+          40 50 54 36 60 -10 -20 -22 -6 -18 5 blend
+          0 rrcurveto
+          102 -56 1 blend
+          0 44 -66 -12 39 2 blend
+          0 -82 25 1 blend
+          rrcurveto
+          0 -114 -104 -122 -216 -222 30 -14 10 68 96 5 blend
+          rrcurveto
+          0 -18 -88 1 blend
+          rlineto
+        </CharString>
+        <CharString name="u">
+          232 -13 -22 1 blend
+          -12 rmoveto
+          66 1 2 1 blend
+          0 50 38 48 56 -2 -4 -5 -8 -5 -8 -5 -8 4 blend
+          rrcurveto
+          2 1 2 1 blend
+          0 rlineto
+          4 -82 5 8 10 16 2 blend
+          rlineto
+          26 68 114 1 blend
+          0 rlineto
+          0 478 13 22 1 blend
+          rlineto
+          -30 -85 -142 1 blend
+          0 rlineto
+          0 -358 22 36 1 blend
+          rlineto
+          -60 -72 -44 -32 -60 23 38 24 40 15 26 12 20 17 28 5 blend
+          0 rrcurveto
+          -82 29 48 1 blend
+          0 -34 52 11 18 -22 -36 2 blend
+          0 106 -25 -42 1 blend
+          rrcurveto
+          0 304 -11 -18 1 blend
+          rlineto
+          -30 -85 -142 1 blend
+          0 rlineto
+          0 -308 rlineto
+          0 -124 46 -58 98 -13 -22 7 12 2 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="uacute">
+          1 vsindex
+          232 -22 1 blend
+          -12 rmoveto
+          66 2 1 blend
+          0 50 38 48 56 -4 -8 -8 -8 4 blend
+          rrcurveto
+          2 2 1 blend
+          0 rlineto
+          4 -82 8 16 2 blend
+          rlineto
+          26 114 1 blend
+          0 rlineto
+          0 478 22 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -358 36 1 blend
+          rlineto
+          -60 -72 -44 -32 -60 38 40 26 20 28 5 blend
+          0 rrcurveto
+          -82 48 1 blend
+          0 -34 52 18 -36 2 blend
+          0 106 -42 1 blend
+          rrcurveto
+          0 304 -18 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -308 rlineto
+          0 -124 46 -58 98 -22 12 2 blend
+          0 rrcurveto
+          -16 586 56 -2 2 blend
+          rmoveto
+          148 150 82 8 2 blend
+          rlineto
+          -24 20 -72 94 2 blend
+          rlineto
+          -142 -154 -76 -34 2 blend
+          rlineto
+          18 -16 66 -68 2 blend
+          rlineto
+        </CharString>
+        <CharString name="ucircumflex">
+          1 vsindex
+          232 -22 1 blend
+          -12 rmoveto
+          66 2 1 blend
+          0 50 38 48 56 -4 -8 -8 -8 4 blend
+          rrcurveto
+          2 2 1 blend
+          0 rlineto
+          4 -82 8 16 2 blend
+          rlineto
+          26 114 1 blend
+          0 rlineto
+          0 478 22 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -358 36 1 blend
+          rlineto
+          -60 -72 -44 -32 -60 38 40 26 20 28 5 blend
+          0 rrcurveto
+          -82 48 1 blend
+          0 -34 52 18 -36 2 blend
+          0 106 -42 1 blend
+          rrcurveto
+          0 304 -18 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -308 rlineto
+          0 -124 46 -58 98 -22 12 2 blend
+          0 rrcurveto
+          -86 586 36 -16 2 blend
+          rmoveto
+          112 130 16 -46 2 blend
+          rlineto
+          4 0 rlineto
+          112 -130 16 46 2 blend
+          rlineto
+          18 16 46 44 2 blend
+          rlineto
+          -118 146 12 -18 2 blend
+          rlineto
+          -28 -148 1 blend
+          0 rlineto
+          -118 -146 12 18 2 blend
+          rlineto
+          18 -16 46 -44 2 blend
+          rlineto
+        </CharString>
+        <CharString name="udieresis">
+          1 vsindex
+          232 -22 1 blend
+          -12 rmoveto
+          66 2 1 blend
+          0 50 38 48 56 -4 -8 -8 -8 4 blend
+          rrcurveto
+          2 2 1 blend
+          0 rlineto
+          4 -82 8 16 2 blend
+          rlineto
+          26 114 1 blend
+          0 rlineto
+          0 478 22 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -358 36 1 blend
+          rlineto
+          -60 -72 -44 -32 -60 38 40 26 20 28 5 blend
+          0 rrcurveto
+          -82 48 1 blend
+          0 -34 52 18 -36 2 blend
+          0 106 -42 1 blend
+          rrcurveto
+          0 304 -18 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -308 rlineto
+          0 -124 46 -58 98 -22 12 2 blend
+          0 rrcurveto
+          -58 614 24 -40 2 blend
+          rmoveto
+          18 29 1 blend
+          0 14 14 19 21 2 blend
+          0 18 27 1 blend
+          rrcurveto
+          0 18 -14 14 -18 27 -19 21 -29 4 blend
+          0 rrcurveto
+          -18 -29 1 blend
+          0 -14 -14 -19 -21 2 blend
+          0 -18 -27 1 blend
+          rrcurveto
+          0 -18 14 -14 18 -27 19 -21 29 4 blend
+          0 rrcurveto
+          172 56 1 blend
+          0 rmoveto
+          18 29 1 blend
+          0 14 14 19 21 2 blend
+          0 18 27 1 blend
+          rrcurveto
+          0 18 -14 14 -18 27 -19 21 -29 4 blend
+          0 rrcurveto
+          -18 -29 1 blend
+          0 -14 -14 -19 -21 2 blend
+          0 -18 -27 1 blend
+          rrcurveto
+          0 -18 14 -14 18 -27 19 -21 29 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="ugrave">
+          1 vsindex
+          232 -22 1 blend
+          -12 rmoveto
+          66 2 1 blend
+          0 50 38 48 56 -4 -8 -8 -8 4 blend
+          rrcurveto
+          2 2 1 blend
+          0 rlineto
+          4 -82 8 16 2 blend
+          rlineto
+          26 114 1 blend
+          0 rlineto
+          0 478 22 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -358 36 1 blend
+          rlineto
+          -60 -72 -44 -32 -60 38 40 26 20 28 5 blend
+          0 rrcurveto
+          -82 48 1 blend
+          0 -34 52 18 -36 2 blend
+          0 106 -42 1 blend
+          rrcurveto
+          0 304 -18 1 blend
+          rlineto
+          -30 -142 1 blend
+          0 rlineto
+          0 -308 rlineto
+          0 -124 46 -58 98 -22 12 2 blend
+          0 rrcurveto
+          72 586 48 -2 2 blend
+          rmoveto
+          18 16 66 68 2 blend
+          rlineto
+          -142 154 -76 34 2 blend
+          rlineto
+          -24 -20 -72 -94 2 blend
+          rlineto
+          148 -150 82 -8 2 blend
+          rlineto
+        </CharString>
+        <CharString name="underscore">
+          1 vsindex
+          12 -114 -32 1 blend
+          rmoveto
+          476 0 rlineto
+          0 32 62 1 blend
+          rlineto
+          -476 0 rlineto
+          0 -32 -62 1 blend
+          rlineto
+        </CharString>
+        <CharString name="uni00B2">
+          1 vsindex
+          58 410 -16 -42 2 blend
+          rmoveto
+          250 48 1 blend
+          0 rlineto
+          0 26 78 1 blend
+          rlineto
+          -202 102 1 blend
+          0 rlineto
+          106 104 72 66 -62 -52 -28 -13 4 blend
+          0 84 -25 1 blend
+          rrcurveto
+          0 82 -48 40 -70 2 -12 10 -20 4 blend
+          0 rrcurveto
+          -48 -14 1 blend
+          0 -46 -34 -22 -38 -4 8 -22 -18 4 blend
+          rrcurveto
+          20 -18 50 -46 2 blend
+          rlineto
+          22 34 34 30 38 -6 -14 -14 -14 4 blend
+          0 rrcurveto
+          54 -22 1 blend
+          0 36 -38 -18 18 2 blend
+          0 -60 26 1 blend
+          rrcurveto
+          0 -68 -58 -60 -138 -130 24 -16 -4 46 58 5 blend
+          rrcurveto
+          0 -20 -46 1 blend
+          rlineto
+        </CharString>
+        <CharString name="uni00B3">
+          1 vsindex
+          176 398 12 -42 2 blend
+          rmoveto
+          72 10 1 blend
+          0 56 42 18 8 2 blend
+          0 72 rrcurveto
+          0 56 -46 34 -48 8 -12 18 -2 10 10 5 blend
+          rrcurveto
+          44 16 34 34 -10 6 -16 -8 4 blend
+          0 50 -10 1 blend
+          rrcurveto
+          0 64 -52 38 -64 4 -14 4 -10 4 blend
+          0 rrcurveto
+          -48 -16 1 blend
+          0 -40 -28 -26 -34 8 -20 -14 3 blend
+          rrcurveto
+          20 -18 50 -44 2 blend
+          rlineto
+          26 32 34 22 32 -10 -12 -16 -6 -8 5 blend
+          0 rrcurveto
+          54 -30 1 blend
+          0 34 -32 -18 20 2 blend
+          0 -46 24 1 blend
+          rrcurveto
+          0 -46 -46 -42 -82 16 19 32 41 4 blend
+          0 rrcurveto
+          0 -24 -46 1 blend
+          rlineto
+          88 -31 1 blend
+          0 56 -30 -31 16 2 blend
+          0 -54 24 1 blend
+          rrcurveto
+          0 -56 -44 -32 -52 32 23 18 25 4 blend
+          0 rrcurveto
+          -46 16 1 blend
+          0 -42 28 20 -16 2 blend
+          -24 38 -6 1 blend
+          rrcurveto
+          -24 -18 -50 -40 2 blend
+          rlineto
+          26 -38 48 -36 60 10 -16 10 10 10 5 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="uni00B9">
+          1 vsindex
+          178 410 -16 -42 2 blend
+          rmoveto
+          28 98 1 blend
+          0 rlineto
+          0 390 rlineto
+          -26 -72 1 blend
+          0 rlineto
+          -22 -18 -26 -14 -6 2 3 blend
+          -12 -36 -22 1 blend
+          -8 rrcurveto
+          0 -22 -54 1 blend
+          rlineto
+          82 8 1 blend
+          0 rlineto
+          0 -330 60 1 blend
+          rlineto
+        </CharString>
+        <CharString name="v">
+          1 vsindex
+          194 -18 1 blend
+          0 rmoveto
+          36 162 1 blend
+          0 rlineto
+          180 478 -22 22 2 blend
+          rlineto
+          -32 -132 1 blend
+          0 rlineto
+          -114 -310 60 92 2 blend
+          rlineto
+          -16 -46 -18 -48 -16 -42 4 -4 6 -4 4 -12 6 blend
+          rrcurveto
+          -4 0 rlineto
+          -16 42 -18 48 -16 46 4 12 6 4 4 4 6 blend
+          rrcurveto
+          -114 310 60 -92 2 blend
+          rlineto
+          -34 -138 1 blend
+          0 rlineto
+          182 -478 -18 -22 2 blend
+          rlineto
+        </CharString>
+        <CharString name="w">
+          168 -14 -24 1 blend
+          0 rmoveto
+          38 104 158 1 blend
+          0 rlineto
+          88 310 -38 -54 -82 -136 2 blend
+          rlineto
+          16 46 12 46 12 46 -6 -8 -2 0 -4 -6 -6 0 -5 -4 18 9 6 blend
+          rrcurveto
+          4 0 rlineto
+          14 -46 10 -44 14 -46 -5 -6 -18 -9 -2 -2 4 -2 -4 -6 2 0 6 blend
+          rrcurveto
+          90 -312 -40 -54 84 138 2 blend
+          rlineto
+          42 105 158 1 blend
+          0 rlineto
+          140 478 -15 -26 13 22 2 blend
+          rlineto
+          -32 -78 -126 1 blend
+          0 rlineto
+          -90 -322 32 52 67 112 2 blend
+          rlineto
+          -12 -44 -12 -40 -12 -42 2 4 0 -6 6 8 -4 -10 3 4 -16 -10 6 blend
+          rrcurveto
+          -4 0 rlineto
+          -12 42 -12 40 -12 44 3 2 16 10 3 4 4 10 1 0 0 6 6 blend
+          rrcurveto
+          -92 322 30 44 -67 -112 2 blend
+          rlineto
+          -42 -78 -104 1 blend
+          0 rlineto
+          -92 -322 32 46 67 112 2 blend
+          rlineto
+          -12 -44 -12 -40 -12 -42 2 0 0 -4 4 4 -4 -12 3 4 -16 -10 6 blend
+          rrcurveto
+          -4 0 rlineto
+          -10 42 -12 40 -12 44 3 2 16 10 4 8 4 10 2 4 0 6 6 blend
+          rrcurveto
+          -92 322 34 54 -67 -112 2 blend
+          rlineto
+          -34 -84 -136 1 blend
+          0 rlineto
+          144 -478 -14 -24 -13 -22 2 blend
+          rlineto
+        </CharString>
+        <CharString name="x">
+          14 0 rmoveto
+          1 vsindex
+          32 146 1 blend
+          0 rlineto
+          88 138 -60 -68 2 blend
+          rlineto
+          20 30 18 30 20 -9 -1 -6 -1 -9 5 blend
+          28 rrcurveto
+          4 0 rlineto
+          20 -5 1 blend
+          -28 20 -6 1 blend
+          -30 18 -30 -3 2 2 blend
+          rrcurveto
+          90 -138 -50 68 2 blend
+          rlineto
+          34 150 1 blend
+          0 rlineto
+          -164 248 14 -8 2 blend
+          rlineto
+          150 230 -8 30 2 blend
+          rlineto
+          -32 -146 1 blend
+          0 rlineto
+          -80 -128 56 58 2 blend
+          rlineto
+          -18 -26 -16 -26 -18 -26 9 -2 4 -4 9 -2 6 blend
+          rrcurveto
+          -4 0 rlineto
+          -18 26 -18 26 -16 26 5 2 4 4 3 2 6 blend
+          rrcurveto
+          -82 128 46 -58 2 blend
+          rlineto
+          -34 -150 1 blend
+          0 rlineto
+          150 -228 -8 -12 2 blend
+          rlineto
+          -164 -250 14 -10 2 blend
+          rlineto
+        </CharString>
+        <CharString name="y">
+          1 vsindex
+          66 -222 66 34 2 blend
+          rmoveto
+          82 42 1 blend
+          0 48 80 24 74 6 -19 28 61 4 blend
+          rrcurveto
+          192 546 -24 -54 2 blend
+          rlineto
+          -32 -132 1 blend
+          0 rlineto
+          -108 -314 58 122 2 blend
+          rlineto
+          -14 -40 -16 -52 -16 -42 2 -8 6 6 6 -6 6 blend
+          rrcurveto
+          -4 0 rlineto
+          -18 42 -20 52 -16 40 6 8 10 -6 2 6 6 blend
+          rrcurveto
+          -122 314 62 -122 2 blend
+          rlineto
+          -34 -138 1 blend
+          0 rlineto
+          198 -490 -8 8 2 blend
+          rlineto
+          -14 -44 8 22 2 blend
+          rlineto
+          -26 -78 -42 -58 -60 16 48 20 38 14 5 blend
+          0 rrcurveto
+          -12 2 1 blend
+          0 -16 4 -10 10 -4 -6 3 blend
+          4 rrcurveto
+          -10 -28 -20 -98 2 blend
+          rlineto
+          12 -6 18 10 -2 2 3 blend
+          -4 16 18 1 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="yacute">
+          1 vsindex
+          66 -222 66 34 2 blend
+          rmoveto
+          82 42 1 blend
+          0 48 80 24 74 6 -19 28 61 4 blend
+          rrcurveto
+          192 546 -24 -54 2 blend
+          rlineto
+          -32 -132 1 blend
+          0 rlineto
+          -108 -314 58 122 2 blend
+          rlineto
+          -14 -40 -16 -52 -16 -42 2 -8 6 6 6 -6 6 blend
+          rrcurveto
+          -4 0 rlineto
+          -18 42 -20 52 -16 40 6 8 10 -6 2 6 6 blend
+          rrcurveto
+          -122 314 62 -122 2 blend
+          rlineto
+          -34 -138 1 blend
+          0 rlineto
+          198 -490 -8 8 2 blend
+          rlineto
+          -14 -44 8 22 2 blend
+          rlineto
+          -26 -78 -42 -58 -60 16 48 20 38 14 5 blend
+          0 rrcurveto
+          -12 2 1 blend
+          0 -16 4 -10 10 -4 -6 3 blend
+          4 rrcurveto
+          -10 -28 -20 -98 2 blend
+          rlineto
+          12 -6 18 10 -2 2 3 blend
+          -4 16 18 1 blend
+          0 rrcurveto
+          114 796 -10 -36 2 blend
+          rmoveto
+          148 150 82 8 2 blend
+          rlineto
+          -24 20 -72 94 2 blend
+          rlineto
+          -142 -154 -76 -34 2 blend
+          rlineto
+          18 -16 66 -68 2 blend
+          rlineto
+        </CharString>
+        <CharString name="ydieresis">
+          1 vsindex
+          66 -222 66 34 2 blend
+          rmoveto
+          82 42 1 blend
+          0 48 80 24 74 6 -19 28 61 4 blend
+          rrcurveto
+          192 546 -24 -54 2 blend
+          rlineto
+          -32 -132 1 blend
+          0 rlineto
+          -108 -314 58 122 2 blend
+          rlineto
+          -14 -40 -16 -52 -16 -42 2 -8 6 6 6 -6 6 blend
+          rrcurveto
+          -4 0 rlineto
+          -18 42 -20 52 -16 40 6 8 10 -6 2 6 6 blend
+          rrcurveto
+          -122 314 62 -122 2 blend
+          rlineto
+          -34 -138 1 blend
+          0 rlineto
+          198 -490 -8 8 2 blend
+          rlineto
+          -14 -44 8 22 2 blend
+          rlineto
+          -26 -78 -42 -58 -60 16 48 20 38 14 5 blend
+          0 rrcurveto
+          -12 2 1 blend
+          0 -16 4 -10 10 -4 -6 3 blend
+          4 rrcurveto
+          -10 -28 -20 -98 2 blend
+          rlineto
+          12 -6 18 10 -2 2 3 blend
+          -4 16 18 1 blend
+          0 rrcurveto
+          72 824 -42 -74 2 blend
+          rmoveto
+          18 29 1 blend
+          0 14 14 19 21 2 blend
+          0 18 27 1 blend
+          rrcurveto
+          0 18 -14 14 -18 27 -19 21 -29 4 blend
+          0 rrcurveto
+          -18 -29 1 blend
+          0 -14 -14 -19 -21 2 blend
+          0 -18 -27 1 blend
+          rrcurveto
+          0 -18 14 -14 18 -27 19 -21 29 4 blend
+          0 rrcurveto
+          172 56 1 blend
+          0 rmoveto
+          18 29 1 blend
+          0 14 14 19 21 2 blend
+          0 18 27 1 blend
+          rrcurveto
+          0 18 -14 14 -18 27 -19 21 -29 4 blend
+          0 rrcurveto
+          -18 -29 1 blend
+          0 -14 -14 -19 -21 2 blend
+          0 -18 -27 1 blend
+          rrcurveto
+          0 -18 14 -14 18 -27 19 -21 29 4 blend
+          0 rrcurveto
+        </CharString>
+        <CharString name="yen">
+          220 -22 -36 1 blend
+          0 rmoveto
+          30 86 142 1 blend
+          0 rlineto
+          0 162 -18 -22 1 blend
+          rlineto
+          170 -12 -20 1 blend
+          0 rlineto
+          0 28 40 56 1 blend
+          rlineto
+          -170 12 20 1 blend
+          0 rlineto
+          0 80 -22 -36 1 blend
+          rlineto
+          170 -12 -20 1 blend
+          0 rlineto
+          0 28 40 56 1 blend
+          rlineto
+          -158 30 44 1 blend
+          0 rlineto
+          178 342 -27 -38 -44 -60 2 blend
+          rlineto
+          -32 -84 -140 1 blend
+          0 rlineto
+          -100 -202 36 60 51 84 2 blend
+          rlineto
+          -22 -45 -22 -43 -26 -50 4 7 1 2 4 6 -1 -1 7 11 5 7 6 blend
+          rrcurveto
+          -4 0 rlineto
+          -24 50 -22 4 8 -5 -8 5 7 3 blend
+          44 -22 4 7 1 blend
+          44 rrcurveto
+          -100 202 36 60 -51 -84 2 blend
+          rlineto
+          -34 -85 -142 1 blend
+          0 rlineto
+          176 -342 -26 -36 44 60 2 blend
+          rlineto
+          -156 28 42 1 blend
+          0 rlineto
+          0 -28 -40 -56 1 blend
+          rlineto
+          168 -10 -18 1 blend
+          0 rlineto
+          0 -80 22 36 1 blend
+          rlineto
+          -168 10 18 1 blend
+          0 rlineto
+          0 -28 -40 -56 1 blend
+          rlineto
+          168 -10 -18 1 blend
+          0 rlineto
+          0 -162 18 22 1 blend
+          rlineto
+        </CharString>
+        <CharString name="z">
+          1 vsindex
+          26 14 1 blend
+          0 rmoveto
+          344 66 1 blend
+          0 rlineto
+          0 28 106 1 blend
+          rlineto
+          -304 108 1 blend
+          0 rlineto
+          294 434 -104 -160 2 blend
+          rlineto
+          0 16 76 1 blend
+          rlineto
+          -302 -80 1 blend
+          0 rlineto
+          0 -28 -106 1 blend
+          rlineto
+          262 -94 1 blend
+          0 rlineto
+          -294 -434 104 160 2 blend
+          rlineto
+          0 -16 -76 1 blend
+          rlineto
+        </CharString>
+        <CharString name="zero">
+          1 vsindex
+          236 34 1 blend
+          -12 rmoveto
+          120 20 1 blend
+          0 66 122 30 -7 2 blend
+          0 212 5 1 blend
+          rrcurveto
+          0 212 -66 118 -120 4 -30 -8 -20 4 blend
+          0 rrcurveto
+          -120 -20 1 blend
+          0 -66 -118 -30 9 2 blend
+          0 -212 -5 1 blend
+          rrcurveto
+          0 -212 66 -122 120 -5 30 7 20 4 blend
+          0 rrcurveto
+          0 28 104 1 blend
+          rmoveto
+          -94 54 1 blend
+          0 -60 108 26 -76 2 blend
+          0 198 -30 1 blend
+          rrcurveto
+          0 198 60 104 94 -30 -26 -78 -54 4 blend
+          0 rrcurveto
+          94 -54 1 blend
+          0 60 -104 -26 78 2 blend
+          0 -198 30 1 blend
+          rrcurveto
+          0 -198 -60 -108 -94 30 26 76 54 4 blend
+          0 rrcurveto
+        </CharString>
+      </CharStrings>
+      <VarStore Format="1">
+        <Format value="1"/>
+        <VarRegionList>
+          <!-- RegionAxisCount=1 -->
+          <!-- RegionCount=3 -->
+          <Region index="0">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.6"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
+          <Region index="1">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.6"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
+          <Region index="2">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
+        </VarRegionList>
+        <!-- VarDataCount=2 -->
+        <VarData index="0">
+          <!-- ItemCount=0 -->
+          <NumShorts value="0"/>
+          <!-- VarRegionCount=2 -->
+          <VarRegionIndex index="0" value="0"/>
+          <VarRegionIndex index="1" value="1"/>
+        </VarData>
+        <VarData index="1">
+          <!-- ItemCount=0 -->
+          <NumShorts value="0"/>
+          <!-- VarRegionCount=1 -->
+          <VarRegionIndex index="0" value="2"/>
+        </VarData>
+      </VarStore>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF2>
+
+  <GDEF>
+    <Version value="0x00010003"/>
+    <GlyphClassDef Format="2">
+      <ClassDef glyph="A" class="1"/>
+      <ClassDef glyph="AE" class="1"/>
+      <ClassDef glyph="B" class="1"/>
+      <ClassDef glyph="C" class="1"/>
+      <ClassDef glyph="D" class="1"/>
+      <ClassDef glyph="E" class="1"/>
+      <ClassDef glyph="F" class="1"/>
+      <ClassDef glyph="G" class="1"/>
+      <ClassDef glyph="H" class="1"/>
+      <ClassDef glyph="I" class="1"/>
+      <ClassDef glyph="J" class="1"/>
+      <ClassDef glyph="K" class="1"/>
+      <ClassDef glyph="L" class="1"/>
+      <ClassDef glyph="M" class="1"/>
+      <ClassDef glyph="N" class="1"/>
+      <ClassDef glyph="O" class="1"/>
+      <ClassDef glyph="Oslash" class="1"/>
+      <ClassDef glyph="P" class="1"/>
+      <ClassDef glyph="Q" class="1"/>
+      <ClassDef glyph="R" class="1"/>
+      <ClassDef glyph="S" class="1"/>
+      <ClassDef glyph="T" class="1"/>
+      <ClassDef glyph="U" class="1"/>
+      <ClassDef glyph="V" class="1"/>
+      <ClassDef glyph="W" class="1"/>
+      <ClassDef glyph="X" class="1"/>
+      <ClassDef glyph="Y" class="1"/>
+      <ClassDef glyph="Z" class="1"/>
+      <ClassDef glyph="a" class="1"/>
+      <ClassDef glyph="ae" class="1"/>
+      <ClassDef glyph="b" class="1"/>
+      <ClassDef glyph="c" class="1"/>
+      <ClassDef glyph="d" class="1"/>
+      <ClassDef glyph="e" class="1"/>
+      <ClassDef glyph="eth" class="1"/>
+      <ClassDef glyph="f" class="1"/>
+      <ClassDef glyph="g" class="1"/>
+      <ClassDef glyph="glyph00259" class="1"/>
+      <ClassDef glyph="h" class="1"/>
+      <ClassDef glyph="i" class="1"/>
+      <ClassDef glyph="j" class="1"/>
+      <ClassDef glyph="k" class="1"/>
+      <ClassDef glyph="l" class="1"/>
+      <ClassDef glyph="m" class="1"/>
+      <ClassDef glyph="n" class="1"/>
+      <ClassDef glyph="o" class="1"/>
+      <ClassDef glyph="oslash" class="1"/>
+      <ClassDef glyph="p" class="1"/>
+      <ClassDef glyph="q" class="1"/>
+      <ClassDef glyph="r" class="1"/>
+      <ClassDef glyph="s" class="1"/>
+      <ClassDef glyph="t" class="1"/>
+      <ClassDef glyph="thorn" class="1"/>
+      <ClassDef glyph="u" class="1"/>
+      <ClassDef glyph="v" class="1"/>
+      <ClassDef glyph="w" class="1"/>
+      <ClassDef glyph="x" class="1"/>
+      <ClassDef glyph="y" class="1"/>
+      <ClassDef glyph="z" class="1"/>
+    </GlyphClassDef>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=1 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=53 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=1 -->
+        <VarRegionIndex index="0" value="0"/>
+        <Item index="0" value="[-112]"/>
+        <Item index="1" value="[-94]"/>
+        <Item index="2" value="[-88]"/>
+        <Item index="3" value="[-80]"/>
+        <Item index="4" value="[-70]"/>
+        <Item index="5" value="[-68]"/>
+        <Item index="6" value="[-66]"/>
+        <Item index="7" value="[-60]"/>
+        <Item index="8" value="[-56]"/>
+        <Item index="9" value="[-50]"/>
+        <Item index="10" value="[-48]"/>
+        <Item index="11" value="[-46]"/>
+        <Item index="12" value="[-44]"/>
+        <Item index="13" value="[-42]"/>
+        <Item index="14" value="[-40]"/>
+        <Item index="15" value="[-38]"/>
+        <Item index="16" value="[-36]"/>
+        <Item index="17" value="[-34]"/>
+        <Item index="18" value="[-32]"/>
+        <Item index="19" value="[-30]"/>
+        <Item index="20" value="[-28]"/>
+        <Item index="21" value="[-24]"/>
+        <Item index="22" value="[-22]"/>
+        <Item index="23" value="[-20]"/>
+        <Item index="24" value="[-18]"/>
+        <Item index="25" value="[-16]"/>
+        <Item index="26" value="[-14]"/>
+        <Item index="27" value="[-12]"/>
+        <Item index="28" value="[-10]"/>
+        <Item index="29" value="[-8]"/>
+        <Item index="30" value="[-6]"/>
+        <Item index="31" value="[-5]"/>
+        <Item index="32" value="[-4]"/>
+        <Item index="33" value="[-2]"/>
+        <Item index="34" value="[2]"/>
+        <Item index="35" value="[4]"/>
+        <Item index="36" value="[6]"/>
+        <Item index="37" value="[8]"/>
+        <Item index="38" value="[10]"/>
+        <Item index="39" value="[12]"/>
+        <Item index="40" value="[18]"/>
+        <Item index="41" value="[20]"/>
+        <Item index="42" value="[22]"/>
+        <Item index="43" value="[24]"/>
+        <Item index="44" value="[30]"/>
+        <Item index="45" value="[32]"/>
+        <Item index="46" value="[34]"/>
+        <Item index="47" value="[40]"/>
+        <Item index="48" value="[42]"/>
+        <Item index="49" value="[46]"/>
+        <Item index="50" value="[50]"/>
+        <Item index="51" value="[56]"/>
+        <Item index="52" value="[60]"/>
+      </VarData>
+    </VarStore>
+  </GDEF>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=4 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="cyrl"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="2">
+        <ScriptTag value="grek"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="3">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="9"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=13 -->
+        <ExtensionPos index="0" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="1">
+            <Coverage Format="1">
+              <Glyph value="F"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <!-- PairSetCount=1 -->
+            <PairSet index="0">
+              <!-- PairValueCount=2 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="icircumflex"/>
+                <Value1 XAdvance="40"/>
+              </PairValueRecord>
+              <PairValueRecord index="1">
+                <SecondGlyph value="idieresis"/>
+                <Value1 XAdvance="40"/>
+              </PairValueRecord>
+            </PairSet>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="1" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="1">
+            <Coverage Format="1">
+              <Glyph value="V"/>
+              <Glyph value="f"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <!-- PairSetCount=2 -->
+            <PairSet index="0">
+              <!-- PairValueCount=4 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="igrave"/>
+                <Value1 XAdvance="20"/>
+              </PairValueRecord>
+              <PairValueRecord index="1">
+                <SecondGlyph value="iacute"/>
+                <Value1 XAdvance="20"/>
+              </PairValueRecord>
+              <PairValueRecord index="2">
+                <SecondGlyph value="icircumflex"/>
+                <Value1 XAdvance="60"/>
+              </PairValueRecord>
+              <PairValueRecord index="3">
+                <SecondGlyph value="idieresis"/>
+                <Value1 XAdvance="60"/>
+              </PairValueRecord>
+            </PairSet>
+            <PairSet index="1">
+              <!-- PairValueCount=3 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="igrave"/>
+                <Value1 XAdvance="60"/>
+              </PairValueRecord>
+              <PairValueRecord index="1">
+                <SecondGlyph value="icircumflex"/>
+                <Value1 XAdvance="60"/>
+              </PairValueRecord>
+              <PairValueRecord index="2">
+                <SecondGlyph value="idieresis"/>
+                <Value1 XAdvance="60"/>
+              </PairValueRecord>
+            </PairSet>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="2" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="1">
+            <Coverage Format="1">
+              <Glyph value="h"/>
+              <Glyph value="m"/>
+              <Glyph value="n"/>
+              <Glyph value="r"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <!-- PairSetCount=4 -->
+            <PairSet index="0">
+              <!-- PairValueCount=1 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="glyph00246"/>
+                <Value1 XAdvance="20"/>
+              </PairValueRecord>
+            </PairSet>
+            <PairSet index="1">
+              <!-- PairValueCount=1 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="glyph00246"/>
+                <Value1 XAdvance="20"/>
+              </PairValueRecord>
+            </PairSet>
+            <PairSet index="2">
+              <!-- PairValueCount=1 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="glyph00246"/>
+                <Value1 XAdvance="20"/>
+              </PairValueRecord>
+            </PairSet>
+            <PairSet index="3">
+              <!-- PairValueCount=1 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="glyph00261"/>
+                <Value1 XAdvance="20"/>
+              </PairValueRecord>
+            </PairSet>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="3" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="1">
+            <Coverage Format="1">
+              <Glyph value="x"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <!-- PairSetCount=1 -->
+            <PairSet index="0">
+              <!-- PairValueCount=2 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="comma"/>
+                <Value1 XAdvance="0"/>
+              </PairValueRecord>
+              <PairValueRecord index="1">
+                <SecondGlyph value="semicolon"/>
+                <Value1 XAdvance="0"/>
+              </PairValueRecord>
+            </PairSet>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="4" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="1">
+            <Coverage Format="1">
+              <Glyph value="ntilde"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <!-- PairSetCount=1 -->
+            <PairSet index="0">
+              <!-- PairValueCount=1 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="glyph00246"/>
+                <Value1 XAdvance="20"/>
+              </PairValueRecord>
+            </PairSet>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="5" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="1">
+            <Coverage Format="1">
+              <Glyph value="glyph00118"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <!-- PairSetCount=1 -->
+            <PairSet index="0">
+              <!-- PairValueCount=3 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="igrave"/>
+                <Value1 XAdvance="60"/>
+              </PairValueRecord>
+              <PairValueRecord index="1">
+                <SecondGlyph value="icircumflex"/>
+                <Value1 XAdvance="60"/>
+              </PairValueRecord>
+              <PairValueRecord index="2">
+                <SecondGlyph value="idieresis"/>
+                <Value1 XAdvance="60"/>
+              </PairValueRecord>
+            </PairSet>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="6" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="1">
+            <Coverage Format="1">
+              <Glyph value="slash"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <!-- PairSetCount=1 -->
+            <PairSet index="0">
+              <!-- PairValueCount=3 -->
+              <PairValueRecord index="0">
+                <SecondGlyph value="igrave"/>
+                <Value1 XAdvance="40"/>
+              </PairValueRecord>
+              <PairValueRecord index="1">
+                <SecondGlyph value="icircumflex"/>
+                <Value1 XAdvance="80"/>
+              </PairValueRecord>
+              <PairValueRecord index="2">
+                <SecondGlyph value="idieresis"/>
+                <Value1 XAdvance="80"/>
+              </PairValueRecord>
+            </PairSet>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="7" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="2">
+            <Coverage Format="2">
+              <Glyph value="A"/>
+              <Glyph value="D"/>
+              <Glyph value="E"/>
+              <Glyph value="H"/>
+              <Glyph value="I"/>
+              <Glyph value="M"/>
+              <Glyph value="N"/>
+              <Glyph value="O"/>
+              <Glyph value="Q"/>
+              <Glyph value="U"/>
+              <Glyph value="a"/>
+              <Glyph value="b"/>
+              <Glyph value="d"/>
+              <Glyph value="e"/>
+              <Glyph value="h"/>
+              <Glyph value="i"/>
+              <Glyph value="l"/>
+              <Glyph value="m"/>
+              <Glyph value="n"/>
+              <Glyph value="o"/>
+              <Glyph value="p"/>
+              <Glyph value="q"/>
+              <Glyph value="t"/>
+              <Glyph value="u"/>
+              <Glyph value="Agrave"/>
+              <Glyph value="Aacute"/>
+              <Glyph value="Acircumflex"/>
+              <Glyph value="Atilde"/>
+              <Glyph value="Adieresis"/>
+              <Glyph value="Aring"/>
+              <Glyph value="AE"/>
+              <Glyph value="Egrave"/>
+              <Glyph value="Eacute"/>
+              <Glyph value="Ecircumflex"/>
+              <Glyph value="Edieresis"/>
+              <Glyph value="Igrave"/>
+              <Glyph value="Iacute"/>
+              <Glyph value="Icircumflex"/>
+              <Glyph value="Idieresis"/>
+              <Glyph value="Ntilde"/>
+              <Glyph value="Ograve"/>
+              <Glyph value="Oacute"/>
+              <Glyph value="Ocircumflex"/>
+              <Glyph value="Otilde"/>
+              <Glyph value="Odieresis"/>
+              <Glyph value="Oslash"/>
+              <Glyph value="Ugrave"/>
+              <Glyph value="Uacute"/>
+              <Glyph value="Ucircumflex"/>
+              <Glyph value="Udieresis"/>
+              <Glyph value="Eth"/>
+              <Glyph value="agrave"/>
+              <Glyph value="aacute"/>
+              <Glyph value="acircumflex"/>
+              <Glyph value="atilde"/>
+              <Glyph value="adieresis"/>
+              <Glyph value="aring"/>
+              <Glyph value="ae"/>
+              <Glyph value="egrave"/>
+              <Glyph value="eacute"/>
+              <Glyph value="ecircumflex"/>
+              <Glyph value="edieresis"/>
+              <Glyph value="igrave"/>
+              <Glyph value="iacute"/>
+              <Glyph value="icircumflex"/>
+              <Glyph value="idieresis"/>
+              <Glyph value="ntilde"/>
+              <Glyph value="ograve"/>
+              <Glyph value="oacute"/>
+              <Glyph value="ocircumflex"/>
+              <Glyph value="otilde"/>
+              <Glyph value="odieresis"/>
+              <Glyph value="oslash"/>
+              <Glyph value="ugrave"/>
+              <Glyph value="uacute"/>
+              <Glyph value="ucircumflex"/>
+              <Glyph value="udieresis"/>
+              <Glyph value="thorn"/>
+              <Glyph value="glyph00117"/>
+              <Glyph value="glyph00119"/>
+              <Glyph value="glyph00120"/>
+              <Glyph value="mu"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <ClassDef1 Format="2">
+              <ClassDef glyph="A" class="7"/>
+              <ClassDef glyph="AE" class="9"/>
+              <ClassDef glyph="Aacute" class="7"/>
+              <ClassDef glyph="Acircumflex" class="7"/>
+              <ClassDef glyph="Adieresis" class="7"/>
+              <ClassDef glyph="Agrave" class="7"/>
+              <ClassDef glyph="Aring" class="7"/>
+              <ClassDef glyph="Atilde" class="7"/>
+              <ClassDef glyph="D" class="4"/>
+              <ClassDef glyph="E" class="9"/>
+              <ClassDef glyph="Eacute" class="9"/>
+              <ClassDef glyph="Ecircumflex" class="9"/>
+              <ClassDef glyph="Edieresis" class="9"/>
+              <ClassDef glyph="Egrave" class="9"/>
+              <ClassDef glyph="Eth" class="4"/>
+              <ClassDef glyph="H" class="10"/>
+              <ClassDef glyph="I" class="13"/>
+              <ClassDef glyph="Iacute" class="13"/>
+              <ClassDef glyph="Icircumflex" class="13"/>
+              <ClassDef glyph="Idieresis" class="13"/>
+              <ClassDef glyph="Igrave" class="13"/>
+              <ClassDef glyph="M" class="10"/>
+              <ClassDef glyph="N" class="10"/>
+              <ClassDef glyph="Ntilde" class="10"/>
+              <ClassDef glyph="O" class="4"/>
+              <ClassDef glyph="Oacute" class="4"/>
+              <ClassDef glyph="Ocircumflex" class="4"/>
+              <ClassDef glyph="Odieresis" class="4"/>
+              <ClassDef glyph="Ograve" class="4"/>
+              <ClassDef glyph="Oslash" class="4"/>
+              <ClassDef glyph="Otilde" class="4"/>
+              <ClassDef glyph="Q" class="4"/>
+              <ClassDef glyph="U" class="11"/>
+              <ClassDef glyph="Uacute" class="11"/>
+              <ClassDef glyph="Ucircumflex" class="11"/>
+              <ClassDef glyph="Udieresis" class="11"/>
+              <ClassDef glyph="Ugrave" class="11"/>
+              <ClassDef glyph="a" class="8"/>
+              <ClassDef glyph="aacute" class="8"/>
+              <ClassDef glyph="acircumflex" class="8"/>
+              <ClassDef glyph="adieresis" class="8"/>
+              <ClassDef glyph="ae" class="5"/>
+              <ClassDef glyph="agrave" class="8"/>
+              <ClassDef glyph="aring" class="8"/>
+              <ClassDef glyph="atilde" class="8"/>
+              <ClassDef glyph="b" class="2"/>
+              <ClassDef glyph="d" class="14"/>
+              <ClassDef glyph="e" class="5"/>
+              <ClassDef glyph="eacute" class="5"/>
+              <ClassDef glyph="ecircumflex" class="5"/>
+              <ClassDef glyph="edieresis" class="5"/>
+              <ClassDef glyph="egrave" class="5"/>
+              <ClassDef glyph="glyph00117" class="3"/>
+              <ClassDef glyph="glyph00119" class="15"/>
+              <ClassDef glyph="glyph00120" class="15"/>
+              <ClassDef glyph="h" class="6"/>
+              <ClassDef glyph="i" class="12"/>
+              <ClassDef glyph="iacute" class="12"/>
+              <ClassDef glyph="icircumflex" class="12"/>
+              <ClassDef glyph="idieresis" class="12"/>
+              <ClassDef glyph="igrave" class="12"/>
+              <ClassDef glyph="l" class="3"/>
+              <ClassDef glyph="m" class="6"/>
+              <ClassDef glyph="mu" class="1"/>
+              <ClassDef glyph="n" class="6"/>
+              <ClassDef glyph="ntilde" class="6"/>
+              <ClassDef glyph="o" class="2"/>
+              <ClassDef glyph="oacute" class="2"/>
+              <ClassDef glyph="ocircumflex" class="2"/>
+              <ClassDef glyph="odieresis" class="2"/>
+              <ClassDef glyph="ograve" class="2"/>
+              <ClassDef glyph="oslash" class="2"/>
+              <ClassDef glyph="otilde" class="2"/>
+              <ClassDef glyph="p" class="2"/>
+              <ClassDef glyph="t" class="15"/>
+              <ClassDef glyph="thorn" class="2"/>
+            </ClassDef1>
+            <ClassDef2 Format="2">
+              <ClassDef glyph="A" class="7"/>
+              <ClassDef glyph="AE" class="31"/>
+              <ClassDef glyph="Aacute" class="7"/>
+              <ClassDef glyph="Acircumflex" class="7"/>
+              <ClassDef glyph="Adieresis" class="7"/>
+              <ClassDef glyph="Agrave" class="7"/>
+              <ClassDef glyph="Aring" class="7"/>
+              <ClassDef glyph="Atilde" class="7"/>
+              <ClassDef glyph="C" class="3"/>
+              <ClassDef glyph="Ccedilla" class="3"/>
+              <ClassDef glyph="Eth" class="32"/>
+              <ClassDef glyph="G" class="3"/>
+              <ClassDef glyph="J" class="36"/>
+              <ClassDef glyph="O" class="3"/>
+              <ClassDef glyph="Oacute" class="3"/>
+              <ClassDef glyph="Ocircumflex" class="3"/>
+              <ClassDef glyph="Odieresis" class="3"/>
+              <ClassDef glyph="Ograve" class="3"/>
+              <ClassDef glyph="Oslash" class="3"/>
+              <ClassDef glyph="Otilde" class="3"/>
+              <ClassDef glyph="Q" class="3"/>
+              <ClassDef glyph="S" class="17"/>
+              <ClassDef glyph="T" class="18"/>
+              <ClassDef glyph="U" class="8"/>
+              <ClassDef glyph="Uacute" class="8"/>
+              <ClassDef glyph="Ucircumflex" class="8"/>
+              <ClassDef glyph="Udieresis" class="8"/>
+              <ClassDef glyph="Ugrave" class="8"/>
+              <ClassDef glyph="V" class="37"/>
+              <ClassDef glyph="W" class="24"/>
+              <ClassDef glyph="X" class="43"/>
+              <ClassDef glyph="Y" class="19"/>
+              <ClassDef glyph="Yacute" class="19"/>
+              <ClassDef glyph="Z" class="21"/>
+              <ClassDef glyph="a" class="2"/>
+              <ClassDef glyph="aacute" class="2"/>
+              <ClassDef glyph="acircumflex" class="2"/>
+              <ClassDef glyph="adieresis" class="2"/>
+              <ClassDef glyph="ae" class="2"/>
+              <ClassDef glyph="agrave" class="2"/>
+              <ClassDef glyph="aring" class="2"/>
+              <ClassDef glyph="asterisk" class="44"/>
+              <ClassDef glyph="atilde" class="2"/>
+              <ClassDef glyph="b" class="4"/>
+              <ClassDef glyph="backslash" class="45"/>
+              <ClassDef glyph="braceright" class="23"/>
+              <ClassDef glyph="bracketright" class="23"/>
+              <ClassDef glyph="c" class="1"/>
+              <ClassDef glyph="ccedilla" class="1"/>
+              <ClassDef glyph="colon" class="38"/>
+              <ClassDef glyph="comma" class="26"/>
+              <ClassDef glyph="d" class="1"/>
+              <ClassDef glyph="e" class="1"/>
+              <ClassDef glyph="eacute" class="1"/>
+              <ClassDef glyph="ecircumflex" class="1"/>
+              <ClassDef glyph="edieresis" class="1"/>
+              <ClassDef glyph="egrave" class="1"/>
+              <ClassDef glyph="exclam" class="33"/>
+              <ClassDef glyph="exclamdown" class="46"/>
+              <ClassDef glyph="f" class="11"/>
+              <ClassDef glyph="g" class="20"/>
+              <ClassDef glyph="germandbls" class="4"/>
+              <ClassDef glyph="glyph00117" class="4"/>
+              <ClassDef glyph="glyph00118" class="11"/>
+              <ClassDef glyph="glyph00119" class="11"/>
+              <ClassDef glyph="glyph00120" class="11"/>
+              <ClassDef glyph="glyph00237" class="10"/>
+              <ClassDef glyph="glyph00238" class="13"/>
+              <ClassDef glyph="glyph00239" class="10"/>
+              <ClassDef glyph="glyph00240" class="10"/>
+              <ClassDef glyph="glyph00241" class="10"/>
+              <ClassDef glyph="glyph00243" class="29"/>
+              <ClassDef glyph="glyph00244" class="13"/>
+              <ClassDef glyph="glyph00245" class="13"/>
+              <ClassDef glyph="glyph00246" class="29"/>
+              <ClassDef glyph="glyph00247" class="13"/>
+              <ClassDef glyph="glyph00248" class="13"/>
+              <ClassDef glyph="glyph00249" class="13"/>
+              <ClassDef glyph="glyph00250" class="13"/>
+              <ClassDef glyph="glyph00251" class="10"/>
+              <ClassDef glyph="glyph00252" class="29"/>
+              <ClassDef glyph="glyph00253" class="10"/>
+              <ClassDef glyph="glyph00254" class="13"/>
+              <ClassDef glyph="glyph00257" class="13"/>
+              <ClassDef glyph="glyph00258" class="34"/>
+              <ClassDef glyph="glyph00259" class="34"/>
+              <ClassDef glyph="glyph00261" class="29"/>
+              <ClassDef glyph="glyph00263" class="10"/>
+              <ClassDef glyph="glyph00264" class="10"/>
+              <ClassDef glyph="guillemotleft" class="40"/>
+              <ClassDef glyph="guillemotright" class="41"/>
+              <ClassDef glyph="h" class="4"/>
+              <ClassDef glyph="hyphen" class="27"/>
+              <ClassDef glyph="i" class="9"/>
+              <ClassDef glyph="iacute" class="9"/>
+              <ClassDef glyph="icircumflex" class="9"/>
+              <ClassDef glyph="idieresis" class="9"/>
+              <ClassDef glyph="igrave" class="9"/>
+              <ClassDef glyph="j" class="22"/>
+              <ClassDef glyph="k" class="4"/>
+              <ClassDef glyph="l" class="4"/>
+              <ClassDef glyph="m" class="5"/>
+              <ClassDef glyph="mu" class="39"/>
+              <ClassDef glyph="n" class="5"/>
+              <ClassDef glyph="ntilde" class="5"/>
+              <ClassDef glyph="o" class="1"/>
+              <ClassDef glyph="oacute" class="1"/>
+              <ClassDef glyph="ocircumflex" class="1"/>
+              <ClassDef glyph="odieresis" class="1"/>
+              <ClassDef glyph="ograve" class="1"/>
+              <ClassDef glyph="oslash" class="1"/>
+              <ClassDef glyph="otilde" class="1"/>
+              <ClassDef glyph="p" class="5"/>
+              <ClassDef glyph="parenright" class="23"/>
+              <ClassDef glyph="period" class="26"/>
+              <ClassDef glyph="periodcentered" class="47"/>
+              <ClassDef glyph="q" class="1"/>
+              <ClassDef glyph="question" class="30"/>
+              <ClassDef glyph="questiondown" class="48"/>
+              <ClassDef glyph="quotedbl" class="42"/>
+              <ClassDef glyph="quotesingle" class="42"/>
+              <ClassDef glyph="r" class="5"/>
+              <ClassDef glyph="registered" class="49"/>
+              <ClassDef glyph="s" class="16"/>
+              <ClassDef glyph="semicolon" class="38"/>
+              <ClassDef glyph="slash" class="50"/>
+              <ClassDef glyph="t" class="12"/>
+              <ClassDef glyph="thorn" class="4"/>
+              <ClassDef glyph="u" class="6"/>
+              <ClassDef glyph="uacute" class="6"/>
+              <ClassDef glyph="ucircumflex" class="6"/>
+              <ClassDef glyph="udieresis" class="6"/>
+              <ClassDef glyph="ugrave" class="6"/>
+              <ClassDef glyph="v" class="35"/>
+              <ClassDef glyph="w" class="28"/>
+              <ClassDef glyph="x" class="25"/>
+              <ClassDef glyph="y" class="15"/>
+              <ClassDef glyph="yacute" class="15"/>
+              <ClassDef glyph="ydieresis" class="15"/>
+              <ClassDef glyph="z" class="14"/>
+            </ClassDef2>
+            <!-- Class1Count=16 -->
+            <!-- Class2Count=51 -->
+            <Class1Record index="0">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-32"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="1">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="2">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-56"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-38"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="4"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="-60"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="3">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="6"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="4">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-28"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-42"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="5">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="6"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="14"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="14"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="14"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-42"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="6">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-42"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="7">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="30"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="30"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="12"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-102"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="-68"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="8">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="4"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="-60"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-62"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="9">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="10">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="11">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="-44"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="12">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="13">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="14">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="15">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="22"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="22"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="42"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="22"/>
+              </Class2Record>
+            </Class1Record>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="8" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="2">
+            <Coverage Format="1">
+              <Glyph value="G"/>
+              <Glyph value="L"/>
+              <Glyph value="R"/>
+              <Glyph value="S"/>
+              <Glyph value="T"/>
+              <Glyph value="Y"/>
+              <Glyph value="Z"/>
+              <Glyph value="c"/>
+              <Glyph value="g"/>
+              <Glyph value="r"/>
+              <Glyph value="s"/>
+              <Glyph value="y"/>
+              <Glyph value="z"/>
+              <Glyph value="Yacute"/>
+              <Glyph value="glyph00084"/>
+              <Glyph value="ccedilla"/>
+              <Glyph value="yacute"/>
+              <Glyph value="ydieresis"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <ClassDef1 Format="2">
+              <ClassDef glyph="G" class="2"/>
+              <ClassDef glyph="L" class="6"/>
+              <ClassDef glyph="R" class="11"/>
+              <ClassDef glyph="S" class="7"/>
+              <ClassDef glyph="T" class="8"/>
+              <ClassDef glyph="Y" class="9"/>
+              <ClassDef glyph="Yacute" class="9"/>
+              <ClassDef glyph="Z" class="13"/>
+              <ClassDef glyph="c" class="3"/>
+              <ClassDef glyph="ccedilla" class="3"/>
+              <ClassDef glyph="g" class="10"/>
+              <ClassDef glyph="glyph00084" class="6"/>
+              <ClassDef glyph="r" class="5"/>
+              <ClassDef glyph="s" class="1"/>
+              <ClassDef glyph="y" class="4"/>
+              <ClassDef glyph="yacute" class="4"/>
+              <ClassDef glyph="ydieresis" class="4"/>
+              <ClassDef glyph="z" class="12"/>
+            </ClassDef1>
+            <ClassDef2 Format="2">
+              <ClassDef glyph="A" class="7"/>
+              <ClassDef glyph="AE" class="31"/>
+              <ClassDef glyph="Aacute" class="7"/>
+              <ClassDef glyph="Acircumflex" class="7"/>
+              <ClassDef glyph="Adieresis" class="7"/>
+              <ClassDef glyph="Agrave" class="7"/>
+              <ClassDef glyph="Aring" class="7"/>
+              <ClassDef glyph="Atilde" class="7"/>
+              <ClassDef glyph="C" class="3"/>
+              <ClassDef glyph="Ccedilla" class="3"/>
+              <ClassDef glyph="Eth" class="32"/>
+              <ClassDef glyph="G" class="3"/>
+              <ClassDef glyph="J" class="36"/>
+              <ClassDef glyph="O" class="3"/>
+              <ClassDef glyph="Oacute" class="3"/>
+              <ClassDef glyph="Ocircumflex" class="3"/>
+              <ClassDef glyph="Odieresis" class="3"/>
+              <ClassDef glyph="Ograve" class="3"/>
+              <ClassDef glyph="Oslash" class="3"/>
+              <ClassDef glyph="Otilde" class="3"/>
+              <ClassDef glyph="Q" class="3"/>
+              <ClassDef glyph="S" class="17"/>
+              <ClassDef glyph="T" class="18"/>
+              <ClassDef glyph="U" class="8"/>
+              <ClassDef glyph="Uacute" class="8"/>
+              <ClassDef glyph="Ucircumflex" class="8"/>
+              <ClassDef glyph="Udieresis" class="8"/>
+              <ClassDef glyph="Ugrave" class="8"/>
+              <ClassDef glyph="V" class="37"/>
+              <ClassDef glyph="W" class="24"/>
+              <ClassDef glyph="X" class="43"/>
+              <ClassDef glyph="Y" class="19"/>
+              <ClassDef glyph="Yacute" class="19"/>
+              <ClassDef glyph="Z" class="21"/>
+              <ClassDef glyph="a" class="2"/>
+              <ClassDef glyph="aacute" class="2"/>
+              <ClassDef glyph="acircumflex" class="2"/>
+              <ClassDef glyph="adieresis" class="2"/>
+              <ClassDef glyph="ae" class="2"/>
+              <ClassDef glyph="agrave" class="2"/>
+              <ClassDef glyph="aring" class="2"/>
+              <ClassDef glyph="asterisk" class="44"/>
+              <ClassDef glyph="atilde" class="2"/>
+              <ClassDef glyph="b" class="4"/>
+              <ClassDef glyph="backslash" class="45"/>
+              <ClassDef glyph="braceright" class="23"/>
+              <ClassDef glyph="bracketright" class="23"/>
+              <ClassDef glyph="c" class="1"/>
+              <ClassDef glyph="ccedilla" class="1"/>
+              <ClassDef glyph="colon" class="38"/>
+              <ClassDef glyph="comma" class="26"/>
+              <ClassDef glyph="d" class="1"/>
+              <ClassDef glyph="e" class="1"/>
+              <ClassDef glyph="eacute" class="1"/>
+              <ClassDef glyph="ecircumflex" class="1"/>
+              <ClassDef glyph="edieresis" class="1"/>
+              <ClassDef glyph="egrave" class="1"/>
+              <ClassDef glyph="exclam" class="33"/>
+              <ClassDef glyph="exclamdown" class="46"/>
+              <ClassDef glyph="f" class="11"/>
+              <ClassDef glyph="g" class="20"/>
+              <ClassDef glyph="germandbls" class="4"/>
+              <ClassDef glyph="glyph00117" class="4"/>
+              <ClassDef glyph="glyph00118" class="11"/>
+              <ClassDef glyph="glyph00119" class="11"/>
+              <ClassDef glyph="glyph00120" class="11"/>
+              <ClassDef glyph="glyph00237" class="10"/>
+              <ClassDef glyph="glyph00238" class="13"/>
+              <ClassDef glyph="glyph00239" class="10"/>
+              <ClassDef glyph="glyph00240" class="10"/>
+              <ClassDef glyph="glyph00241" class="10"/>
+              <ClassDef glyph="glyph00243" class="29"/>
+              <ClassDef glyph="glyph00244" class="13"/>
+              <ClassDef glyph="glyph00245" class="13"/>
+              <ClassDef glyph="glyph00246" class="29"/>
+              <ClassDef glyph="glyph00247" class="13"/>
+              <ClassDef glyph="glyph00248" class="13"/>
+              <ClassDef glyph="glyph00249" class="13"/>
+              <ClassDef glyph="glyph00250" class="13"/>
+              <ClassDef glyph="glyph00251" class="10"/>
+              <ClassDef glyph="glyph00252" class="29"/>
+              <ClassDef glyph="glyph00253" class="10"/>
+              <ClassDef glyph="glyph00254" class="13"/>
+              <ClassDef glyph="glyph00257" class="13"/>
+              <ClassDef glyph="glyph00258" class="34"/>
+              <ClassDef glyph="glyph00259" class="34"/>
+              <ClassDef glyph="glyph00261" class="29"/>
+              <ClassDef glyph="glyph00263" class="10"/>
+              <ClassDef glyph="glyph00264" class="10"/>
+              <ClassDef glyph="guillemotleft" class="40"/>
+              <ClassDef glyph="guillemotright" class="41"/>
+              <ClassDef glyph="h" class="4"/>
+              <ClassDef glyph="hyphen" class="27"/>
+              <ClassDef glyph="i" class="9"/>
+              <ClassDef glyph="iacute" class="9"/>
+              <ClassDef glyph="icircumflex" class="9"/>
+              <ClassDef glyph="idieresis" class="9"/>
+              <ClassDef glyph="igrave" class="9"/>
+              <ClassDef glyph="j" class="22"/>
+              <ClassDef glyph="k" class="4"/>
+              <ClassDef glyph="l" class="4"/>
+              <ClassDef glyph="m" class="5"/>
+              <ClassDef glyph="mu" class="39"/>
+              <ClassDef glyph="n" class="5"/>
+              <ClassDef glyph="ntilde" class="5"/>
+              <ClassDef glyph="o" class="1"/>
+              <ClassDef glyph="oacute" class="1"/>
+              <ClassDef glyph="ocircumflex" class="1"/>
+              <ClassDef glyph="odieresis" class="1"/>
+              <ClassDef glyph="ograve" class="1"/>
+              <ClassDef glyph="oslash" class="1"/>
+              <ClassDef glyph="otilde" class="1"/>
+              <ClassDef glyph="p" class="5"/>
+              <ClassDef glyph="parenright" class="23"/>
+              <ClassDef glyph="period" class="26"/>
+              <ClassDef glyph="periodcentered" class="47"/>
+              <ClassDef glyph="q" class="1"/>
+              <ClassDef glyph="question" class="30"/>
+              <ClassDef glyph="questiondown" class="48"/>
+              <ClassDef glyph="quotedbl" class="42"/>
+              <ClassDef glyph="quotesingle" class="42"/>
+              <ClassDef glyph="r" class="5"/>
+              <ClassDef glyph="registered" class="49"/>
+              <ClassDef glyph="s" class="16"/>
+              <ClassDef glyph="semicolon" class="38"/>
+              <ClassDef glyph="slash" class="50"/>
+              <ClassDef glyph="t" class="12"/>
+              <ClassDef glyph="thorn" class="4"/>
+              <ClassDef glyph="u" class="6"/>
+              <ClassDef glyph="uacute" class="6"/>
+              <ClassDef glyph="ucircumflex" class="6"/>
+              <ClassDef glyph="udieresis" class="6"/>
+              <ClassDef glyph="ugrave" class="6"/>
+              <ClassDef glyph="v" class="35"/>
+              <ClassDef glyph="w" class="28"/>
+              <ClassDef glyph="x" class="25"/>
+              <ClassDef glyph="y" class="15"/>
+              <ClassDef glyph="yacute" class="15"/>
+              <ClassDef glyph="ydieresis" class="15"/>
+              <ClassDef glyph="z" class="14"/>
+            </ClassDef2>
+            <!-- Class1Count=14 -->
+            <!-- Class2Count=51 -->
+            <Class1Record index="0">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="1">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-66"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="2">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-32"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="24"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="3">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="18"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="32"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="4">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="60"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="5">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-32"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="30"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="86"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="-42"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="6">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-120"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-68"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-54"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-62"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-74"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-42"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="-48"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-136"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="-80"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-76"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="-76"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="7">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="12"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="8">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-58"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-80"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-50"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-50"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-84"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-58"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-50"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-80"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-62"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-50"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-98"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-80"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-42"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="-100"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-130"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-60"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="-106"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="9">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-60"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-60"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-74"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-58"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-100"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-38"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="-82"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="10">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="24"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="30"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="22"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-28"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="22"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="64"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="11">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-32"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="12">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="13">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-28"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-42"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-42"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-60"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="9" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="2">
+            <Coverage Format="1">
+              <Glyph value="B"/>
+              <Glyph value="C"/>
+              <Glyph value="F"/>
+              <Glyph value="K"/>
+              <Glyph value="W"/>
+              <Glyph value="f"/>
+              <Glyph value="j"/>
+              <Glyph value="k"/>
+              <Glyph value="v"/>
+              <Glyph value="w"/>
+              <Glyph value="x"/>
+              <Glyph value="Ccedilla"/>
+              <Glyph value="glyph00118"/>
+              <Glyph value="period"/>
+              <Glyph value="comma"/>
+              <Glyph value="exclam"/>
+              <Glyph value="question"/>
+              <Glyph value="hyphen"/>
+              <Glyph value="parenleft"/>
+              <Glyph value="bracketleft"/>
+              <Glyph value="braceleft"/>
+              <Glyph value="glyph00237"/>
+              <Glyph value="glyph00240"/>
+              <Glyph value="glyph00244"/>
+              <Glyph value="glyph00245"/>
+              <Glyph value="glyph00246"/>
+              <Glyph value="glyph00248"/>
+              <Glyph value="glyph00249"/>
+              <Glyph value="glyph00250"/>
+              <Glyph value="glyph00253"/>
+              <Glyph value="glyph00257"/>
+              <Glyph value="glyph00258"/>
+              <Glyph value="glyph00259"/>
+              <Glyph value="glyph00261"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <ClassDef1 Format="2">
+              <ClassDef glyph="B" class="10"/>
+              <ClassDef glyph="F" class="19"/>
+              <ClassDef glyph="K" class="11"/>
+              <ClassDef glyph="W" class="3"/>
+              <ClassDef glyph="braceleft" class="2"/>
+              <ClassDef glyph="bracketleft" class="2"/>
+              <ClassDef glyph="comma" class="5"/>
+              <ClassDef glyph="exclam" class="16"/>
+              <ClassDef glyph="f" class="13"/>
+              <ClassDef glyph="glyph00118" class="13"/>
+              <ClassDef glyph="glyph00237" class="4"/>
+              <ClassDef glyph="glyph00240" class="1"/>
+              <ClassDef glyph="glyph00244" class="4"/>
+              <ClassDef glyph="glyph00245" class="1"/>
+              <ClassDef glyph="glyph00246" class="17"/>
+              <ClassDef glyph="glyph00248" class="1"/>
+              <ClassDef glyph="glyph00249" class="4"/>
+              <ClassDef glyph="glyph00250" class="4"/>
+              <ClassDef glyph="glyph00253" class="17"/>
+              <ClassDef glyph="glyph00257" class="1"/>
+              <ClassDef glyph="glyph00258" class="14"/>
+              <ClassDef glyph="glyph00259" class="14"/>
+              <ClassDef glyph="glyph00261" class="14"/>
+              <ClassDef glyph="hyphen" class="7"/>
+              <ClassDef glyph="j" class="6"/>
+              <ClassDef glyph="k" class="8"/>
+              <ClassDef glyph="parenleft" class="2"/>
+              <ClassDef glyph="period" class="5"/>
+              <ClassDef glyph="question" class="12"/>
+              <ClassDef glyph="v" class="18"/>
+              <ClassDef glyph="w" class="9"/>
+              <ClassDef glyph="x" class="15"/>
+            </ClassDef1>
+            <ClassDef2 Format="2">
+              <ClassDef glyph="A" class="7"/>
+              <ClassDef glyph="AE" class="31"/>
+              <ClassDef glyph="Aacute" class="7"/>
+              <ClassDef glyph="Acircumflex" class="7"/>
+              <ClassDef glyph="Adieresis" class="7"/>
+              <ClassDef glyph="Agrave" class="7"/>
+              <ClassDef glyph="Aring" class="7"/>
+              <ClassDef glyph="Atilde" class="7"/>
+              <ClassDef glyph="C" class="3"/>
+              <ClassDef glyph="Ccedilla" class="3"/>
+              <ClassDef glyph="Eth" class="32"/>
+              <ClassDef glyph="G" class="3"/>
+              <ClassDef glyph="J" class="36"/>
+              <ClassDef glyph="O" class="3"/>
+              <ClassDef glyph="Oacute" class="3"/>
+              <ClassDef glyph="Ocircumflex" class="3"/>
+              <ClassDef glyph="Odieresis" class="3"/>
+              <ClassDef glyph="Ograve" class="3"/>
+              <ClassDef glyph="Oslash" class="3"/>
+              <ClassDef glyph="Otilde" class="3"/>
+              <ClassDef glyph="Q" class="3"/>
+              <ClassDef glyph="S" class="17"/>
+              <ClassDef glyph="T" class="18"/>
+              <ClassDef glyph="U" class="8"/>
+              <ClassDef glyph="Uacute" class="8"/>
+              <ClassDef glyph="Ucircumflex" class="8"/>
+              <ClassDef glyph="Udieresis" class="8"/>
+              <ClassDef glyph="Ugrave" class="8"/>
+              <ClassDef glyph="V" class="37"/>
+              <ClassDef glyph="W" class="24"/>
+              <ClassDef glyph="X" class="43"/>
+              <ClassDef glyph="Y" class="19"/>
+              <ClassDef glyph="Yacute" class="19"/>
+              <ClassDef glyph="Z" class="21"/>
+              <ClassDef glyph="a" class="2"/>
+              <ClassDef glyph="aacute" class="2"/>
+              <ClassDef glyph="acircumflex" class="2"/>
+              <ClassDef glyph="adieresis" class="2"/>
+              <ClassDef glyph="ae" class="2"/>
+              <ClassDef glyph="agrave" class="2"/>
+              <ClassDef glyph="aring" class="2"/>
+              <ClassDef glyph="asterisk" class="44"/>
+              <ClassDef glyph="atilde" class="2"/>
+              <ClassDef glyph="b" class="4"/>
+              <ClassDef glyph="backslash" class="45"/>
+              <ClassDef glyph="braceright" class="23"/>
+              <ClassDef glyph="bracketright" class="23"/>
+              <ClassDef glyph="c" class="1"/>
+              <ClassDef glyph="ccedilla" class="1"/>
+              <ClassDef glyph="colon" class="38"/>
+              <ClassDef glyph="comma" class="26"/>
+              <ClassDef glyph="d" class="1"/>
+              <ClassDef glyph="e" class="1"/>
+              <ClassDef glyph="eacute" class="1"/>
+              <ClassDef glyph="ecircumflex" class="1"/>
+              <ClassDef glyph="edieresis" class="1"/>
+              <ClassDef glyph="egrave" class="1"/>
+              <ClassDef glyph="exclam" class="33"/>
+              <ClassDef glyph="exclamdown" class="46"/>
+              <ClassDef glyph="f" class="11"/>
+              <ClassDef glyph="g" class="20"/>
+              <ClassDef glyph="germandbls" class="4"/>
+              <ClassDef glyph="glyph00117" class="4"/>
+              <ClassDef glyph="glyph00118" class="11"/>
+              <ClassDef glyph="glyph00119" class="11"/>
+              <ClassDef glyph="glyph00120" class="11"/>
+              <ClassDef glyph="glyph00237" class="10"/>
+              <ClassDef glyph="glyph00238" class="13"/>
+              <ClassDef glyph="glyph00239" class="10"/>
+              <ClassDef glyph="glyph00240" class="10"/>
+              <ClassDef glyph="glyph00241" class="10"/>
+              <ClassDef glyph="glyph00243" class="29"/>
+              <ClassDef glyph="glyph00244" class="13"/>
+              <ClassDef glyph="glyph00245" class="13"/>
+              <ClassDef glyph="glyph00246" class="29"/>
+              <ClassDef glyph="glyph00247" class="13"/>
+              <ClassDef glyph="glyph00248" class="13"/>
+              <ClassDef glyph="glyph00249" class="13"/>
+              <ClassDef glyph="glyph00250" class="13"/>
+              <ClassDef glyph="glyph00251" class="10"/>
+              <ClassDef glyph="glyph00252" class="29"/>
+              <ClassDef glyph="glyph00253" class="10"/>
+              <ClassDef glyph="glyph00254" class="13"/>
+              <ClassDef glyph="glyph00257" class="13"/>
+              <ClassDef glyph="glyph00258" class="34"/>
+              <ClassDef glyph="glyph00259" class="34"/>
+              <ClassDef glyph="glyph00261" class="29"/>
+              <ClassDef glyph="glyph00263" class="10"/>
+              <ClassDef glyph="glyph00264" class="10"/>
+              <ClassDef glyph="guillemotleft" class="40"/>
+              <ClassDef glyph="guillemotright" class="41"/>
+              <ClassDef glyph="h" class="4"/>
+              <ClassDef glyph="hyphen" class="27"/>
+              <ClassDef glyph="i" class="9"/>
+              <ClassDef glyph="iacute" class="9"/>
+              <ClassDef glyph="icircumflex" class="9"/>
+              <ClassDef glyph="idieresis" class="9"/>
+              <ClassDef glyph="igrave" class="9"/>
+              <ClassDef glyph="j" class="22"/>
+              <ClassDef glyph="k" class="4"/>
+              <ClassDef glyph="l" class="4"/>
+              <ClassDef glyph="m" class="5"/>
+              <ClassDef glyph="mu" class="39"/>
+              <ClassDef glyph="n" class="5"/>
+              <ClassDef glyph="ntilde" class="5"/>
+              <ClassDef glyph="o" class="1"/>
+              <ClassDef glyph="oacute" class="1"/>
+              <ClassDef glyph="ocircumflex" class="1"/>
+              <ClassDef glyph="odieresis" class="1"/>
+              <ClassDef glyph="ograve" class="1"/>
+              <ClassDef glyph="oslash" class="1"/>
+              <ClassDef glyph="otilde" class="1"/>
+              <ClassDef glyph="p" class="5"/>
+              <ClassDef glyph="parenright" class="23"/>
+              <ClassDef glyph="period" class="26"/>
+              <ClassDef glyph="periodcentered" class="47"/>
+              <ClassDef glyph="q" class="1"/>
+              <ClassDef glyph="question" class="30"/>
+              <ClassDef glyph="questiondown" class="48"/>
+              <ClassDef glyph="quotedbl" class="42"/>
+              <ClassDef glyph="quotesingle" class="42"/>
+              <ClassDef glyph="r" class="5"/>
+              <ClassDef glyph="registered" class="49"/>
+              <ClassDef glyph="s" class="16"/>
+              <ClassDef glyph="semicolon" class="38"/>
+              <ClassDef glyph="slash" class="50"/>
+              <ClassDef glyph="t" class="12"/>
+              <ClassDef glyph="thorn" class="4"/>
+              <ClassDef glyph="u" class="6"/>
+              <ClassDef glyph="uacute" class="6"/>
+              <ClassDef glyph="ucircumflex" class="6"/>
+              <ClassDef glyph="udieresis" class="6"/>
+              <ClassDef glyph="ugrave" class="6"/>
+              <ClassDef glyph="v" class="35"/>
+              <ClassDef glyph="w" class="28"/>
+              <ClassDef glyph="x" class="25"/>
+              <ClassDef glyph="y" class="15"/>
+              <ClassDef glyph="yacute" class="15"/>
+              <ClassDef glyph="ydieresis" class="15"/>
+              <ClassDef glyph="z" class="14"/>
+            </ClassDef2>
+            <!-- Class1Count=20 -->
+            <!-- Class2Count=51 -->
+            <Class1Record index="0">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-36"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="22"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="1">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="2">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="80"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="3">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-80"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="50"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="-46"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="4">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="5">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-32"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-98"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-76"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="18"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-56"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="-70"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-114"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="6">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="7">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-58"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="8">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-6"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="4"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="9">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-6"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="60"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="10">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="11">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-38"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="26"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="12">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="13">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="50"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="70"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="60"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="50"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-38"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="30"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="22"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="70"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="86"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="96"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="14">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-60"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="15">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="60"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="16">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="17">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="18">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="60"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="19">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-36"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="14"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="12"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-56"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-142"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="12"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="32"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="-86"/>
+              </Class2Record>
+            </Class1Record>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="10" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="2">
+            <Coverage Format="1">
+              <Glyph value="J"/>
+              <Glyph value="P"/>
+              <Glyph value="V"/>
+              <Glyph value="colon"/>
+              <Glyph value="semicolon"/>
+              <Glyph value="quotesingle"/>
+              <Glyph value="quotedbl"/>
+              <Glyph value="guillemotleft"/>
+              <Glyph value="guillemotright"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <ClassDef1 Format="2">
+              <ClassDef glyph="J" class="1"/>
+              <ClassDef glyph="P" class="2"/>
+              <ClassDef glyph="V" class="3"/>
+              <ClassDef glyph="colon" class="4"/>
+              <ClassDef glyph="guillemotleft" class="5"/>
+              <ClassDef glyph="guillemotright" class="6"/>
+              <ClassDef glyph="quotedbl" class="7"/>
+              <ClassDef glyph="quotesingle" class="7"/>
+              <ClassDef glyph="semicolon" class="4"/>
+            </ClassDef1>
+            <ClassDef2 Format="2">
+              <ClassDef glyph="A" class="7"/>
+              <ClassDef glyph="AE" class="31"/>
+              <ClassDef glyph="Aacute" class="7"/>
+              <ClassDef glyph="Acircumflex" class="7"/>
+              <ClassDef glyph="Adieresis" class="7"/>
+              <ClassDef glyph="Agrave" class="7"/>
+              <ClassDef glyph="Aring" class="7"/>
+              <ClassDef glyph="Atilde" class="7"/>
+              <ClassDef glyph="C" class="3"/>
+              <ClassDef glyph="Ccedilla" class="3"/>
+              <ClassDef glyph="Eth" class="32"/>
+              <ClassDef glyph="G" class="3"/>
+              <ClassDef glyph="J" class="36"/>
+              <ClassDef glyph="O" class="3"/>
+              <ClassDef glyph="Oacute" class="3"/>
+              <ClassDef glyph="Ocircumflex" class="3"/>
+              <ClassDef glyph="Odieresis" class="3"/>
+              <ClassDef glyph="Ograve" class="3"/>
+              <ClassDef glyph="Oslash" class="3"/>
+              <ClassDef glyph="Otilde" class="3"/>
+              <ClassDef glyph="Q" class="3"/>
+              <ClassDef glyph="S" class="17"/>
+              <ClassDef glyph="T" class="18"/>
+              <ClassDef glyph="U" class="8"/>
+              <ClassDef glyph="Uacute" class="8"/>
+              <ClassDef glyph="Ucircumflex" class="8"/>
+              <ClassDef glyph="Udieresis" class="8"/>
+              <ClassDef glyph="Ugrave" class="8"/>
+              <ClassDef glyph="V" class="37"/>
+              <ClassDef glyph="W" class="24"/>
+              <ClassDef glyph="X" class="43"/>
+              <ClassDef glyph="Y" class="19"/>
+              <ClassDef glyph="Yacute" class="19"/>
+              <ClassDef glyph="Z" class="21"/>
+              <ClassDef glyph="a" class="2"/>
+              <ClassDef glyph="aacute" class="2"/>
+              <ClassDef glyph="acircumflex" class="2"/>
+              <ClassDef glyph="adieresis" class="2"/>
+              <ClassDef glyph="ae" class="2"/>
+              <ClassDef glyph="agrave" class="2"/>
+              <ClassDef glyph="aring" class="2"/>
+              <ClassDef glyph="asterisk" class="44"/>
+              <ClassDef glyph="atilde" class="2"/>
+              <ClassDef glyph="b" class="4"/>
+              <ClassDef glyph="backslash" class="45"/>
+              <ClassDef glyph="braceright" class="23"/>
+              <ClassDef glyph="bracketright" class="23"/>
+              <ClassDef glyph="c" class="1"/>
+              <ClassDef glyph="ccedilla" class="1"/>
+              <ClassDef glyph="colon" class="38"/>
+              <ClassDef glyph="comma" class="26"/>
+              <ClassDef glyph="d" class="1"/>
+              <ClassDef glyph="e" class="1"/>
+              <ClassDef glyph="eacute" class="1"/>
+              <ClassDef glyph="ecircumflex" class="1"/>
+              <ClassDef glyph="edieresis" class="1"/>
+              <ClassDef glyph="egrave" class="1"/>
+              <ClassDef glyph="exclam" class="33"/>
+              <ClassDef glyph="exclamdown" class="46"/>
+              <ClassDef glyph="f" class="11"/>
+              <ClassDef glyph="g" class="20"/>
+              <ClassDef glyph="germandbls" class="4"/>
+              <ClassDef glyph="glyph00117" class="4"/>
+              <ClassDef glyph="glyph00118" class="11"/>
+              <ClassDef glyph="glyph00119" class="11"/>
+              <ClassDef glyph="glyph00120" class="11"/>
+              <ClassDef glyph="glyph00237" class="10"/>
+              <ClassDef glyph="glyph00238" class="13"/>
+              <ClassDef glyph="glyph00239" class="10"/>
+              <ClassDef glyph="glyph00240" class="10"/>
+              <ClassDef glyph="glyph00241" class="10"/>
+              <ClassDef glyph="glyph00243" class="29"/>
+              <ClassDef glyph="glyph00244" class="13"/>
+              <ClassDef glyph="glyph00245" class="13"/>
+              <ClassDef glyph="glyph00246" class="29"/>
+              <ClassDef glyph="glyph00247" class="13"/>
+              <ClassDef glyph="glyph00248" class="13"/>
+              <ClassDef glyph="glyph00249" class="13"/>
+              <ClassDef glyph="glyph00250" class="13"/>
+              <ClassDef glyph="glyph00251" class="10"/>
+              <ClassDef glyph="glyph00252" class="29"/>
+              <ClassDef glyph="glyph00253" class="10"/>
+              <ClassDef glyph="glyph00254" class="13"/>
+              <ClassDef glyph="glyph00257" class="13"/>
+              <ClassDef glyph="glyph00258" class="34"/>
+              <ClassDef glyph="glyph00259" class="34"/>
+              <ClassDef glyph="glyph00261" class="29"/>
+              <ClassDef glyph="glyph00263" class="10"/>
+              <ClassDef glyph="glyph00264" class="10"/>
+              <ClassDef glyph="guillemotleft" class="40"/>
+              <ClassDef glyph="guillemotright" class="41"/>
+              <ClassDef glyph="h" class="4"/>
+              <ClassDef glyph="hyphen" class="27"/>
+              <ClassDef glyph="i" class="9"/>
+              <ClassDef glyph="iacute" class="9"/>
+              <ClassDef glyph="icircumflex" class="9"/>
+              <ClassDef glyph="idieresis" class="9"/>
+              <ClassDef glyph="igrave" class="9"/>
+              <ClassDef glyph="j" class="22"/>
+              <ClassDef glyph="k" class="4"/>
+              <ClassDef glyph="l" class="4"/>
+              <ClassDef glyph="m" class="5"/>
+              <ClassDef glyph="mu" class="39"/>
+              <ClassDef glyph="n" class="5"/>
+              <ClassDef glyph="ntilde" class="5"/>
+              <ClassDef glyph="o" class="1"/>
+              <ClassDef glyph="oacute" class="1"/>
+              <ClassDef glyph="ocircumflex" class="1"/>
+              <ClassDef glyph="odieresis" class="1"/>
+              <ClassDef glyph="ograve" class="1"/>
+              <ClassDef glyph="oslash" class="1"/>
+              <ClassDef glyph="otilde" class="1"/>
+              <ClassDef glyph="p" class="5"/>
+              <ClassDef glyph="parenright" class="23"/>
+              <ClassDef glyph="period" class="26"/>
+              <ClassDef glyph="periodcentered" class="47"/>
+              <ClassDef glyph="q" class="1"/>
+              <ClassDef glyph="question" class="30"/>
+              <ClassDef glyph="questiondown" class="48"/>
+              <ClassDef glyph="quotedbl" class="42"/>
+              <ClassDef glyph="quotesingle" class="42"/>
+              <ClassDef glyph="r" class="5"/>
+              <ClassDef glyph="registered" class="49"/>
+              <ClassDef glyph="s" class="16"/>
+              <ClassDef glyph="semicolon" class="38"/>
+              <ClassDef glyph="slash" class="50"/>
+              <ClassDef glyph="t" class="12"/>
+              <ClassDef glyph="thorn" class="4"/>
+              <ClassDef glyph="u" class="6"/>
+              <ClassDef glyph="uacute" class="6"/>
+              <ClassDef glyph="ucircumflex" class="6"/>
+              <ClassDef glyph="udieresis" class="6"/>
+              <ClassDef glyph="ugrave" class="6"/>
+              <ClassDef glyph="v" class="35"/>
+              <ClassDef glyph="w" class="28"/>
+              <ClassDef glyph="x" class="25"/>
+              <ClassDef glyph="y" class="15"/>
+              <ClassDef glyph="yacute" class="15"/>
+              <ClassDef glyph="ydieresis" class="15"/>
+              <ClassDef glyph="z" class="14"/>
+            </ClassDef2>
+            <!-- Class1Count=8 -->
+            <!-- Class2Count=51 -->
+            <Class1Record index="0">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-70"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="1">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="2">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-26"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-50"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-50"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-32"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-42"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-100"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-96"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-150"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="42"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="-96"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="3">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-28"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-56"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-80"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="54"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="-62"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="4">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="4"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-66"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="5">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="6">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-38"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-30"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-22"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="7">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-100"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-80"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="11" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="2">
+            <Coverage Format="1">
+              <Glyph value="Thorn"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <ClassDef1 Format="1">
+              <ClassDef glyph="Thorn" class="1"/>
+            </ClassDef1>
+            <ClassDef2 Format="2">
+              <ClassDef glyph="A" class="7"/>
+              <ClassDef glyph="AE" class="31"/>
+              <ClassDef glyph="Aacute" class="7"/>
+              <ClassDef glyph="Acircumflex" class="7"/>
+              <ClassDef glyph="Adieresis" class="7"/>
+              <ClassDef glyph="Agrave" class="7"/>
+              <ClassDef glyph="Aring" class="7"/>
+              <ClassDef glyph="Atilde" class="7"/>
+              <ClassDef glyph="C" class="3"/>
+              <ClassDef glyph="Ccedilla" class="3"/>
+              <ClassDef glyph="Eth" class="32"/>
+              <ClassDef glyph="G" class="3"/>
+              <ClassDef glyph="J" class="36"/>
+              <ClassDef glyph="O" class="3"/>
+              <ClassDef glyph="Oacute" class="3"/>
+              <ClassDef glyph="Ocircumflex" class="3"/>
+              <ClassDef glyph="Odieresis" class="3"/>
+              <ClassDef glyph="Ograve" class="3"/>
+              <ClassDef glyph="Oslash" class="3"/>
+              <ClassDef glyph="Otilde" class="3"/>
+              <ClassDef glyph="Q" class="3"/>
+              <ClassDef glyph="S" class="17"/>
+              <ClassDef glyph="T" class="18"/>
+              <ClassDef glyph="U" class="8"/>
+              <ClassDef glyph="Uacute" class="8"/>
+              <ClassDef glyph="Ucircumflex" class="8"/>
+              <ClassDef glyph="Udieresis" class="8"/>
+              <ClassDef glyph="Ugrave" class="8"/>
+              <ClassDef glyph="V" class="37"/>
+              <ClassDef glyph="W" class="24"/>
+              <ClassDef glyph="X" class="43"/>
+              <ClassDef glyph="Y" class="19"/>
+              <ClassDef glyph="Yacute" class="19"/>
+              <ClassDef glyph="Z" class="21"/>
+              <ClassDef glyph="a" class="2"/>
+              <ClassDef glyph="aacute" class="2"/>
+              <ClassDef glyph="acircumflex" class="2"/>
+              <ClassDef glyph="adieresis" class="2"/>
+              <ClassDef glyph="ae" class="2"/>
+              <ClassDef glyph="agrave" class="2"/>
+              <ClassDef glyph="aring" class="2"/>
+              <ClassDef glyph="asterisk" class="44"/>
+              <ClassDef glyph="atilde" class="2"/>
+              <ClassDef glyph="b" class="4"/>
+              <ClassDef glyph="backslash" class="45"/>
+              <ClassDef glyph="braceright" class="23"/>
+              <ClassDef glyph="bracketright" class="23"/>
+              <ClassDef glyph="c" class="1"/>
+              <ClassDef glyph="ccedilla" class="1"/>
+              <ClassDef glyph="colon" class="38"/>
+              <ClassDef glyph="comma" class="26"/>
+              <ClassDef glyph="d" class="1"/>
+              <ClassDef glyph="e" class="1"/>
+              <ClassDef glyph="eacute" class="1"/>
+              <ClassDef glyph="ecircumflex" class="1"/>
+              <ClassDef glyph="edieresis" class="1"/>
+              <ClassDef glyph="egrave" class="1"/>
+              <ClassDef glyph="exclam" class="33"/>
+              <ClassDef glyph="exclamdown" class="46"/>
+              <ClassDef glyph="f" class="11"/>
+              <ClassDef glyph="g" class="20"/>
+              <ClassDef glyph="germandbls" class="4"/>
+              <ClassDef glyph="glyph00117" class="4"/>
+              <ClassDef glyph="glyph00118" class="11"/>
+              <ClassDef glyph="glyph00119" class="11"/>
+              <ClassDef glyph="glyph00120" class="11"/>
+              <ClassDef glyph="glyph00237" class="10"/>
+              <ClassDef glyph="glyph00238" class="13"/>
+              <ClassDef glyph="glyph00239" class="10"/>
+              <ClassDef glyph="glyph00240" class="10"/>
+              <ClassDef glyph="glyph00241" class="10"/>
+              <ClassDef glyph="glyph00243" class="29"/>
+              <ClassDef glyph="glyph00244" class="13"/>
+              <ClassDef glyph="glyph00245" class="13"/>
+              <ClassDef glyph="glyph00246" class="29"/>
+              <ClassDef glyph="glyph00247" class="13"/>
+              <ClassDef glyph="glyph00248" class="13"/>
+              <ClassDef glyph="glyph00249" class="13"/>
+              <ClassDef glyph="glyph00250" class="13"/>
+              <ClassDef glyph="glyph00251" class="10"/>
+              <ClassDef glyph="glyph00252" class="29"/>
+              <ClassDef glyph="glyph00253" class="10"/>
+              <ClassDef glyph="glyph00254" class="13"/>
+              <ClassDef glyph="glyph00257" class="13"/>
+              <ClassDef glyph="glyph00258" class="34"/>
+              <ClassDef glyph="glyph00259" class="34"/>
+              <ClassDef glyph="glyph00261" class="29"/>
+              <ClassDef glyph="glyph00263" class="10"/>
+              <ClassDef glyph="glyph00264" class="10"/>
+              <ClassDef glyph="guillemotleft" class="40"/>
+              <ClassDef glyph="guillemotright" class="41"/>
+              <ClassDef glyph="h" class="4"/>
+              <ClassDef glyph="hyphen" class="27"/>
+              <ClassDef glyph="i" class="9"/>
+              <ClassDef glyph="iacute" class="9"/>
+              <ClassDef glyph="icircumflex" class="9"/>
+              <ClassDef glyph="idieresis" class="9"/>
+              <ClassDef glyph="igrave" class="9"/>
+              <ClassDef glyph="j" class="22"/>
+              <ClassDef glyph="k" class="4"/>
+              <ClassDef glyph="l" class="4"/>
+              <ClassDef glyph="m" class="5"/>
+              <ClassDef glyph="mu" class="39"/>
+              <ClassDef glyph="n" class="5"/>
+              <ClassDef glyph="ntilde" class="5"/>
+              <ClassDef glyph="o" class="1"/>
+              <ClassDef glyph="oacute" class="1"/>
+              <ClassDef glyph="ocircumflex" class="1"/>
+              <ClassDef glyph="odieresis" class="1"/>
+              <ClassDef glyph="ograve" class="1"/>
+              <ClassDef glyph="oslash" class="1"/>
+              <ClassDef glyph="otilde" class="1"/>
+              <ClassDef glyph="p" class="5"/>
+              <ClassDef glyph="parenright" class="23"/>
+              <ClassDef glyph="period" class="26"/>
+              <ClassDef glyph="periodcentered" class="47"/>
+              <ClassDef glyph="q" class="1"/>
+              <ClassDef glyph="question" class="30"/>
+              <ClassDef glyph="questiondown" class="48"/>
+              <ClassDef glyph="quotedbl" class="42"/>
+              <ClassDef glyph="quotesingle" class="42"/>
+              <ClassDef glyph="r" class="5"/>
+              <ClassDef glyph="registered" class="49"/>
+              <ClassDef glyph="s" class="16"/>
+              <ClassDef glyph="semicolon" class="38"/>
+              <ClassDef glyph="slash" class="50"/>
+              <ClassDef glyph="t" class="12"/>
+              <ClassDef glyph="thorn" class="4"/>
+              <ClassDef glyph="u" class="6"/>
+              <ClassDef glyph="uacute" class="6"/>
+              <ClassDef glyph="ucircumflex" class="6"/>
+              <ClassDef glyph="udieresis" class="6"/>
+              <ClassDef glyph="ugrave" class="6"/>
+              <ClassDef glyph="v" class="35"/>
+              <ClassDef glyph="w" class="28"/>
+              <ClassDef glyph="x" class="25"/>
+              <ClassDef glyph="y" class="15"/>
+              <ClassDef glyph="yacute" class="15"/>
+              <ClassDef glyph="ydieresis" class="15"/>
+              <ClassDef glyph="z" class="14"/>
+            </ClassDef2>
+            <!-- Class1Count=2 -->
+            <!-- Class2Count=51 -->
+            <Class1Record index="0">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="-110"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="1">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-80"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="-80"/>
+              </Class2Record>
+            </Class1Record>
+          </PairPos>
+        </ExtensionPos>
+        <ExtensionPos index="12" Format="1">
+          <ExtensionLookupType value="2"/>
+          <PairPos Format="2">
+            <Coverage Format="1">
+              <Glyph value="X"/>
+              <Glyph value="germandbls"/>
+              <Glyph value="exclamdown"/>
+              <Glyph value="questiondown"/>
+              <Glyph value="periodcentered"/>
+              <Glyph value="slash"/>
+              <Glyph value="backslash"/>
+            </Coverage>
+            <ValueFormat1 value="4"/>
+            <ValueFormat2 value="0"/>
+            <ClassDef1 Format="2">
+              <ClassDef glyph="X" class="1"/>
+              <ClassDef glyph="backslash" class="2"/>
+              <ClassDef glyph="exclamdown" class="3"/>
+              <ClassDef glyph="germandbls" class="4"/>
+              <ClassDef glyph="periodcentered" class="5"/>
+              <ClassDef glyph="questiondown" class="6"/>
+              <ClassDef glyph="slash" class="7"/>
+            </ClassDef1>
+            <ClassDef2 Format="2">
+              <ClassDef glyph="A" class="7"/>
+              <ClassDef glyph="AE" class="31"/>
+              <ClassDef glyph="Aacute" class="7"/>
+              <ClassDef glyph="Acircumflex" class="7"/>
+              <ClassDef glyph="Adieresis" class="7"/>
+              <ClassDef glyph="Agrave" class="7"/>
+              <ClassDef glyph="Aring" class="7"/>
+              <ClassDef glyph="Atilde" class="7"/>
+              <ClassDef glyph="C" class="3"/>
+              <ClassDef glyph="Ccedilla" class="3"/>
+              <ClassDef glyph="Eth" class="32"/>
+              <ClassDef glyph="G" class="3"/>
+              <ClassDef glyph="J" class="36"/>
+              <ClassDef glyph="O" class="3"/>
+              <ClassDef glyph="Oacute" class="3"/>
+              <ClassDef glyph="Ocircumflex" class="3"/>
+              <ClassDef glyph="Odieresis" class="3"/>
+              <ClassDef glyph="Ograve" class="3"/>
+              <ClassDef glyph="Oslash" class="3"/>
+              <ClassDef glyph="Otilde" class="3"/>
+              <ClassDef glyph="Q" class="3"/>
+              <ClassDef glyph="S" class="17"/>
+              <ClassDef glyph="T" class="18"/>
+              <ClassDef glyph="U" class="8"/>
+              <ClassDef glyph="Uacute" class="8"/>
+              <ClassDef glyph="Ucircumflex" class="8"/>
+              <ClassDef glyph="Udieresis" class="8"/>
+              <ClassDef glyph="Ugrave" class="8"/>
+              <ClassDef glyph="V" class="37"/>
+              <ClassDef glyph="W" class="24"/>
+              <ClassDef glyph="X" class="43"/>
+              <ClassDef glyph="Y" class="19"/>
+              <ClassDef glyph="Yacute" class="19"/>
+              <ClassDef glyph="Z" class="21"/>
+              <ClassDef glyph="a" class="2"/>
+              <ClassDef glyph="aacute" class="2"/>
+              <ClassDef glyph="acircumflex" class="2"/>
+              <ClassDef glyph="adieresis" class="2"/>
+              <ClassDef glyph="ae" class="2"/>
+              <ClassDef glyph="agrave" class="2"/>
+              <ClassDef glyph="aring" class="2"/>
+              <ClassDef glyph="asterisk" class="44"/>
+              <ClassDef glyph="atilde" class="2"/>
+              <ClassDef glyph="b" class="4"/>
+              <ClassDef glyph="backslash" class="45"/>
+              <ClassDef glyph="braceright" class="23"/>
+              <ClassDef glyph="bracketright" class="23"/>
+              <ClassDef glyph="c" class="1"/>
+              <ClassDef glyph="ccedilla" class="1"/>
+              <ClassDef glyph="colon" class="38"/>
+              <ClassDef glyph="comma" class="26"/>
+              <ClassDef glyph="d" class="1"/>
+              <ClassDef glyph="e" class="1"/>
+              <ClassDef glyph="eacute" class="1"/>
+              <ClassDef glyph="ecircumflex" class="1"/>
+              <ClassDef glyph="edieresis" class="1"/>
+              <ClassDef glyph="egrave" class="1"/>
+              <ClassDef glyph="exclam" class="33"/>
+              <ClassDef glyph="exclamdown" class="46"/>
+              <ClassDef glyph="f" class="11"/>
+              <ClassDef glyph="g" class="20"/>
+              <ClassDef glyph="germandbls" class="4"/>
+              <ClassDef glyph="glyph00117" class="4"/>
+              <ClassDef glyph="glyph00118" class="11"/>
+              <ClassDef glyph="glyph00119" class="11"/>
+              <ClassDef glyph="glyph00120" class="11"/>
+              <ClassDef glyph="glyph00237" class="10"/>
+              <ClassDef glyph="glyph00238" class="13"/>
+              <ClassDef glyph="glyph00239" class="10"/>
+              <ClassDef glyph="glyph00240" class="10"/>
+              <ClassDef glyph="glyph00241" class="10"/>
+              <ClassDef glyph="glyph00243" class="29"/>
+              <ClassDef glyph="glyph00244" class="13"/>
+              <ClassDef glyph="glyph00245" class="13"/>
+              <ClassDef glyph="glyph00246" class="29"/>
+              <ClassDef glyph="glyph00247" class="13"/>
+              <ClassDef glyph="glyph00248" class="13"/>
+              <ClassDef glyph="glyph00249" class="13"/>
+              <ClassDef glyph="glyph00250" class="13"/>
+              <ClassDef glyph="glyph00251" class="10"/>
+              <ClassDef glyph="glyph00252" class="29"/>
+              <ClassDef glyph="glyph00253" class="10"/>
+              <ClassDef glyph="glyph00254" class="13"/>
+              <ClassDef glyph="glyph00257" class="13"/>
+              <ClassDef glyph="glyph00258" class="34"/>
+              <ClassDef glyph="glyph00259" class="34"/>
+              <ClassDef glyph="glyph00261" class="29"/>
+              <ClassDef glyph="glyph00263" class="10"/>
+              <ClassDef glyph="glyph00264" class="10"/>
+              <ClassDef glyph="guillemotleft" class="40"/>
+              <ClassDef glyph="guillemotright" class="41"/>
+              <ClassDef glyph="h" class="4"/>
+              <ClassDef glyph="hyphen" class="27"/>
+              <ClassDef glyph="i" class="9"/>
+              <ClassDef glyph="iacute" class="9"/>
+              <ClassDef glyph="icircumflex" class="9"/>
+              <ClassDef glyph="idieresis" class="9"/>
+              <ClassDef glyph="igrave" class="9"/>
+              <ClassDef glyph="j" class="22"/>
+              <ClassDef glyph="k" class="4"/>
+              <ClassDef glyph="l" class="4"/>
+              <ClassDef glyph="m" class="5"/>
+              <ClassDef glyph="mu" class="39"/>
+              <ClassDef glyph="n" class="5"/>
+              <ClassDef glyph="ntilde" class="5"/>
+              <ClassDef glyph="o" class="1"/>
+              <ClassDef glyph="oacute" class="1"/>
+              <ClassDef glyph="ocircumflex" class="1"/>
+              <ClassDef glyph="odieresis" class="1"/>
+              <ClassDef glyph="ograve" class="1"/>
+              <ClassDef glyph="oslash" class="1"/>
+              <ClassDef glyph="otilde" class="1"/>
+              <ClassDef glyph="p" class="5"/>
+              <ClassDef glyph="parenright" class="23"/>
+              <ClassDef glyph="period" class="26"/>
+              <ClassDef glyph="periodcentered" class="47"/>
+              <ClassDef glyph="q" class="1"/>
+              <ClassDef glyph="question" class="30"/>
+              <ClassDef glyph="questiondown" class="48"/>
+              <ClassDef glyph="quotedbl" class="42"/>
+              <ClassDef glyph="quotesingle" class="42"/>
+              <ClassDef glyph="r" class="5"/>
+              <ClassDef glyph="registered" class="49"/>
+              <ClassDef glyph="s" class="16"/>
+              <ClassDef glyph="semicolon" class="38"/>
+              <ClassDef glyph="slash" class="50"/>
+              <ClassDef glyph="t" class="12"/>
+              <ClassDef glyph="thorn" class="4"/>
+              <ClassDef glyph="u" class="6"/>
+              <ClassDef glyph="uacute" class="6"/>
+              <ClassDef glyph="ucircumflex" class="6"/>
+              <ClassDef glyph="udieresis" class="6"/>
+              <ClassDef glyph="ugrave" class="6"/>
+              <ClassDef glyph="v" class="35"/>
+              <ClassDef glyph="w" class="28"/>
+              <ClassDef glyph="x" class="25"/>
+              <ClassDef glyph="y" class="15"/>
+              <ClassDef glyph="yacute" class="15"/>
+              <ClassDef glyph="ydieresis" class="15"/>
+              <ClassDef glyph="z" class="14"/>
+            </ClassDef2>
+            <!-- Class1Count=8 -->
+            <!-- Class2Count=51 -->
+            <Class1Record index="0">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="1">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="24"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="2">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-100"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-80"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="80"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-60"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="3">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-24"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-16"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="4">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="10"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="-8"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="-60"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="5">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-60"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="-42"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="-18"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="6">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-12"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="-28"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="-14"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="-80"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="-60"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="70"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="-28"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="-34"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+            <Class1Record index="7">
+              <Class2Record index="0">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="1">
+                <Value1 XAdvance="-44"/>
+              </Class2Record>
+              <Class2Record index="2">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="3">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="4">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="5">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="6">
+                <Value1 XAdvance="-20"/>
+              </Class2Record>
+              <Class2Record index="7">
+                <Value1 XAdvance="-40"/>
+              </Class2Record>
+              <Class2Record index="8">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="9">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="10">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="11">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="12">
+                <Value1 XAdvance="20"/>
+              </Class2Record>
+              <Class2Record index="13">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="14">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="15">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="16">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="17">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="18">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="19">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="20">
+                <Value1 XAdvance="-10"/>
+              </Class2Record>
+              <Class2Record index="21">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="22">
+                <Value1 XAdvance="40"/>
+              </Class2Record>
+              <Class2Record index="23">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="24">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="25">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="26">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="27">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="28">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="29">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="30">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="31">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="32">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="33">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="34">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="35">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="36">
+                <Value1 XAdvance="-80"/>
+              </Class2Record>
+              <Class2Record index="37">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="38">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="39">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="40">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="41">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="42">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="43">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="44">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="45">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="46">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="47">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="48">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="49">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+              <Class2Record index="50">
+                <Value1 XAdvance="0"/>
+              </Class2Record>
+            </Class1Record>
+          </PairPos>
+        </ExtensionPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=4 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=6 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+            <FeatureIndex index="2" value="2"/>
+            <FeatureIndex index="3" value="3"/>
+            <FeatureIndex index="4" value="4"/>
+            <FeatureIndex index="5" value="5"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="cyrl"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=6 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+            <FeatureIndex index="2" value="2"/>
+            <FeatureIndex index="3" value="3"/>
+            <FeatureIndex index="4" value="4"/>
+            <FeatureIndex index="5" value="5"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="2">
+        <ScriptTag value="grek"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=6 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+            <FeatureIndex index="2" value="2"/>
+            <FeatureIndex index="3" value="3"/>
+            <FeatureIndex index="4" value="4"/>
+            <FeatureIndex index="5" value="5"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="3">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=6 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+            <FeatureIndex index="2" value="2"/>
+            <FeatureIndex index="3" value="3"/>
+            <FeatureIndex index="4" value="4"/>
+            <FeatureIndex index="5" value="5"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=6 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="ccmp"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="4"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="dnom"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="6"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="2">
+        <FeatureTag value="frac"/>
+        <Feature>
+          <!-- LookupCount=3 -->
+          <LookupListIndex index="0" value="5"/>
+          <LookupListIndex index="1" value="7"/>
+          <LookupListIndex index="2" value="8"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="3">
+        <FeatureTag value="liga"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="11"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="4">
+        <FeatureTag value="numr"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="5"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="5">
+        <FeatureTag value="sups"/>
+        <Feature>
+          <!-- LookupCount=4 -->
+          <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="1" value="1"/>
+          <LookupListIndex index="2" value="3"/>
+          <LookupListIndex index="3" value="2"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=12 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="2">
+          <Substitution in="a" out="glyph00237"/>
+          <Substitution in="b" out="glyph00238"/>
+          <Substitution in="c" out="glyph00239"/>
+          <Substitution in="d" out="glyph00240"/>
+          <Substitution in="e" out="glyph00241"/>
+          <Substitution in="eacute" out="glyph00264"/>
+          <Substitution in="egrave" out="glyph00263"/>
+          <Substitution in="f" out="glyph00242"/>
+          <Substitution in="g" out="glyph00243"/>
+          <Substitution in="h" out="glyph00244"/>
+          <Substitution in="i" out="glyph00245"/>
+          <Substitution in="j" out="glyph00246"/>
+          <Substitution in="k" out="glyph00247"/>
+          <Substitution in="l" out="glyph00248"/>
+          <Substitution in="m" out="glyph00249"/>
+          <Substitution in="n" out="glyph00250"/>
+          <Substitution in="o" out="glyph00251"/>
+          <Substitution in="p" out="glyph00252"/>
+          <Substitution in="q" out="glyph00253"/>
+          <Substitution in="r" out="glyph00254"/>
+          <Substitution in="s" out="glyph00255"/>
+          <Substitution in="t" out="glyph00256"/>
+          <Substitution in="u" out="glyph00257"/>
+          <Substitution in="v" out="glyph00258"/>
+          <Substitution in="w" out="glyph00259"/>
+          <Substitution in="x" out="glyph00260"/>
+          <Substitution in="y" out="glyph00261"/>
+          <Substitution in="z" out="glyph00262"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="1">
+          <Substitution in="A" out="glyph00211"/>
+          <Substitution in="B" out="glyph00212"/>
+          <Substitution in="C" out="glyph00213"/>
+          <Substitution in="D" out="glyph00214"/>
+          <Substitution in="E" out="glyph00215"/>
+          <Substitution in="F" out="glyph00216"/>
+          <Substitution in="G" out="glyph00217"/>
+          <Substitution in="H" out="glyph00218"/>
+          <Substitution in="I" out="glyph00219"/>
+          <Substitution in="J" out="glyph00220"/>
+          <Substitution in="K" out="glyph00221"/>
+          <Substitution in="L" out="glyph00222"/>
+          <Substitution in="M" out="glyph00223"/>
+          <Substitution in="N" out="glyph00224"/>
+          <Substitution in="O" out="glyph00225"/>
+          <Substitution in="P" out="glyph00226"/>
+          <Substitution in="Q" out="glyph00227"/>
+          <Substitution in="R" out="glyph00228"/>
+          <Substitution in="S" out="glyph00229"/>
+          <Substitution in="T" out="glyph00230"/>
+          <Substitution in="U" out="glyph00231"/>
+          <Substitution in="V" out="glyph00232"/>
+          <Substitution in="W" out="glyph00233"/>
+          <Substitution in="X" out="glyph00234"/>
+          <Substitution in="Y" out="glyph00235"/>
+          <Substitution in="Z" out="glyph00236"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="2">
+          <Substitution in="colon" out="glyph00265"/>
+          <Substitution in="hyphen" out="glyph00266"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="3">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="2">
+          <Substitution in="comma" out="glyph00180"/>
+          <Substitution in="eight" out="glyph00173"/>
+          <Substitution in="equal" out="glyph00176"/>
+          <Substitution in="five" out="glyph00170"/>
+          <Substitution in="four" out="glyph00169"/>
+          <Substitution in="nine" out="glyph00174"/>
+          <Substitution in="one" out="uni00B9"/>
+          <Substitution in="parenleft" out="glyph00177"/>
+          <Substitution in="parenright" out="glyph00178"/>
+          <Substitution in="period" out="glyph00179"/>
+          <Substitution in="plus" out="glyph00175"/>
+          <Substitution in="seven" out="glyph00172"/>
+          <Substitution in="six" out="glyph00171"/>
+          <Substitution in="three" out="uni00B3"/>
+          <Substitution in="two" out="uni00B2"/>
+          <Substitution in="zero" out="glyph00165"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="4">
+        <LookupType value="4"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0" Format="1">
+          <LigatureSet glyph="L">
+            <Ligature components="periodcentered,L" glyph="glyph00084"/>
+          </LigatureSet>
+          <LigatureSet glyph="l">
+            <Ligature components="periodcentered,l" glyph="glyph00117"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="5">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="2">
+          <Substitution in="comma" out="glyph00208"/>
+          <Substitution in="eight" out="glyph00203"/>
+          <Substitution in="five" out="glyph00200"/>
+          <Substitution in="four" out="glyph00199"/>
+          <Substitution in="nine" out="glyph00204"/>
+          <Substitution in="one" out="glyph00196"/>
+          <Substitution in="parenleft" out="glyph00205"/>
+          <Substitution in="parenright" out="glyph00206"/>
+          <Substitution in="period" out="glyph00207"/>
+          <Substitution in="seven" out="glyph00202"/>
+          <Substitution in="six" out="glyph00201"/>
+          <Substitution in="three" out="glyph00198"/>
+          <Substitution in="two" out="glyph00197"/>
+          <Substitution in="zero" out="glyph00195"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="6">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="2">
+          <Substitution in="comma" out="glyph00194"/>
+          <Substitution in="eight" out="glyph00189"/>
+          <Substitution in="five" out="glyph00186"/>
+          <Substitution in="four" out="glyph00185"/>
+          <Substitution in="nine" out="glyph00190"/>
+          <Substitution in="one" out="glyph00182"/>
+          <Substitution in="parenleft" out="glyph00191"/>
+          <Substitution in="parenright" out="glyph00192"/>
+          <Substitution in="period" out="glyph00193"/>
+          <Substitution in="seven" out="glyph00188"/>
+          <Substitution in="six" out="glyph00187"/>
+          <Substitution in="three" out="glyph00184"/>
+          <Substitution in="two" out="glyph00183"/>
+          <Substitution in="zero" out="glyph00181"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="7">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="1">
+          <Substitution in="slash" out="glyph00272"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="8">
+        <LookupType value="6"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=3 -->
+        <ChainContextSubst index="0" Format="3">
+          <!-- BacktrackGlyphCount=1 -->
+          <BacktrackCoverage index="0" Format="2">
+            <Glyph value="glyph00195"/>
+            <Glyph value="glyph00196"/>
+            <Glyph value="glyph00197"/>
+            <Glyph value="glyph00198"/>
+            <Glyph value="glyph00199"/>
+            <Glyph value="glyph00200"/>
+            <Glyph value="glyph00201"/>
+            <Glyph value="glyph00202"/>
+            <Glyph value="glyph00203"/>
+            <Glyph value="glyph00204"/>
+          </BacktrackCoverage>
+          <!-- InputGlyphCount=1 -->
+          <InputCoverage index="0" Format="1">
+            <Glyph value="space"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- SubstCount=1 -->
+          <SubstLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="9"/>
+          </SubstLookupRecord>
+        </ChainContextSubst>
+        <ChainContextSubst index="1" Format="3">
+          <!-- BacktrackGlyphCount=1 -->
+          <BacktrackCoverage index="0" Format="2">
+            <Glyph value="glyph00181"/>
+            <Glyph value="glyph00182"/>
+            <Glyph value="glyph00183"/>
+            <Glyph value="glyph00184"/>
+            <Glyph value="glyph00185"/>
+            <Glyph value="glyph00186"/>
+            <Glyph value="glyph00187"/>
+            <Glyph value="glyph00188"/>
+            <Glyph value="glyph00189"/>
+            <Glyph value="glyph00190"/>
+            <Glyph value="glyph00191"/>
+            <Glyph value="glyph00192"/>
+            <Glyph value="glyph00193"/>
+            <Glyph value="glyph00194"/>
+            <Glyph value="glyph00272"/>
+          </BacktrackCoverage>
+          <!-- InputGlyphCount=1 -->
+          <InputCoverage index="0" Format="2">
+            <Glyph value="glyph00195"/>
+            <Glyph value="glyph00196"/>
+            <Glyph value="glyph00197"/>
+            <Glyph value="glyph00198"/>
+            <Glyph value="glyph00199"/>
+            <Glyph value="glyph00200"/>
+            <Glyph value="glyph00201"/>
+            <Glyph value="glyph00202"/>
+            <Glyph value="glyph00203"/>
+            <Glyph value="glyph00204"/>
+            <Glyph value="glyph00205"/>
+            <Glyph value="glyph00206"/>
+            <Glyph value="glyph00207"/>
+            <Glyph value="glyph00208"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- SubstCount=1 -->
+          <SubstLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="9"/>
+          </SubstLookupRecord>
+        </ChainContextSubst>
+        <ChainContextSubst index="2" Format="3">
+          <!-- BacktrackGlyphCount=2 -->
+          <BacktrackCoverage index="0" Format="1">
+            <Glyph value="glyph00293"/>
+          </BacktrackCoverage>
+          <BacktrackCoverage index="1" Format="2">
+            <Glyph value="glyph00181"/>
+            <Glyph value="glyph00182"/>
+            <Glyph value="glyph00183"/>
+            <Glyph value="glyph00184"/>
+            <Glyph value="glyph00185"/>
+            <Glyph value="glyph00186"/>
+            <Glyph value="glyph00187"/>
+            <Glyph value="glyph00188"/>
+            <Glyph value="glyph00189"/>
+            <Glyph value="glyph00190"/>
+          </BacktrackCoverage>
+          <!-- InputGlyphCount=1 -->
+          <InputCoverage index="0" Format="2">
+            <Glyph value="glyph00195"/>
+            <Glyph value="glyph00196"/>
+            <Glyph value="glyph00197"/>
+            <Glyph value="glyph00198"/>
+            <Glyph value="glyph00199"/>
+            <Glyph value="glyph00200"/>
+            <Glyph value="glyph00201"/>
+            <Glyph value="glyph00202"/>
+            <Glyph value="glyph00203"/>
+            <Glyph value="glyph00204"/>
+            <Glyph value="glyph00205"/>
+            <Glyph value="glyph00206"/>
+            <Glyph value="glyph00207"/>
+            <Glyph value="glyph00208"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- SubstCount=1 -->
+          <SubstLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="10"/>
+          </SubstLookupRecord>
+        </ChainContextSubst>
+      </Lookup>
+      <Lookup index="9">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="2">
+          <Substitution in="glyph00195" out="glyph00181"/>
+          <Substitution in="glyph00196" out="glyph00182"/>
+          <Substitution in="glyph00197" out="glyph00183"/>
+          <Substitution in="glyph00198" out="glyph00184"/>
+          <Substitution in="glyph00199" out="glyph00185"/>
+          <Substitution in="glyph00200" out="glyph00186"/>
+          <Substitution in="glyph00201" out="glyph00187"/>
+          <Substitution in="glyph00202" out="glyph00188"/>
+          <Substitution in="glyph00203" out="glyph00189"/>
+          <Substitution in="glyph00204" out="glyph00190"/>
+          <Substitution in="glyph00205" out="glyph00191"/>
+          <Substitution in="glyph00206" out="glyph00192"/>
+          <Substitution in="glyph00207" out="glyph00193"/>
+          <Substitution in="glyph00208" out="glyph00194"/>
+          <Substitution in="space" out="glyph00293"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="10">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="1">
+          <Substitution in="glyph00195" out="glyph00181"/>
+          <Substitution in="glyph00196" out="glyph00182"/>
+          <Substitution in="glyph00197" out="glyph00183"/>
+          <Substitution in="glyph00198" out="glyph00184"/>
+          <Substitution in="glyph00199" out="glyph00185"/>
+          <Substitution in="glyph00200" out="glyph00186"/>
+          <Substitution in="glyph00201" out="glyph00187"/>
+          <Substitution in="glyph00202" out="glyph00188"/>
+          <Substitution in="glyph00203" out="glyph00189"/>
+          <Substitution in="glyph00204" out="glyph00190"/>
+          <Substitution in="glyph00205" out="glyph00191"/>
+          <Substitution in="glyph00206" out="glyph00192"/>
+          <Substitution in="glyph00207" out="glyph00193"/>
+          <Substitution in="glyph00208" out="glyph00194"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="11">
+        <LookupType value="4"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0" Format="1">
+          <LigatureSet glyph="f">
+            <Ligature components="f,t" glyph="glyph00120"/>
+            <Ligature components="f" glyph="glyph00118"/>
+            <Ligature components="t" glyph="glyph00119"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=3 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.6"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.6"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="2">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=4 -->
+      <VarData index="0">
+        <!-- ItemCount=54 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=1 -->
+        <VarRegionIndex index="0" value="2"/>
+        <Item index="0" value="[-26]"/>
+        <Item index="1" value="[4]"/>
+        <Item index="2" value="[10]"/>
+        <Item index="3" value="[12]"/>
+        <Item index="4" value="[13]"/>
+        <Item index="5" value="[16]"/>
+        <Item index="6" value="[18]"/>
+        <Item index="7" value="[20]"/>
+        <Item index="8" value="[22]"/>
+        <Item index="9" value="[24]"/>
+        <Item index="10" value="[26]"/>
+        <Item index="11" value="[28]"/>
+        <Item index="12" value="[30]"/>
+        <Item index="13" value="[33]"/>
+        <Item index="14" value="[34]"/>
+        <Item index="15" value="[35]"/>
+        <Item index="16" value="[36]"/>
+        <Item index="17" value="[38]"/>
+        <Item index="18" value="[39]"/>
+        <Item index="19" value="[40]"/>
+        <Item index="20" value="[42]"/>
+        <Item index="21" value="[44]"/>
+        <Item index="22" value="[46]"/>
+        <Item index="23" value="[48]"/>
+        <Item index="24" value="[50]"/>
+        <Item index="25" value="[51]"/>
+        <Item index="26" value="[52]"/>
+        <Item index="27" value="[54]"/>
+        <Item index="28" value="[56]"/>
+        <Item index="29" value="[58]"/>
+        <Item index="30" value="[59]"/>
+        <Item index="31" value="[60]"/>
+        <Item index="32" value="[62]"/>
+        <Item index="33" value="[64]"/>
+        <Item index="34" value="[66]"/>
+        <Item index="35" value="[68]"/>
+        <Item index="36" value="[70]"/>
+        <Item index="37" value="[72]"/>
+        <Item index="38" value="[74]"/>
+        <Item index="39" value="[78]"/>
+        <Item index="40" value="[79]"/>
+        <Item index="41" value="[82]"/>
+        <Item index="42" value="[84]"/>
+        <Item index="43" value="[85]"/>
+        <Item index="44" value="[86]"/>
+        <Item index="45" value="[87]"/>
+        <Item index="46" value="[90]"/>
+        <Item index="47" value="[96]"/>
+        <Item index="48" value="[108]"/>
+        <Item index="49" value="[112]"/>
+        <Item index="50" value="[116]"/>
+        <Item index="51" value="[118]"/>
+        <Item index="52" value="[122]"/>
+        <Item index="53" value="[124]"/>
+      </VarData>
+      <VarData index="1">
+        <!-- ItemCount=22 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=2 -->
+        <VarRegionIndex index="0" value="0"/>
+        <VarRegionIndex index="1" value="1"/>
+        <Item index="0" value="[4, 6]"/>
+        <Item index="1" value="[14, 22]"/>
+        <Item index="2" value="[18, 30]"/>
+        <Item index="3" value="[19, 28]"/>
+        <Item index="4" value="[20, 34]"/>
+        <Item index="5" value="[24, 40]"/>
+        <Item index="6" value="[25, 42]"/>
+        <Item index="7" value="[26, 44]"/>
+        <Item index="8" value="[29, 48]"/>
+        <Item index="9" value="[30, 48]"/>
+        <Item index="10" value="[30, 50]"/>
+        <Item index="11" value="[31, 51]"/>
+        <Item index="12" value="[32, 54]"/>
+        <Item index="13" value="[36, 60]"/>
+        <Item index="14" value="[37, 62]"/>
+        <Item index="15" value="[41, 68]"/>
+        <Item index="16" value="[48, 78]"/>
+        <Item index="17" value="[50, 80]"/>
+        <Item index="18" value="[59, 98]"/>
+        <Item index="19" value="[65, 108]"/>
+        <Item index="20" value="[73, 122]"/>
+        <Item index="21" value="[76, 126]"/>
+      </VarData>
+      <VarData index="2">
+        <!-- ItemCount=9 -->
+        <NumShorts value="1"/>
+        <!-- VarRegionCount=1 -->
+        <VarRegionIndex index="0" value="2"/>
+        <Item index="0" value="[128]"/>
+        <Item index="1" value="[140]"/>
+        <Item index="2" value="[148]"/>
+        <Item index="3" value="[168]"/>
+        <Item index="4" value="[176]"/>
+        <Item index="5" value="[206]"/>
+        <Item index="6" value="[244]"/>
+        <Item index="7" value="[268]"/>
+        <Item index="8" value="[274]"/>
+      </VarData>
+      <VarData index="3">
+        <!-- ItemCount=1 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=0 -->
+        <Item index="0" value="[]"/>
+      </VarData>
+    </VarStore>
+    <AdvWidthMap>
+      <Map glyph=".notdef" outer="1" inner="17"/>
+      <Map glyph="A" outer="0" inner="33"/>
+      <Map glyph="AE" outer="0" inner="24"/>
+      <Map glyph="Aacute" outer="0" inner="33"/>
+      <Map glyph="Acircumflex" outer="0" inner="33"/>
+      <Map glyph="Adieresis" outer="0" inner="33"/>
+      <Map glyph="Agrave" outer="0" inner="33"/>
+      <Map glyph="Aring" outer="0" inner="33"/>
+      <Map glyph="Atilde" outer="0" inner="33"/>
+      <Map glyph="B" outer="0" inner="17"/>
+      <Map glyph="C" outer="0" inner="9"/>
+      <Map glyph="Ccedilla" outer="0" inner="9"/>
+      <Map glyph="D" outer="1" inner="6"/>
+      <Map glyph="E" outer="0" inner="22"/>
+      <Map glyph="Eacute" outer="0" inner="22"/>
+      <Map glyph="Ecircumflex" outer="0" inner="22"/>
+      <Map glyph="Edieresis" outer="0" inner="22"/>
+      <Map glyph="Egrave" outer="0" inner="22"/>
+      <Map glyph="Eth" outer="1" inner="8"/>
+      <Map glyph="F" outer="0" inner="34"/>
+      <Map glyph="G" outer="0" inner="22"/>
+      <Map glyph="H" outer="1" inner="8"/>
+      <Map glyph="I" outer="0" inner="42"/>
+      <Map glyph="Iacute" outer="0" inner="42"/>
+      <Map glyph="Icircumflex" outer="0" inner="42"/>
+      <Map glyph="Idieresis" outer="0" inner="42"/>
+      <Map glyph="Igrave" outer="0" inner="42"/>
+      <Map glyph="J" outer="0" inner="33"/>
+      <Map glyph="K" outer="0" inner="39"/>
+      <Map glyph="L" outer="0" inner="36"/>
+      <Map glyph="M" outer="1" inner="16"/>
+      <Map glyph="N" outer="1" inner="5"/>
+      <Map glyph="Ntilde" outer="0" inner="19"/>
+      <Map glyph="O" outer="1" inner="7"/>
+      <Map glyph="Oacute" outer="0" inner="21"/>
+      <Map glyph="Ocircumflex" outer="0" inner="21"/>
+      <Map glyph="Odieresis" outer="0" inner="21"/>
+      <Map glyph="Ograve" outer="0" inner="21"/>
+      <Map glyph="Oslash" outer="1" inner="7"/>
+      <Map glyph="Otilde" outer="0" inner="21"/>
+      <Map glyph="P" outer="0" inner="34"/>
+      <Map glyph="Q" outer="0" inner="21"/>
+      <Map glyph="R" outer="0" inner="47"/>
+      <Map glyph="S" outer="0" inner="23"/>
+      <Map glyph="T" outer="1" inner="7"/>
+      <Map glyph="Thorn" outer="0" inner="38"/>
+      <Map glyph="U" outer="0" inner="20"/>
+      <Map glyph="Uacute" outer="0" inner="20"/>
+      <Map glyph="Ucircumflex" outer="0" inner="20"/>
+      <Map glyph="Udieresis" outer="0" inner="20"/>
+      <Map glyph="Ugrave" outer="0" inner="20"/>
+      <Map glyph="V" outer="0" inner="46"/>
+      <Map glyph="W" outer="1" inner="13"/>
+      <Map glyph="X" outer="0" inner="51"/>
+      <Map glyph="Y" outer="1" inner="19"/>
+      <Map glyph="Yacute" outer="0" inner="48"/>
+      <Map glyph="Z" outer="0" inner="1"/>
+      <Map glyph="a" outer="1" inner="10"/>
+      <Map glyph="aacute" outer="0" inner="24"/>
+      <Map glyph="acircumflex" outer="0" inner="24"/>
+      <Map glyph="acute" outer="0" inner="11"/>
+      <Map glyph="adieresis" outer="0" inner="24"/>
+      <Map glyph="ae" outer="1" inner="0"/>
+      <Map glyph="agrave" outer="0" inner="24"/>
+      <Map glyph="ampersand" outer="2" inner="0"/>
+      <Map glyph="aring" outer="0" inner="24"/>
+      <Map glyph="asciicircum" outer="0" inner="35"/>
+      <Map glyph="asciitilde" outer="0" inner="35"/>
+      <Map glyph="asterisk" outer="0" inner="44"/>
+      <Map glyph="at" outer="1" inner="20"/>
+      <Map glyph="atilde" outer="0" inner="24"/>
+      <Map glyph="b" outer="0" inner="20"/>
+      <Map glyph="backslash" outer="0" inner="0"/>
+      <Map glyph="bar" outer="0" inner="29"/>
+      <Map glyph="braceleft" outer="0" inner="46"/>
+      <Map glyph="braceright" outer="0" inner="46"/>
+      <Map glyph="bracketleft" outer="0" inner="46"/>
+      <Map glyph="bracketright" outer="0" inner="46"/>
+      <Map glyph="brokenbar" outer="0" inner="29"/>
+      <Map glyph="c" outer="0" inner="10"/>
+      <Map glyph="ccedilla" outer="0" inner="10"/>
+      <Map glyph="cedilla" outer="0" inner="11"/>
+      <Map glyph="cent" outer="0" inner="35"/>
+      <Map glyph="colon" outer="0" inner="49"/>
+      <Map glyph="comma" outer="0" inner="49"/>
+      <Map glyph="copyright" outer="0" inner="3"/>
+      <Map glyph="currency" outer="0" inner="35"/>
+      <Map glyph="d" outer="0" inner="19"/>
+      <Map glyph="degree" outer="0" inner="38"/>
+      <Map glyph="dieresis" outer="0" inner="11"/>
+      <Map glyph="divide" outer="0" inner="35"/>
+      <Map glyph="dollar" outer="0" inner="35"/>
+      <Map glyph="e" outer="1" inner="9"/>
+      <Map glyph="eacute" outer="0" inner="23"/>
+      <Map glyph="ecircumflex" outer="0" inner="23"/>
+      <Map glyph="edieresis" outer="0" inner="23"/>
+      <Map glyph="egrave" outer="0" inner="23"/>
+      <Map glyph="eight" outer="0" inner="35"/>
+      <Map glyph="equal" outer="0" inner="35"/>
+      <Map glyph="eth" outer="0" inner="14"/>
+      <Map glyph="exclam" outer="0" inner="49"/>
+      <Map glyph="exclamdown" outer="0" inner="49"/>
+      <Map glyph="f" outer="0" inner="48"/>
+      <Map glyph="five" outer="0" inner="35"/>
+      <Map glyph="four" outer="0" inner="35"/>
+      <Map glyph="g" outer="0" inner="34"/>
+      <Map glyph="germandbls" outer="0" inner="53"/>
+      <Map glyph="glyph00084" outer="2" inner="1"/>
+      <Map glyph="glyph00117" outer="2" inner="7"/>
+      <Map glyph="glyph00118" outer="2" inner="4"/>
+      <Map glyph="glyph00119" outer="2" inner="5"/>
+      <Map glyph="glyph00120" outer="2" inner="8"/>
+      <Map glyph="glyph00165" outer="0" inner="7"/>
+      <Map glyph="glyph00169" outer="0" inner="7"/>
+      <Map glyph="glyph00170" outer="0" inner="7"/>
+      <Map glyph="glyph00171" outer="0" inner="7"/>
+      <Map glyph="glyph00172" outer="0" inner="7"/>
+      <Map glyph="glyph00173" outer="0" inner="7"/>
+      <Map glyph="glyph00174" outer="0" inner="7"/>
+      <Map glyph="glyph00175" outer="0" inner="7"/>
+      <Map glyph="glyph00176" outer="0" inner="7"/>
+      <Map glyph="glyph00177" outer="0" inner="35"/>
+      <Map glyph="glyph00178" outer="0" inner="35"/>
+      <Map glyph="glyph00179" outer="0" inner="35"/>
+      <Map glyph="glyph00180" outer="0" inner="35"/>
+      <Map glyph="glyph00181" outer="0" inner="7"/>
+      <Map glyph="glyph00182" outer="0" inner="7"/>
+      <Map glyph="glyph00183" outer="0" inner="7"/>
+      <Map glyph="glyph00184" outer="0" inner="7"/>
+      <Map glyph="glyph00185" outer="0" inner="7"/>
+      <Map glyph="glyph00186" outer="0" inner="7"/>
+      <Map glyph="glyph00187" outer="0" inner="7"/>
+      <Map glyph="glyph00188" outer="0" inner="7"/>
+      <Map glyph="glyph00189" outer="0" inner="7"/>
+      <Map glyph="glyph00190" outer="0" inner="7"/>
+      <Map glyph="glyph00191" outer="0" inner="35"/>
+      <Map glyph="glyph00192" outer="0" inner="35"/>
+      <Map glyph="glyph00193" outer="0" inner="35"/>
+      <Map glyph="glyph00194" outer="0" inner="35"/>
+      <Map glyph="glyph00195" outer="0" inner="7"/>
+      <Map glyph="glyph00196" outer="0" inner="7"/>
+      <Map glyph="glyph00197" outer="0" inner="7"/>
+      <Map glyph="glyph00198" outer="0" inner="7"/>
+      <Map glyph="glyph00199" outer="0" inner="7"/>
+      <Map glyph="glyph00200" outer="0" inner="7"/>
+      <Map glyph="glyph00201" outer="0" inner="7"/>
+      <Map glyph="glyph00202" outer="0" inner="7"/>
+      <Map glyph="glyph00203" outer="0" inner="7"/>
+      <Map glyph="glyph00204" outer="0" inner="7"/>
+      <Map glyph="glyph00205" outer="0" inner="35"/>
+      <Map glyph="glyph00206" outer="0" inner="35"/>
+      <Map glyph="glyph00207" outer="0" inner="35"/>
+      <Map glyph="glyph00208" outer="0" inner="35"/>
+      <Map glyph="glyph00211" outer="0" inner="27"/>
+      <Map glyph="glyph00212" outer="0" inner="14"/>
+      <Map glyph="glyph00213" outer="0" inner="10"/>
+      <Map glyph="glyph00214" outer="0" inner="15"/>
+      <Map glyph="glyph00215" outer="0" inner="18"/>
+      <Map glyph="glyph00216" outer="0" inner="26"/>
+      <Map glyph="glyph00217" outer="0" inner="20"/>
+      <Map glyph="glyph00218" outer="0" inner="18"/>
+      <Map glyph="glyph00219" outer="0" inner="29"/>
+      <Map glyph="glyph00220" outer="0" inner="24"/>
+      <Map glyph="glyph00221" outer="0" inner="31"/>
+      <Map glyph="glyph00222" outer="0" inner="27"/>
+      <Map glyph="glyph00223" outer="1" inner="14"/>
+      <Map glyph="glyph00224" outer="1" inner="4"/>
+      <Map glyph="glyph00225" outer="0" inner="19"/>
+      <Map glyph="glyph00226" outer="0" inner="25"/>
+      <Map glyph="glyph00227" outer="0" inner="19"/>
+      <Map glyph="glyph00228" outer="0" inner="30"/>
+      <Map glyph="glyph00229" outer="0" inner="19"/>
+      <Map glyph="glyph00230" outer="0" inner="20"/>
+      <Map glyph="glyph00231" outer="0" inner="16"/>
+      <Map glyph="glyph00232" outer="0" inner="36"/>
+      <Map glyph="glyph00233" outer="1" inner="11"/>
+      <Map glyph="glyph00234" outer="0" inner="45"/>
+      <Map glyph="glyph00235" outer="0" inner="40"/>
+      <Map glyph="glyph00236" outer="0" inner="4"/>
+      <Map glyph="glyph00237" outer="1" inner="2"/>
+      <Map glyph="glyph00238" outer="0" inner="10"/>
+      <Map glyph="glyph00239" outer="0" inner="5"/>
+      <Map glyph="glyph00240" outer="0" inner="10"/>
+      <Map glyph="glyph00241" outer="1" inner="1"/>
+      <Map glyph="glyph00242" outer="0" inner="35"/>
+      <Map glyph="glyph00243" outer="0" inner="19"/>
+      <Map glyph="glyph00244" outer="0" inner="18"/>
+      <Map glyph="glyph00245" outer="0" inner="23"/>
+      <Map glyph="glyph00246" outer="0" inner="22"/>
+      <Map glyph="glyph00247" outer="0" inner="38"/>
+      <Map glyph="glyph00248" outer="0" inner="21"/>
+      <Map glyph="glyph00249" outer="0" inner="19"/>
+      <Map glyph="glyph00250" outer="0" inner="14"/>
+      <Map glyph="glyph00251" outer="0" inner="6"/>
+      <Map glyph="glyph00252" outer="0" inner="10"/>
+      <Map glyph="glyph00253" outer="0" inner="10"/>
+      <Map glyph="glyph00254" outer="0" inner="36"/>
+      <Map glyph="glyph00255" outer="0" inner="12"/>
+      <Map glyph="glyph00256" outer="0" inner="31"/>
+      <Map glyph="glyph00257" outer="0" inner="11"/>
+      <Map glyph="glyph00258" outer="0" inner="38"/>
+      <Map glyph="glyph00259" outer="0" inner="40"/>
+      <Map glyph="glyph00260" outer="0" inner="46"/>
+      <Map glyph="glyph00261" outer="0" inner="38"/>
+      <Map glyph="glyph00262" outer="0" inner="23"/>
+      <Map glyph="glyph00263" outer="0" inner="8"/>
+      <Map glyph="glyph00264" outer="0" inner="8"/>
+      <Map glyph="glyph00265" outer="0" inner="35"/>
+      <Map glyph="glyph00266" outer="0" inner="13"/>
+      <Map glyph="glyph00272" outer="0" inner="8"/>
+      <Map glyph="glyph00293" outer="0" inner="2"/>
+      <Map glyph="grave" outer="0" inner="11"/>
+      <Map glyph="greater" outer="0" inner="35"/>
+      <Map glyph="guillemotleft" outer="0" inner="49"/>
+      <Map glyph="guillemotright" outer="0" inner="49"/>
+      <Map glyph="h" outer="0" inner="31"/>
+      <Map glyph="hyphen" outer="0" inner="22"/>
+      <Map glyph="i" outer="0" inner="34"/>
+      <Map glyph="iacute" outer="0" inner="34"/>
+      <Map glyph="icircumflex" outer="0" inner="34"/>
+      <Map glyph="idieresis" outer="0" inner="34"/>
+      <Map glyph="igrave" outer="0" inner="34"/>
+      <Map glyph="j" outer="0" inner="35"/>
+      <Map glyph="k" outer="0" inner="50"/>
+      <Map glyph="l" outer="0" inner="35"/>
+      <Map glyph="less" outer="0" inner="35"/>
+      <Map glyph="logicalnot" outer="0" inner="35"/>
+      <Map glyph="m" outer="0" inner="32"/>
+      <Map glyph="macron" outer="0" inner="11"/>
+      <Map glyph="mu" outer="0" inner="36"/>
+      <Map glyph="multiply" outer="0" inner="35"/>
+      <Map glyph="n" outer="0" inner="28"/>
+      <Map glyph="nine" outer="0" inner="35"/>
+      <Map glyph="ntilde" outer="0" inner="28"/>
+      <Map glyph="numbersign" outer="1" inner="15"/>
+      <Map glyph="o" outer="0" inner="11"/>
+      <Map glyph="oacute" outer="0" inner="11"/>
+      <Map glyph="ocircumflex" outer="0" inner="11"/>
+      <Map glyph="odieresis" outer="0" inner="11"/>
+      <Map glyph="ograve" outer="0" inner="11"/>
+      <Map glyph="one" outer="0" inner="35"/>
+      <Map glyph="onehalf" outer="0" inner="41"/>
+      <Map glyph="onequarter" outer="0" inner="32"/>
+      <Map glyph="ordfeminine" outer="0" inner="12"/>
+      <Map glyph="ordmasculine" outer="0" inner="6"/>
+      <Map glyph="oslash" outer="1" inner="3"/>
+      <Map glyph="otilde" outer="0" inner="11"/>
+      <Map glyph="p" outer="0" inner="19"/>
+      <Map glyph="paragraph" outer="2" inner="3"/>
+      <Map glyph="parenleft" outer="0" inner="46"/>
+      <Map glyph="parenright" outer="0" inner="46"/>
+      <Map glyph="percent" outer="0" inner="37"/>
+      <Map glyph="period" outer="0" inner="49"/>
+      <Map glyph="periodcentered" outer="0" inner="49"/>
+      <Map glyph="plus" outer="0" inner="35"/>
+      <Map glyph="plusminus" outer="0" inner="35"/>
+      <Map glyph="q" outer="0" inner="19"/>
+      <Map glyph="question" outer="0" inner="42"/>
+      <Map glyph="questiondown" outer="0" inner="42"/>
+      <Map glyph="quotedbl" outer="2" inner="6"/>
+      <Map glyph="quotesingle" outer="0" inner="49"/>
+      <Map glyph="r" outer="0" inner="49"/>
+      <Map glyph="registered" outer="0" inner="43"/>
+      <Map glyph="s" outer="0" inner="26"/>
+      <Map glyph="section" outer="0" inner="35"/>
+      <Map glyph="semicolon" outer="0" inner="49"/>
+      <Map glyph="seven" outer="0" inner="35"/>
+      <Map glyph="six" outer="0" inner="35"/>
+      <Map glyph="slash" outer="0" inner="0"/>
+      <Map glyph="space" outer="3" inner="0"/>
+      <Map glyph="sterling" outer="0" inner="35"/>
+      <Map glyph="t" outer="1" inner="18"/>
+      <Map glyph="thorn" outer="0" inner="19"/>
+      <Map glyph="three" outer="0" inner="35"/>
+      <Map glyph="threequarters" outer="0" inner="23"/>
+      <Map glyph="two" outer="0" inner="35"/>
+      <Map glyph="u" outer="1" inner="12"/>
+      <Map glyph="uacute" outer="0" inner="27"/>
+      <Map glyph="ucircumflex" outer="0" inner="27"/>
+      <Map glyph="udieresis" outer="0" inner="27"/>
+      <Map glyph="ugrave" outer="0" inner="27"/>
+      <Map glyph="underscore" outer="3" inner="0"/>
+      <Map glyph="uni00B2" outer="0" inner="7"/>
+      <Map glyph="uni00B3" outer="0" inner="7"/>
+      <Map glyph="uni00B9" outer="0" inner="7"/>
+      <Map glyph="v" outer="0" inner="52"/>
+      <Map glyph="w" outer="1" inner="21"/>
+      <Map glyph="x" outer="2" inner="2"/>
+      <Map glyph="y" outer="0" inner="51"/>
+      <Map glyph="yacute" outer="0" inner="51"/>
+      <Map glyph="ydieresis" outer="0" inner="51"/>
+      <Map glyph="yen" outer="1" inner="15"/>
+      <Map glyph="z" outer="0" inner="39"/>
+      <Map glyph="zero" outer="0" inner="35"/>
+    </AdvWidthMap>
+  </HVAR>
+
+  <MVAR>
+    <Version value="0x00010000"/>
+    <Reserved value="0"/>
+    <ValueRecordSize value="8"/>
+    <!-- ValueRecordCount=2 -->
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=2 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.6"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.6"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=2 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=2 -->
+        <VarRegionIndex index="0" value="0"/>
+        <VarRegionIndex index="1" value="1"/>
+        <Item index="0" value="[8, 14]"/>
+        <Item index="1" value="[13, 22]"/>
+      </VarData>
+    </VarStore>
+    <ValueRecord index="0">
+      <ValueTag value="stro"/>
+      <VarIdx value="0"/>
+    </ValueRecord>
+    <ValueRecord index="1">
+      <ValueTag value="xhgt"/>
+      <VarIdx value="1"/>
+    </ValueRecord>
+  </MVAR>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=2 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="wght"/>
+        <AxisNameID value="287"/>  <!-- Weight -->
+        <AxisOrdering value="0"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="ital"/>
+        <AxisNameID value="286"/>  <!-- Italic -->
+        <AxisOrdering value="1"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=8 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="2">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="288"/>  <!-- ExtraLight -->
+        <NominalValue value="200.0"/>
+        <RangeMinValue value="200.0"/>
+        <RangeMaxValue value="250.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="2">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="290"/>  <!-- Light -->
+        <NominalValue value="300.0"/>
+        <RangeMinValue value="250.0"/>
+        <RangeMaxValue value="350.0"/>
+      </AxisValue>
+      <AxisValue index="2" Format="2">
+        <AxisIndex value="0"/>
+        <Flags value="2"/>
+        <ValueNameID value="292"/>  <!-- Regular -->
+        <NominalValue value="400.0"/>
+        <RangeMinValue value="350.0"/>
+        <RangeMaxValue value="500.0"/>
+      </AxisValue>
+      <AxisValue index="3" Format="2">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="294"/>  <!-- Semibold -->
+        <NominalValue value="600.0"/>
+        <RangeMinValue value="500.0"/>
+        <RangeMaxValue value="650.0"/>
+      </AxisValue>
+      <AxisValue index="4" Format="2">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="296"/>  <!-- Bold -->
+        <NominalValue value="700.0"/>
+        <RangeMinValue value="650.0"/>
+        <RangeMaxValue value="800.0"/>
+      </AxisValue>
+      <AxisValue index="5" Format="2">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="298"/>  <!-- Black -->
+        <NominalValue value="900.0"/>
+        <RangeMinValue value="800.0"/>
+        <RangeMaxValue value="900.0"/>
+      </AxisValue>
+      <AxisValue index="6" Format="3">
+        <AxisIndex value="0"/>
+        <Flags value="2"/>
+        <ValueNameID value="292"/>  <!-- Regular -->
+        <Value value="400.0"/>
+        <LinkedValue value="700.0"/>
+      </AxisValue>
+      <AxisValue index="7" Format="3">
+        <AxisIndex value="1"/>
+        <Flags value="2"/>
+        <ValueNameID value="285"/>  <!-- Roman -->
+        <Value value="0.0"/>
+        <LinkedValue value="1.0"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="2"/>  <!-- Regular -->
+  </STAT>
+
+  <avar>
+    <segment axis="wght">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="0.1429" to="0.1"/>
+      <mapping from="0.2857" to="0.368"/>
+      <mapping from="0.5714" to="0.6"/>
+      <mapping from="0.7143" to="0.824"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+  </avar>
+
+  <fvar>
+
+    <!-- Weight -->
+    <Axis>
+      <AxisTag>wght</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>200.0</MinValue>
+      <DefaultValue>200.0</DefaultValue>
+      <MaxValue>900.0</MaxValue>
+      <AxisNameID>287</AxisNameID>
+    </Axis>
+
+    <!-- ExtraLight -->
+    <!-- PostScript: SourceSansRoman-ExtraLight -->
+    <NamedInstance flags="0x0" postscriptNameID="289" subfamilyNameID="288">
+      <coord axis="wght" value="200.0"/>
+    </NamedInstance>
+
+    <!-- Light -->
+    <!-- PostScript: SourceSansRoman-Light -->
+    <NamedInstance flags="0x0" postscriptNameID="291" subfamilyNameID="290">
+      <coord axis="wght" value="300.0"/>
+    </NamedInstance>
+
+    <!-- Regular -->
+    <!-- PostScript: SourceSansRoman-Regular -->
+    <NamedInstance flags="0x0" postscriptNameID="293" subfamilyNameID="292">
+      <coord axis="wght" value="400.0"/>
+    </NamedInstance>
+
+    <!-- Semibold -->
+    <!-- PostScript: SourceSansRoman-Semibold -->
+    <NamedInstance flags="0x0" postscriptNameID="295" subfamilyNameID="294">
+      <coord axis="wght" value="600.0"/>
+    </NamedInstance>
+
+    <!-- Bold -->
+    <!-- PostScript: SourceSansRoman-Bold -->
+    <NamedInstance flags="0x0" postscriptNameID="297" subfamilyNameID="296">
+      <coord axis="wght" value="700.0"/>
+    </NamedInstance>
+
+    <!-- Black -->
+    <!-- PostScript: SourceSansRoman-Black -->
+    <NamedInstance flags="0x0" postscriptNameID="299" subfamilyNameID="298">
+      <coord axis="wght" value="900.0"/>
+    </NamedInstance>
+  </fvar>
+
+  <DSIG>
+    <!-- note that the Digital Signature will be invalid after recompilation! -->
+    <tableHeader flag="0x0" numSigs="0" version="1"/>
+  </DSIG>
+
+</ttFont>

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,34 @@
+[tox]
+envlist = py3{6,7,8}-cov, htmlcov
+skip_missing_interpreters=true
+
+[testenv]
+deps =
+    pytest
+    cov: coverage
+commands =
+    cov: coverage run --parallel-mode -m pytest {posargs}
+    !cov: pytest {posargs}
+
+[testenv:htmlcov]
+basepython = python3
+deps =
+    coverage
+skip_install = true
+commands =
+    coverage combine
+    coverage report
+    coverage html
+
+[pytest]
+testpaths =
+    tests
+    cffsubr
+addopts =
+    -r a
+    --doctest-modules
+    --doctest-ignore-import-errors
+    --pyargs
+doctest_optionflags =
+    ALLOW_UNICODE
+    ELLIPSIS


### PR DESCRIPTION
it's ok to break API given we have 0 users and in such early stages.
I think exposing the tx interface is not a good idea; it's awkward how it requires one to pass a full OTF data and then it returns only the single modified table -- yes, for CFF 1.0 you can pass just that as input but for CFF 2.0 you need the whole font.

So we need fonttools to insert the compressed table back into the font. The main public `subroutinize` function can then take a TTFont object, take the CFF or CFF2 table in it, pass it on to tx to do the job, then re-insert it back in.

Since CFF table stores the glyph names and CFF2 does not, when converting from one to the other one loses the glyph names unless one sets the post.formatType to 2.0. So I do that by default, but added an option to keep_glyph_names which when set to False will _not_ downgrade the post table from 3.0 to 2.0, thus letting go of the glyph names.

I will add some tests later.