### PR TITLE
Build wheels for Windows 32-bit x86 platform

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -50,8 +50,8 @@ jobs:
         CIBW_BUILD: "cp36-*"
         # build using the manylinux1 image to ensure manylinux1 wheels are produced
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-        # skip PyPy (no manylinux1), 32-bit linux and win, and other architectures
-        CIBW_SKIP: "pp* cp*manylinux_i686 cp*manylinux_aarch64 cp*manylinux_ppc64le cp*manylinux_s390x cp*win32"
+        # skip PyPy (no manylinux1), 32-bit linux, and other architectures
+        CIBW_SKIP: "pp* cp*manylinux_i686 cp*manylinux_aarch64 cp*manylinux_ppc64le cp*manylinux_s390x"
         CIBW_TEST_REQUIRES: "pytest"
         # run test suite with pytest, no coverage
         # TODO: run with coverage and publish to codecov.io


### PR DESCRIPTION
This reverts commit 389a13654619714dc9c90d692ca5fbf32b86825d.

In ufo2ft and fontmake we still run tests on Windows Python 32-bit. This is still the default python version that you download it from Python.org so for a lot of beginners that's the python they will get, even if arguably nowadays 64-bit should always be preferred.

If/until we can build wheels for 32-bit windows python, we should continue to do so.