### PR TITLE
Disable tx optimization options

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ class ExecutableBuildExt(build_ext):
         dest_path = self.get_ext_fullpath(ext.name)
         mkpath(os.path.dirname(dest_path), verbose=self.verbose, dry_run=self.dry_run)
 
-        copy_file(exe_fullpath, dest_path, verbose=self.verbose, dry_run=self.dry_run)
+        copy_file(exe_fullpath, dest_path, verbose=self.verbose)
 
 
 cmdclass["build_ext"] = ExecutableBuildExt

--- a/src/cffsubr/__init__.py
+++ b/src/cffsubr/__init__.py
@@ -92,7 +92,14 @@ def _tx_subroutinize(data: bytes, output_format: str = CFFTableTag.CFF) -> bytes
     with tempfile.NamedTemporaryFile(prefix="tx-", delete=False) as input_tmp:
         input_tmp.write(data)
 
-    args = [f"-{output_format.rstrip().lower()}", "+S", "+b"]
+    args = [
+        f"-{output_format.rstrip().lower()}",
+        "+S",  # subroutinize
+        "+b",  # preserve glyph order
+        "-E",  # don't optimize for embedding
+        "-F",  # don't optimize Family zones
+        "-O",  # don't optimize for ROM
+    ]
     kwargs = dict(check=True, stderr=subprocess.PIPE)
 
     if sys.platform == "win32":


### PR DESCRIPTION
In a project that uses cffsubr, we noticed FamilyOtherBlues being dropped from the font. This seems to be caused by +F option being the default. While this optimization may be harmless, it is not something that should happen during subroutinization, so i disable this and other optimization options just in case.