### PR TITLE
Test Python 3.9 through 3.12

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{6,7,8}-cov, htmlcov
+envlist = py3{6,7,8,9,10,11,12}-cov, htmlcov
 skip_missing_interpreters=true
 
 [testenv]


### PR DESCRIPTION
Add `py39-cov` through `py312-cov` environments to the `tox` configuration.