### PR TITLE
Add cffsubr to entry_points

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,7 @@ setup(
     platforms=["posix", "nt"],
     package_dir={"": "src"},
     packages=find_packages("src"),
+    entry_points={"console_scripts": ["cffsubr = cffsubr.__main__:main"]},
     ext_modules=[tx],
     zip_safe=False,
     cmdclass=cmdclass,


### PR DESCRIPTION
I don't know what it is about Python setuptools that I find so confusing, but I can with all honesty not tell you if this is even the correct fix for this issue, only that I know that this is broken for me, and that this fixed it for me.

Installing this package leads to no `cffsubr` in my path.

Adding this line fixed it. I don't see where else it's even being declared to install the script. I don't need another link to `tx`, not the purpose of this package, right?