### PR TITLE
Handle importlib.resources.path removal in Python 3.13

### DIFF
--- a/src/cffsubr/__init__.py
+++ b/src/cffsubr/__init__.py
@@ -8,10 +8,19 @@ from typing import BinaryIO, Optional, Union
 import sys
 
 try:
-    from importlib.resources import path
+    # Python >= 3.9
+    from importlib.resources import as_file, files
 except ImportError:
-    # use backport for python < 3.7
-    from importlib_resources import path
+    try:
+        # python >= 3.7, deprecated in python 3.11, removed in 3.13
+        from importlib.resources import path
+    except ImportError:
+        # use backport for python < 3.7
+        from importlib_resources import path
+else:
+    # https://docs.python.org/3.11/library/importlib.resources.html#importlib.resources.as_file
+    def path(package, resource):
+        return as_file(files(package).joinpath(resource))
 
 from fontTools import ttLib
 


### PR DESCRIPTION
Tested with:

`tox && tox -e py39-cov && tox -e py310-cov && tox -e py311-cov && tox -e py312-cov && tox -e py313-cov`

This could be simplified by dropping support for Python 3.6 and 3.7, which have reached end-of-life.