### PR TITLE
Only depend on setuptools-git-ls-files for sdist

### DIFF
--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -1,0 +1,19 @@
+"""
+This is a custom PEP 517 build backend that extends setuptool's build backend
+in order to provide different dependencies for wheel and sdist builds.
+
+Please see the following link for documentation about this technique:
+
+https://setuptools.pypa.io/en/latest/build_meta.html#dynamic-build-dependencies-and-other-build-meta-tweaks
+"""
+
+from setuptools import build_meta as _orig
+from setuptools.build_meta import *
+
+
+def get_requires_for_build_sdist(config_settings=None):
+    return _orig.get_requires_for_build_sdist(config_settings) + [
+        # Finds all git tracked files including submodules, when
+        # making sdist MANIFEST
+        "setuptools-git-ls-files"
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "setuptools",
-    "wheel",
     "setuptools_scm",
-    "setuptools-git-ls-files",
 ]
-build-backend = "setuptools.build_meta"
+build-backend = "backend"
+backend-path = ["_custom_build"]

--- a/setup.py
+++ b/setup.py
@@ -143,11 +143,6 @@ setup(
         "importlib_resources; python_version < '3.7'",
         "fontTools >= 4.10.2",
     ],
-    setup_requires=[
-        "setuptools_scm",
-        # finds all git tracked files including submodules when making sdist MANIFEST
-        "setuptools-git-ls-files",
-    ],
     extras_require={"testing": ["pytest"]},
     python_requires=">=3.6",
     classifiers=[


### PR DESCRIPTION
Some PEP 517 build frontends, like PyPA build, have a feature to check that build dependencies are present prior to starting the build.

The setuptools-git-ls-files dependency is only needed when constructing the sdist but not when building a wheel. Some package managers, such as [nixpkgs](https://github.com/NixOS/nixpkgs), only build wheels but still need to bundle and depend on this to pass validation.

This commit adds some complexity to specify that setuptools-git-ls-files is only needed when building an sdist by extending setuptools.

This technique using an in-tree backend is [documented in setuptools](https://setuptools.pypa.io/en/latest/build_meta.html#dynamic-build-dependencies-and-other-build-meta-tweaks).

I also removed `wheel` as a dependency, because, in contrast, it is not needed to build an sdist, and setuptools specifies it as a dependency only needed to build a wheel in its own get_requires_for_build_wheel hook.