### PR TITLE
add .exe to embedded tx path name on windows

### DIFF
--- a/src/cffsubr/__init__.py
+++ b/src/cffsubr/__init__.py
@@ -46,6 +46,11 @@ class Error(Exception):
     pass
 
 
+TX_EXE = "tx"
+if sys.version == "win32":
+    TX_EXE += ".exe"
+
+
 def _run_embedded_tx(*args, **kwargs):
     """Run the embedded tx executable with the list of positional arguments.
 
@@ -55,7 +60,7 @@ def _run_embedded_tx(*args, **kwargs):
         subprocess.CompletedProcess object with the following attributes:
         args, returncode, stdout, stderr.
     """
-    with path(__name__, "tx") as tx_cli:
+    with path(__name__, TX_EXE) as tx_cli:
         return subprocess.run([str(tx_cli)] + list(args), **kwargs)
 
 


### PR DESCRIPTION
I'm getting FileNotFound on python3.7
https://ci.appveyor.com/project/fonttools/ufo2ft/builds/33297119/job/6gih0w0a5q4h8g34#L167

not sure why python3.6 doesn't fail. Maybe the importlib_metadata backport works a bit differently than the stdlib copy of importlib.metadata.

One more reason to add tests for all supported pythons.